### PR TITLE
Add delta streaming API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,40 @@ namespace.drafts.find(savedId).then(draft) {
 
 ```
 
+Using the Delta Streaming API
+------
+
+```javascript
+var DELTA_EXCLUDE_TYPES = ['contact', 'calendar', 'event', 'file', 'tag'];
+var timestampMs = Date.now();
+
+namespace.deltas.generateCursor(timestampMs, function(cursor) {
+
+  // Save inital cursor.
+  persistCursor(cursor);
+
+  // Start the stream and add event handlers.
+  var stream = namespace.deltas.startStream(cursor, DELTA_EXCLUDE_TYPES);
+
+  stream.on('delta', function(delta) {
+    // Handle the new delta here.
+    console.log('Received delta:', delta);
+    // Save new cursor so this delta doesn't need to be re-fetched for future streams.
+    persistCursor(delta.cursor);
+
+  }).on('error', function(err) {
+    // Handle errors here, such as by restarting the stream at the last cursor.
+    console.error('Delta streaming error:', err);
+
+  });
+
+  // Closing the stream explicitly, if needed
+  stopButton.addEventListener('click', function() {
+    stream.close();
+  });
+})
+```
+
 Contributing 
 ----
 

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -114,12 +114,26 @@
       });
       return this.request = request(reqOpts).on('response', (function(_this) {
         return function(response) {
-          var timeout;
+          var timeoutId;
+          if (response.statusCode !== 200) {
+            response.on('data', function(data) {
+              var e, err;
+              err = data;
+              try {
+                err = JSON.parse(err);
+              } catch (_error) {
+                e = _error;
+              }
+              console.error('Nylas DeltaStream connection error:', err);
+              return _this.emit('error', err);
+            });
+            return;
+          }
           _this.emit('response', response);
-          timeout = void 0;
+          timeoutId = void 0;
           return response.on('data', function(data) {
-            clearTimeout(timeout);
-            return timeout = setTimeout(_this._restartConnection.bind(_this), STREAMING_TIMEOUT_MS);
+            clearTimeout(timeoutId);
+            return timeoutId = setTimeout(_this._restartConnection.bind(_this), STREAMING_TIMEOUT_MS);
           }).pipe(JSONStream.parse()).on('data', function(obj) {
             if (obj.cursor) {
               _this.cursor = obj.cursor;
@@ -127,9 +141,12 @@
             return _this.emit('delta', obj);
           });
         };
-      })(this)).on('error', function(err) {
-        return this.emit('error', err);
-      });
+      })(this)).on('error', (function(_this) {
+        return function(err) {
+          console.error('Nylas DeltaStream error:', err);
+          return _this.emit('error', err);
+        };
+      })(this));
     };
 
     DeltaStream.prototype._restartConnection = function() {

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -1,7 +1,9 @@
 (function() {
-  var Delta, DeltaStream, EventEmitter, JSONStream, Promise, STREAMING_TIMEOUT_MS, querystring, request,
+  var Delta, DeltaStream, EventEmitter, JSONStream, Promise, STREAMING_TIMEOUT_MS, backoff, querystring, request,
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
+
+  backoff = require('backoff');
 
   EventEmitter = require('events').EventEmitter;
 
@@ -79,6 +81,8 @@
   DeltaStream = (function(superClass) {
     extend(DeltaStream, superClass);
 
+    DeltaStream.MAX_RESTART_RETRIES = 5;
+
     function DeltaStream(connection, namespaceId, cursor1, excludeTypes1) {
       this.connection = connection;
       this.namespaceId = namespaceId;
@@ -87,6 +91,17 @@
       if (!(this.connection instanceof require('../nylas-connection'))) {
         throw new Error("Connection object not provided");
       }
+      this.restartBackoff = backoff.exponential({
+        randomisationFactor: 0.5,
+        initialDelay: 2000,
+        maxDelay: 30000
+      });
+      this.restartBackoff.failAfter(DeltaStream.MAX_RESTART_RETRIES);
+      this.restartBackoff.on('backoff', this._restartConnection.bind(this)).on('fail', (function(_this) {
+        return function() {
+          return _this.emit('error', "Nylas DeltaStream failed to reconnect after " + DeltaStream.MAX_RESTART_RETRIES + " retries.");
+        };
+      })(this));
       return this;
     }
 
@@ -99,6 +114,7 @@
 
     DeltaStream.prototype.open = function() {
       var path, queryObj, queryStr, reqOpts;
+      this.close();
       path = "/n/" + this.namespaceId + "/delta/streaming";
       queryObj = {
         cursor: this.cursor
@@ -114,7 +130,6 @@
       });
       return this.request = request(reqOpts).on('response', (function(_this) {
         return function(response) {
-          var timeoutId;
           if (response.statusCode !== 200) {
             response.on('data', function(data) {
               var e, err;
@@ -124,33 +139,36 @@
               } catch (_error) {
                 e = _error;
               }
-              console.error('Nylas DeltaStream connection error:', err);
-              return _this.emit('error', err);
+              return _this._onError(err);
             });
             return;
           }
           _this.emit('response', response);
-          timeoutId = void 0;
-          return response.on('data', function(data) {
-            clearTimeout(timeoutId);
-            return timeoutId = setTimeout(_this._restartConnection.bind(_this), STREAMING_TIMEOUT_MS);
-          }).pipe(JSONStream.parse()).on('data', function(obj) {
+          _this._onDataReceived();
+          return response.on('data', _this._onDataReceived.bind(_this)).pipe(JSONStream.parse()).on('data', function(obj) {
             if (obj.cursor) {
               _this.cursor = obj.cursor;
             }
             return _this.emit('delta', obj);
           });
         };
-      })(this)).on('error', (function(_this) {
-        return function(err) {
-          console.error('Nylas DeltaStream error:', err);
-          return _this.emit('error', err);
-        };
-      })(this));
+      })(this)).on('error', this._onError.bind(this));
     };
 
-    DeltaStream.prototype._restartConnection = function() {
-      console.log('Restarting Nylas DeltaStream connection', this);
+    DeltaStream.prototype._onDataReceived = function(data) {
+      clearTimeout(this.timeoutId);
+      this.restartBackoff.reset();
+      return this.timeoutId = setTimeout(this.restartBackoff.backoff, STREAMING_TIMEOUT_MS);
+    };
+
+    DeltaStream.prototype._onError = function(err) {
+      console.error('Nylas DeltaStream error:', err);
+      this.restartBackoff.reset();
+      return this.emit('error', err);
+    };
+
+    DeltaStream.prototype._restartConnection = function(n) {
+      console.log("Restarting Nylas DeltaStream connection (attempt " + (n + 1) + ")", this);
       this.close();
       return this.open();
     };

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -55,11 +55,18 @@
     };
 
     Delta.prototype.startStream = function(cursor, excludeTypes) {
+      if (excludeTypes == null) {
+        excludeTypes = [];
+      }
+      return _startStream(request, cursor, excludeTypes);
+    };
+
+    Delta.prototype._startStream = function(createRequest, cursor, excludeTypes) {
       var stream;
       if (excludeTypes == null) {
         excludeTypes = [];
       }
-      stream = new DeltaStream(this.connection, this.namespaceId, cursor, excludeTypes);
+      stream = new DeltaStream(createRequest, this.connection, this.namespaceId, cursor, excludeTypes);
       stream.open();
       return stream;
     };
@@ -83,7 +90,8 @@
 
     DeltaStream.MAX_RESTART_RETRIES = 5;
 
-    function DeltaStream(connection, namespaceId, cursor1, excludeTypes1) {
+    function DeltaStream(createRequest1, connection, namespaceId, cursor1, excludeTypes1) {
+      this.createRequest = createRequest1;
       this.connection = connection;
       this.namespaceId = namespaceId;
       this.cursor = cursor1;
@@ -93,8 +101,9 @@
       }
       this.restartBackoff = backoff.exponential({
         randomisationFactor: 0.5,
-        initialDelay: 2000,
-        maxDelay: 30000
+        initialDelay: 250,
+        maxDelay: 30000,
+        factor: 4
       });
       this.restartBackoff.failAfter(DeltaStream.MAX_RESTART_RETRIES);
       this.restartBackoff.on('backoff', this._restartConnection.bind(this)).on('fail', (function(_this) {
@@ -113,13 +122,13 @@
     };
 
     DeltaStream.prototype.open = function() {
-      var path, queryObj, queryStr, reqOpts;
+      var path, queryObj, queryStr, ref, reqOpts;
       this.close();
       path = "/n/" + this.namespaceId + "/delta/streaming";
       queryObj = {
         cursor: this.cursor
       };
-      if (this.excludeTypes) {
+      if (((ref = this.excludeTypes) != null ? ref.length : void 0) > 0) {
         queryObj.exclude_types = this.excludeTypes.join(',');
       }
       queryStr = querystring.stringify(queryObj);
@@ -128,7 +137,7 @@
         method: 'GET',
         path: path
       });
-      return this.request = request(reqOpts).on('response', (function(_this) {
+      return this.request = this.createRequest(reqOpts).on('response', (function(_this) {
         return function(response) {
           if (response.statusCode !== 200) {
             response.on('data', function(data) {
@@ -158,7 +167,7 @@
     DeltaStream.prototype._onDataReceived = function(data) {
       clearTimeout(this.timeoutId);
       this.restartBackoff.reset();
-      return this.timeoutId = setTimeout(this.restartBackoff.backoff, STREAMING_TIMEOUT_MS);
+      return this.timeoutId = setTimeout(this.restartBackoff.backoff.bind(this.restartBackoff), STREAMING_TIMEOUT_MS);
     };
 
     DeltaStream.prototype._onError = function(err) {

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -15,7 +15,7 @@
 
   request = require('request');
 
-  STREAMING_TIMEOUT_MS = 2000;
+  STREAMING_TIMEOUT_MS = 5000;
 
   module.exports = Delta = (function() {
     function Delta(connection, namespaceId) {

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -1,0 +1,145 @@
+(function() {
+  var Delta, DeltaStream, EventEmitter, JSONStream, Promise, STREAMING_TIMEOUT_MS, querystring, request,
+    extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+    hasProp = {}.hasOwnProperty;
+
+  EventEmitter = require('events').EventEmitter;
+
+  JSONStream = require('JSONStream');
+
+  Promise = require('bluebird');
+
+  querystring = require('querystring');
+
+  request = require('request');
+
+  STREAMING_TIMEOUT_MS = 2000;
+
+  module.exports = Delta = (function() {
+    function Delta(connection, namespaceId) {
+      this.connection = connection;
+      this.namespaceId = namespaceId;
+      if (!(this.connection instanceof require('../nylas-connection'))) {
+        throw new Error("Connection object not provided");
+      }
+      this;
+    }
+
+    Delta.prototype.generateCursor = function(timestampMs, callback) {
+      var reqOpts;
+      if (callback == null) {
+        callback = null;
+      }
+      reqOpts = {
+        method: 'POST',
+        path: "/n/" + this.namespaceId + "/delta/generate_cursor",
+        body: {
+          start: Math.floor(timestampMs / 1000)
+        }
+      };
+      return this.connection.request(reqOpts).then(function(response) {
+        var cursor;
+        cursor = response.cursor;
+        if (callback) {
+          callback(null, cursor);
+        }
+        return Promise.resolve(cursor);
+      })["catch"](function(err) {
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      });
+    };
+
+    Delta.prototype.startStream = function(cursor, excludeTypes) {
+      var stream;
+      if (excludeTypes == null) {
+        excludeTypes = [];
+      }
+      stream = new DeltaStream(this.connection, this.namespaceId, cursor, excludeTypes);
+      stream.open();
+      return stream;
+    };
+
+    return Delta;
+
+  })();
+
+
+  /*
+  A connection to the Nylas delta streaming API.
+  
+  Emits the following events:
+  - `response` when the connection is established, with one argument, a `http.IncomingMessage`
+  - `delta` for each delta received
+  - `error` when an error occurs in the connection
+   */
+
+  DeltaStream = (function(superClass) {
+    extend(DeltaStream, superClass);
+
+    function DeltaStream(connection, namespaceId, cursor1, excludeTypes1) {
+      this.connection = connection;
+      this.namespaceId = namespaceId;
+      this.cursor = cursor1;
+      this.excludeTypes = excludeTypes1 != null ? excludeTypes1 : [];
+      if (!(this.connection instanceof require('../nylas-connection'))) {
+        throw new Error("Connection object not provided");
+      }
+      return this;
+    }
+
+    DeltaStream.prototype.close = function() {
+      if (this.request) {
+        this.request.abort();
+      }
+      return delete this.request;
+    };
+
+    DeltaStream.prototype.open = function() {
+      var path, queryObj, queryStr, reqOpts;
+      path = "/n/" + this.namespaceId + "/delta/streaming";
+      queryObj = {
+        cursor: this.cursor
+      };
+      if (this.excludeTypes) {
+        queryObj.exclude_types = this.excludeTypes.join(',');
+      }
+      queryStr = querystring.stringify(queryObj);
+      path += '?' + queryStr;
+      reqOpts = this.connection.requestOptions({
+        method: 'GET',
+        path: path
+      });
+      return this.request = request(reqOpts).on('response', (function(_this) {
+        return function(response) {
+          var timeout;
+          _this.emit('response', response);
+          timeout = void 0;
+          return response.on('data', function(data) {
+            clearTimeout(timeout);
+            return timeout = setTimeout(_this._restartConnection.bind(_this), STREAMING_TIMEOUT_MS);
+          }).pipe(JSONStream.parse()).on('data', function(obj) {
+            if (obj.cursor) {
+              _this.cursor = obj.cursor;
+            }
+            return _this.emit('delta', obj);
+          });
+        };
+      })(this)).on('error', function(err) {
+        return this.emit('error', err);
+      });
+    };
+
+    DeltaStream.prototype._restartConnection = function() {
+      console.log('Restarting Nylas DeltaStream connection', this);
+      this.close();
+      return this.open();
+    };
+
+    return DeltaStream;
+
+  })(EventEmitter);
+
+}).call(this);

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -58,7 +58,7 @@
       if (excludeTypes == null) {
         excludeTypes = [];
       }
-      return _startStream(request, cursor, excludeTypes);
+      return this._startStream(request, cursor, excludeTypes);
     };
 
     Delta.prototype._startStream = function(createRequest, cursor, excludeTypes) {

--- a/lib/models/namespace.js
+++ b/lib/models/namespace.js
@@ -1,5 +1,5 @@
 (function() {
-  var Attributes, Calendar, Contact, Draft, Event, File, Message, Namespace, RestfulModel, RestfulModelCollection, Tag, Thread, _,
+  var Attributes, Calendar, Contact, Delta, Draft, Event, File, Message, Namespace, RestfulModel, RestfulModelCollection, Tag, Thread, _,
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
@@ -22,6 +22,8 @@
   Event = require('./event');
 
   Tag = require('./tag');
+
+  Delta = require('./delta');
 
   Attributes = require('./attributes');
 
@@ -56,6 +58,7 @@
       this.calendars = new RestfulModelCollection(Calendar, this.connection, this.id);
       this.events = new RestfulModelCollection(Event, this.connection, this.id);
       this.tags = new RestfulModelCollection(Tag, this.connection, this.id);
+      this.delta = new Delta(this.connection, this.id);
       this;
     }
 

--- a/lib/models/namespace.js
+++ b/lib/models/namespace.js
@@ -58,7 +58,7 @@
       this.calendars = new RestfulModelCollection(Calendar, this.connection, this.id);
       this.events = new RestfulModelCollection(Event, this.connection, this.id);
       this.tags = new RestfulModelCollection(Tag, this.connection, this.id);
-      this.delta = new Delta(this.connection, this.id);
+      this.deltas = new Delta(this.connection, this.id);
       this;
     }
 

--- a/lib/nylas-connection.js
+++ b/lib/nylas-connection.js
@@ -1,7 +1,9 @@
 (function() {
-  var NylasConnection, Promise, _, request;
+  var NylasConnection, Promise, _, clone, request;
 
   _ = require('underscore');
+
+  clone = require('clone');
 
   request = require('request');
 
@@ -19,11 +21,12 @@
       this.accounts = new ManagementModelCollection(Account, this, null);
     }
 
-    NylasConnection.prototype.request = function(options) {
+    NylasConnection.prototype.requestOptions = function(options) {
       var Nylas;
       if (options == null) {
         options = {};
       }
+      options = clone(options);
       Nylas = require('./nylas');
       if (options.method == null) {
         options.method = 'GET';
@@ -48,7 +51,14 @@
           'sendImmediately': true
         };
       }
-      
+      return options;
+    };
+
+    NylasConnection.prototype.request = function(options) {
+      if (options == null) {
+        options = {};
+      }
+      options = this.requestOptions(options);
       return new Promise(function(resolve, reject) {
         return request(options, function(error, response, body) {
           if (error || response.statusCode > 299) {

--- a/models/delta.coffee
+++ b/models/delta.coffee
@@ -5,7 +5,7 @@ Promise = require 'bluebird'
 querystring = require 'querystring'
 request = require 'request'
 
-STREAMING_TIMEOUT_MS = 2000
+STREAMING_TIMEOUT_MS = 5000
 
 module.exports = class Delta
   constructor: (@connection, @namespaceId) ->

--- a/models/delta.coffee
+++ b/models/delta.coffee
@@ -1,0 +1,89 @@
+{EventEmitter} = require 'events'
+JSONStream = require 'JSONStream'
+Promise = require 'bluebird'
+querystring = require 'querystring'
+request = require 'request'
+
+STREAMING_TIMEOUT_MS = 2000
+
+module.exports = class Delta
+  constructor: (@connection, @namespaceId) ->
+    throw new Error("Connection object not provided") unless @connection instanceof require '../nylas-connection'
+    @
+
+  generateCursor: (timestampMs, callback = null) ->
+    reqOpts =
+      method: 'POST'
+      path: "/n/#{@namespaceId}/delta/generate_cursor"
+      # Nylas API takes a UNIX timestamp in seconds, not a C-like millisecond timestamp.
+      body: {start: Math.floor(timestampMs / 1000)}
+
+    @connection.request(reqOpts)
+      .then (response) ->
+        cursor = response.cursor
+        callback(null, cursor) if callback
+        Promise.resolve(cursor)
+      .catch (err) ->
+        callback(err) if callback
+        Promise.reject(err)
+
+  startStream: (cursor, excludeTypes = []) ->
+    stream = new DeltaStream(@connection, @namespaceId, cursor, excludeTypes)
+    stream.open()
+    return stream
+
+###
+A connection to the Nylas delta streaming API.
+
+Emits the following events:
+- `response` when the connection is established, with one argument, a `http.IncomingMessage`
+- `delta` for each delta received
+- `error` when an error occurs in the connection
+###
+class DeltaStream extends EventEmitter
+  # @param {string} cursor Nylas delta API cursor
+  # @param {Array<string>} excludeTypes object types to not return deltas for
+  constructor: (@connection, @namespaceId, @cursor, @excludeTypes = []) ->
+    throw new Error("Connection object not provided") unless @connection instanceof require '../nylas-connection'
+    return @
+
+  close: () ->
+    @request.abort() if @request
+    delete @request
+
+  open: () ->
+    path = "/n/#{@namespaceId}/delta/streaming"
+    queryObj =
+      cursor: @cursor
+    queryObj.exclude_types = @excludeTypes.join(',') if @excludeTypes
+    queryStr = querystring.stringify(queryObj)
+    path += '?' + queryStr
+
+    reqOpts = @connection.requestOptions
+      method: 'GET'
+      path: path
+    @request = request(reqOpts)
+      .on 'response', (response) =>
+        @emit('response', response)  # Successfully established connection
+        timeoutId = undefined
+        response
+          .on 'data', (data) =>
+            # Nylas sends a newline heartbeat in the raw data stream once per second.
+            # Automatically restart the connection if we haven't gotten any data in
+            # STREAMING_TIMEOUT_MS. The connection will restart with the last
+            # received cursor.
+            clearTimeout(timeoutId)
+            # TODO(ericyhwang): Handle errors on reconnection and exponentially back off.
+            timeoutId = setTimeout @_restartConnection.bind(@), STREAMING_TIMEOUT_MS
+          # Each data block received may not be a complete JSON object. Pipe through
+          # JSONStream.parse(), which handles converting data blocks to JSON objects.
+          .pipe(JSONStream.parse()).on 'data', (obj) =>
+            @cursor = obj.cursor if obj.cursor
+            @emit('delta', obj)
+      .on 'error', (err) ->
+        @emit('error', err)
+
+  _restartConnection: () ->
+    console.log 'Restarting Nylas DeltaStream connection', @
+    @close()
+    @open()

--- a/models/delta.coffee
+++ b/models/delta.coffee
@@ -29,7 +29,7 @@ module.exports = class Delta
         Promise.reject(err)
 
   startStream: (cursor, excludeTypes = []) ->
-    return _startStream(request, cursor, excludeTypes)
+    return @_startStream(request, cursor, excludeTypes)
 
   _startStream: (createRequest, cursor, excludeTypes = []) ->
     stream = new DeltaStream(createRequest, @connection, @namespaceId, cursor, excludeTypes)

--- a/models/namespace.coffee
+++ b/models/namespace.coffee
@@ -8,6 +8,7 @@ File = require './file'
 Calendar = require './calendar'
 Event = require './event'
 Tag = require './tag'
+Delta = require './delta'
 
 Attributes = require './attributes'
 _ = require 'underscore'
@@ -39,6 +40,7 @@ class Namespace extends RestfulModel
     @calendars = new RestfulModelCollection(Calendar, @connection, @id)
     @events = new RestfulModelCollection(Event, @connection, @id)
     @tags = new RestfulModelCollection(Tag, @connection, @id)
+    @delta = new Delta(@connection, @id)
     @
 
   me: ->

--- a/models/namespace.coffee
+++ b/models/namespace.coffee
@@ -40,7 +40,7 @@ class Namespace extends RestfulModel
     @calendars = new RestfulModelCollection(Calendar, @connection, @id)
     @events = new RestfulModelCollection(Event, @connection, @id)
     @tags = new RestfulModelCollection(Tag, @connection, @id)
-    @delta = new Delta(@connection, @id)
+    @deltas = new Delta(@connection, @id)
     @
 
   me: ->

--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+clone = require 'clone'
 request = require 'request'
 Promise = require 'bluebird'
 
@@ -15,7 +16,8 @@ class NylasConnection
     @namespaces = new RestfulModelCollection(Namespace, @, null)
     @accounts = new ManagementModelCollection(Account, @, null)
 
-  request: (options={}) ->
+  requestOptions: (options={}) ->
+    options = clone(options)
     Nylas = require './nylas'
     options.method ?= 'GET'
     options.url ?= "#{Nylas.apiServer}#{options.path}" if options.path
@@ -27,6 +29,10 @@ class NylasConnection
         'user': @accessToken,
         'pass': '',
         'sendImmediately': true
+    return options
+
+  request: (options={}) ->
+    options = @requestOptions(options)
 
     new Promise (resolve, reject) ->
       request options, (error, response, body) ->

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "0.9.0",
+    "backoff": "2.4.1",
     "bluebird": "^2.9.13",
     "clone": "1.0.1",
     "JSONStream": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "async": "0.9.0",
     "bluebird": "^2.9.13",
+    "clone": "1.0.1",
+    "JSONStream": "1.0.4",
     "request": "^2.53.0",
     "underscore": "^1.7.0"
   },

--- a/spec/delta-spec.coffee
+++ b/spec/delta-spec.coffee
@@ -1,0 +1,138 @@
+{EventEmitter} = require 'events'
+jasmine = require 'jasmine-node'
+{PassThrough} = require 'stream'
+Delta = require '../models/delta'
+NylasConnection = require '../nylas-connection'
+
+testUntil = (fn) ->
+  finished = false
+  runs ->
+    fn (callback) ->
+      finished = true
+  waitsFor -> finished
+
+describe 'Delta', ->
+  beforeEach ->
+    @connection = new NylasConnection('123')
+    @delta = new Delta(@connection, 'test-namespace-id')
+    jasmine.Clock.useMock()
+
+  describe 'startStream (delta streaming)', ->
+    createRequest = (requestOpts) ->
+      request = new EventEmitter()
+      request.origOpts = requestOpts
+      request.abort = jasmine.createSpy('abort')
+      return request
+
+    createResponse = (statusCode) ->
+      response = new PassThrough()
+      response.statusCode = statusCode
+      return response
+
+    # Listens to the 'delta' event on the stream and pushes them to the returned array.
+    observeDeltas = (stream) ->
+      deltas = []
+      stream.on 'delta', (delta) ->
+        deltas.push(delta)
+      return deltas
+
+    it 'start and close stream', ->
+      stream = @delta._startStream(createRequest, 'deltacursor0')
+      request = stream.request
+
+      expect(request.origOpts.method).toBe('GET')
+      expect(request.origOpts.path).toBe('/n/test-namespace-id/delta/streaming?cursor=deltacursor0')
+
+      expect(request.abort.calls.length).toEqual(0)
+      stream.close()
+      expect(request.abort.calls.length).toEqual(1)
+
+    it 'stream response parsing', ->
+      stream = @delta._startStream(createRequest, 'deltacursor0')
+      request = stream.request
+      deltas = observeDeltas(stream)
+
+      response = createResponse(200)
+      request.emit('response', response)
+      expect(deltas).toEqual([])
+      expect(stream.cursor).toEqual('deltacursor0')
+
+      delta1 =
+        cursor: 'deltacursor1'
+        attributes: {}
+        object: 'thread'
+        event: 'create'
+        id: 'deltaid1'
+
+      response.write(JSON.stringify(delta1))
+      expect(deltas).toEqual([delta1])
+      expect(stream.cursor).toEqual('deltacursor1')
+
+      stream.close()
+
+    it 'stream response parsing, delta split across data packets', ->
+      stream = @delta._startStream(createRequest, 'deltacursor0')
+      request = stream.request
+      deltas = observeDeltas(stream)
+
+      response = createResponse(200)
+      request.emit('response', response)
+      expect(deltas).toEqual([])
+      expect(stream.cursor).toEqual('deltacursor0')
+
+      delta1 =
+        cursor: 'deltacursor1'
+        attributes: {}
+        object: 'thread'
+        event: 'create'
+        id: 'deltaid1'
+      deltaStr = JSON.stringify(delta1)
+
+      # Partial data packet will not result in a delta yet...
+      response.write(deltaStr.substring(0, 20))
+      expect(deltas).toEqual([])
+      expect(stream.cursor).toEqual('deltacursor0')
+
+      # ...now the rest of the delta comes in, and there should be a delta object.
+      response.write(deltaStr.substring(20))
+      expect(deltas).toEqual([delta1])
+      expect(stream.cursor).toEqual('deltacursor1')
+
+      stream.close()
+
+    it 'stream timeout and auto-restart', ->
+      stream = @delta._startStream(createRequest, 'deltacursor0')
+      request = stream.request
+
+      response = createResponse(200)
+      request.emit('response', response)
+      expect(stream.cursor).toEqual('deltacursor0')
+
+      expectRequestNotAborted = (request) ->
+        expect(request.abort.calls.length).toEqual(0)
+
+      # Server sends a heartbeat every second.
+      response.write('\n')
+      jasmine.Clock.tick(1000)
+      expect(request.abort.calls.length).toEqual(0)
+      response.write('\n')
+      expect(request.abort.calls.length).toEqual(0)
+
+      # Actual response packets also reset the timeout.
+      jasmine.Clock.tick(1000)
+      delta1 =
+        cursor: 'deltacursor1'
+      response.write(JSON.stringify(delta1))
+      expect(stream.cursor).toEqual('deltacursor1')
+      jasmine.Clock.tick(1500)
+      expect(request.abort.calls.length).toEqual(0)
+
+      # If the timeout has elapsed since the last data received, the stream is restarted.
+      jasmine.Clock.tick(1000)
+      # The old request should have been aborted, and a new request created.
+      expect(request.abort.calls.length).toEqual(1)
+      expect(stream.request).not.toBe(request)
+      # The new request should be using the last delta cursor received prior to timeout.
+      expect(stream.request.origOpts.path).toBe('/n/test-namespace-id/delta/streaming?cursor=deltacursor1')
+
+      stream.close()


### PR DESCRIPTION
@bengotow 

- New `namespace.delta` to expose delta API
  - `namespace.delta.generateCursor(timestampMs, [callback])` to get a Nylas delta cursor from a C-like timestamp
  - `namespace.delta.startStream(cursor, excludeTypes = [])` to initiate a delta streaming API connection. It returns a `DeltaStream` which emits `response`, `delta`, and `error` events.
- Jasmine tests for delta streaming, covering:
  - Starting and closing a stream
  - Parsing the streaming response into JSON objects
  - Handling JSON objects broken into multiple data packets
  - Automatically restarting the connection after a timeout not receiving any data (normally the Nylas server sends a heartbeat every second on the streaming connection)
- NylasConnection updates
  - NylasConnection now clones the passed-in options and adds the standard Nylas options on the clone, instead of modifying the original passed-in object in-place.
  - Moved said option-modification to new `NylasConnection.requestOptions(opts)` method to build an option object suitable for passing to `request`.
