### PR TITLE
Delta streaming - don't auto-restart when connection is explicitly closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var Nylas = require('nylas').config({
 Every resource method accepts an optional callback as the last argument:
 
 ```javascript
-Nylas.with(accessToken).namespaces.list({}, function(namespaces){
+Nylas.with(accessToken).namespaces.list({}, function(err, namespaces){
 	console.log(namespaces.length);
 });
 ```
@@ -149,7 +149,7 @@ namespace.threads.find('c96gge1jo29pl2rebcb7utsbp', function(err, thread) {
 // as necessary and calls the provided block as threads are received. Calls the final
 // block upon an error, or when processing is finished.
 
-namespace.threads.forEach({tag: 'unread', from: 'no-reply@sentry.com'}, function(thread) {
+namespace.threads.forEach({tag: 'unread', from: 'no-reply@sentry.com'}, function(err, thread) {
    console.log(thread.subject);
 }, function (err) {
    console.log('finished iterating through threads');

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -115,6 +115,9 @@
     }
 
     DeltaStream.prototype.close = function() {
+      clearTimeout(this.timeoutId);
+      delete this.timeoutId;
+      this.restartBackoff.reset();
       if (this.request) {
         this.request.abort();
       }

--- a/models/delta.coffee
+++ b/models/delta.coffee
@@ -67,6 +67,9 @@ class DeltaStream extends EventEmitter
     return @
 
   close: () ->
+    clearTimeout(@timeoutId)
+    delete @timeoutId
+    @restartBackoff.reset()
     @request.abort() if @request
     delete @request
 


### PR DESCRIPTION
@bengotow 

Bunch of small fixes to delta streaming API:
- Clear timeouts when calling `stream.close()` explicitly so the stream doesn't auto-restart in that case
- Add test for ensuring no auto-restart on explicit close
- Fix the auto-restart test, which failed due to bumping up the timeouts in commit d37708327ebd7e809e063a3f8b34fa7a9df13598

Unrelated, I also added missing err params to callbacks in README.md.