### PR TITLE
Created Expand Method to Support the expanded view of threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ namespace.threads.find('c96gge1jo29pl2rebcb7utsbp').then(function(thread) {
    console.log('Thread not found! Error: ' + err.toString());
 });
 
+// Expand a single thread
+
+namespace.threads.expand('c96gge1jo29pl2rebcb7utsbp').then(function(thread) {
+   console.log(thread.messages);
+}).catch(function(err) {
+   console.log('Thread not found! Error: ' + err.toString());
+});
+
 // Fetch a single thread (using optional callback instead of promise)
 
 namespace.threads.find('c96gge1jo29pl2rebcb7utsbp', function(err, thread) {

--- a/lib/models/restful-model-collection.js
+++ b/lib/models/restful-model-collection.js
@@ -136,6 +136,31 @@
       });
     };
 
+    RestfulModelCollection.prototype.expand = function(id, callback) {
+      var err;
+      if (callback == null) {
+        callback = null;
+      }
+      if (!id) {
+        err = new Error("find() must be called with an item id");
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      }
+      return this.getModel(id, {view:'expanded'}).then(function(model) {
+        if (callback) {
+          callback(null, model);
+        }
+        return Promise.resolve(model);
+      })["catch"](function(err) {
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      });
+    };
+
     RestfulModelCollection.prototype.range = function(params, offset, limit, callback) {
       if (params == null) {
         params = {};
@@ -222,10 +247,11 @@
       }
     };
 
-    RestfulModelCollection.prototype.getModel = function(id) {
+    RestfulModelCollection.prototype.getModel = function(id, params) {
       return this.connection.request({
         method: 'GET',
-        path: (this.path()) + "/" + id
+        path: (this.path()) + "/" + id,
+        qs: _.extend({}, params)
       }).then((function(_this) {
         return function(json) {
           var model;

--- a/models/restful-model-collection.coffee
+++ b/models/restful-model-collection.coffee
@@ -63,6 +63,19 @@ class RestfulModelCollection
       callback(err) if callback
       Promise.reject(err)
 
+  find: (id, callback = null) ->
+    if not id
+      err = new Error("find() must be called with an item id")
+      callback(err) if callback
+      return Promise.reject(err)
+
+    @getModel(id, {view: 'expanded'}).then (model) ->
+      callback(null, model) if callback
+      Promise.resolve(model)
+    .catch (err) ->
+      callback(err) if callback
+      Promise.reject(err)
+
   range: (params = {}, offset = 0, limit = 100, callback = null) ->
     new Promise (resolve, reject) =>
       accumulated = []
@@ -110,10 +123,11 @@ class RestfulModelCollection
 
   # Internal
 
-  getModel: (id) ->
+  getModel: (id, params) ->
     @connection.request
       method: 'GET'
       path: "#{@path()}/#{id}"
+      qs: _.extend {}, params
     .then (json) =>
       model = new @modelClass(@connection, @namespaceId, json)
       Promise.resolve(model)

--- a/models/restful-model-collection.coffee
+++ b/models/restful-model-collection.coffee
@@ -63,7 +63,7 @@ class RestfulModelCollection
       callback(err) if callback
       Promise.reject(err)
 
-  find: (id, callback = null) ->
+  expand: (id, callback = null) ->
     if not id
       err = new Error("find() must be called with an item id")
       callback(err) if callback

--- a/spec/restful-model-collection-spec.coffee
+++ b/spec/restful-model-collection-spec.coffee
@@ -194,7 +194,7 @@ describe "RestfulModelCollection", ->
       spyOn(@connection, 'request').andCallFake => Promise.resolve({})
       testUntil (done) =>
         @collection.find('123')
-        expect(@connection.request).toHaveBeenCalledWith({ method : 'GET', path : '/n/test-namespace-id/threads/123' })
+        expect(@connection.request).toHaveBeenCalledWith({ method : 'GET', path : '/n/test-namespace-id/threads/123', qs: {} })
         done()
 
     describe "when the request succeeds", ->

--- a/spec/restful-model-collection-spec.coffee
+++ b/spec/restful-model-collection-spec.coffee
@@ -235,6 +235,56 @@ describe "RestfulModelCollection", ->
             expect(err).toBe(@error)
             done()
 
+  describe "expand", ->
+    it "should reject with an error if an id is not provided", ->
+      testUntil (done) =>
+        @collection.find().catch(done)
+
+    it "should make an API request for the individual model", ->
+      spyOn(@connection, 'request').andCallFake => Promise.resolve({})
+      testUntil (done) =>
+        @collection.expand('123')
+        expect(@connection.request).toHaveBeenCalledWith({ method : 'GET', path : '/n/test-namespace-id/threads/123', qs:{'view':'expanded'}})
+        done()
+
+    describe "when the request succeeds", ->
+      beforeEach ->
+        @item = { id: '123' }
+        spyOn(@connection, 'request').andCallFake =>
+          Promise.resolve(@item)
+
+      it "should resolve with the item", ->
+        testUntil (done) =>
+          @collection.find('123').then (item) =>
+            expect(item instanceof Thread).toBe(true)
+            expect(item.id).toBe('123')
+            done()
+
+      it "should call the optional callback with the first item", ->
+        testUntil (done) =>
+          @collection.find '123', (err, item) =>
+            expect(item instanceof Thread).toBe(true)
+            expect(item.id).toBe('123')
+            done()
+
+    describe "when the request fails", ->
+      beforeEach ->
+        @error = new Error("Network error")
+        spyOn(@connection, 'request').andCallFake =>
+          Promise.reject(@error)
+
+      it "should reject with any underlying error", ->
+        testUntil (done) =>
+          @collection.find('123').catch (err) =>
+            expect(err).toBe(@error)
+            done()
+
+      it "should call the optional callback with the underlying error", ->
+        testUntil (done) =>
+          @collection.find '123', (err, item) =>
+            expect(err).toBe(@error)
+            done()
+
   describe "range", ->
     beforeEach ->
       threadsResponses = []


### PR DESCRIPTION
```js
namespace.threads.expand('c96gge1jo29pl2rebcb7utsbp').then(function(thread) {
    console.log(thread.messages);
}).catch(function(err) {
    console.log('Thread not found! Error: ' + err.toString());
})
```