### PR TITLE
Add params to event.save method

### DIFF
--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -56,13 +56,21 @@
       })
     });
 
-    Event.prototype.save = function(callback) {
+    Event.prototype.save = function(params, callback) {
+      if (params == null) {
+        params = {};
+      }
       if (callback == null) {
         callback = null;
+      }
+      if (_.isFunction(params)) {
+        callback = params;
+        params = {};
       }
       return this.connection.request({
         method: this.id ? 'PUT' : 'POST',
         body: this.toJSON(),
+        qs: params,
         path: this.id ? "/n/" + this.namespaceId + "/events/" + this.id : "/n/" + this.namespaceId + "/events"
       }).then((function(_this) {
         return function(json) {

--- a/lib/models/restful-model-collection.js
+++ b/lib/models/restful-model-collection.js
@@ -182,14 +182,22 @@
       })(this));
     };
 
-    RestfulModelCollection.prototype["delete"] = function(itemOrId, callback) {
+    RestfulModelCollection.prototype["delete"] = function(itemOrId, params, callback) {
       var id;
+      if (params == null) {
+        params = {};
+      }
       if (callback == null) {
         callback = null;
       }
       id = (itemOrId != null ? itemOrId.id : void 0) != null ? itemOrId.id : itemOrId;
+      if (_.isFunction(params)) {
+        callback = params;
+        params = {};
+      }
       return this.connection.request({
         method: 'DELETE',
+        qs: params,
         path: (this.path()) + "/" + id
       }).then(function() {
         if (callback) {

--- a/models/event.coffee
+++ b/models/event.coffee
@@ -42,10 +42,15 @@ class Event extends RestfulModel
       modelKey: 'participants'
       itemClass: Participant
 
-  save: (callback = null) ->
+  save: (params = {}, callback = null) ->
+    if _.isFunction(params)
+      callback = params
+      params = {}
+
     @connection.request
       method: if @id then 'PUT' else 'POST'
       body: @toJSON()
+      qs: params
       path: if @id then "/n/#{@namespaceId}/events/#{@id}" else "/n/#{@namespaceId}/events"
     .then (json) =>
       @fromJSON(json)

--- a/models/restful-model-collection.coffee
+++ b/models/restful-model-collection.coffee
@@ -85,10 +85,14 @@ class RestfulModelCollection
           callback(null, accumulated) if callback
           resolve(accumulated)
 
-  delete: (itemOrId, callback = null) ->
+  delete: (itemOrId, params = {}, callback = null) ->
     id = if itemOrId?.id? then itemOrId.id else itemOrId
+    if _.isFunction(params)
+      callback = params
+      params = {}
     @connection.request
       method: 'DELETE'
+      qs: params
       path: "#{@path()}/#{id}"
     .then ->
       callback(null) if callback

--- a/spec/event-spec.coffee
+++ b/spec/event-spec.coffee
@@ -39,6 +39,7 @@ describe "Event", ->
           _end : undefined,
           participants : [  ]
         },
+        qs : { },
         path : '/n/test-namespace-id/events'
       })
 
@@ -63,7 +64,33 @@ describe "Event", ->
           _end : undefined,
           participants : [  ]
         },
+        qs : { },
         path : '/n/test-namespace-id/events/id-1234'
+      })
+
+    it "should include params in the request if they were passed in", ->
+      spyOn(@connection, 'request').andCallFake -> Promise.resolve()
+      @event.save({ notify_participants: true })
+
+      expect(@connection.request).toHaveBeenCalledWith({
+        method : 'POST',
+        body : {
+          object : 'event',
+          namespace_id : 'test-namespace-id',
+          calendar_id : undefined,
+          busy : undefined,
+          title : undefined,
+          description : undefined,
+          location : undefined,
+          when : undefined,
+          _start : undefined,
+          _end : undefined,
+          participants : [  ]
+        },
+        qs : {
+          notify_participants : true
+        },
+        path : '/n/test-namespace-id/events'
       })
 
     describe "when the request succeeds", ->

--- a/spec/restful-model-collection-spec.coffee
+++ b/spec/restful-model-collection-spec.coffee
@@ -312,13 +312,19 @@ describe "RestfulModelCollection", ->
       spyOn(@connection, 'request').andCallFake ->
         Promise.resolve()
       @collection.delete(@item)
-      expect(@connection.request).toHaveBeenCalledWith({ method: 'DELETE', path: '/n/test-namespace-id/threads/123' })
+      expect(@connection.request).toHaveBeenCalledWith({ method: 'DELETE', qs: { }, path: '/n/test-namespace-id/threads/123' })
 
     it "should accept a model id as the first parameter", ->
       spyOn(@connection, 'request').andCallFake ->
         Promise.resolve()
       @collection.delete(@item.id)
-      expect(@connection.request).toHaveBeenCalledWith({ method: 'DELETE', path: '/n/test-namespace-id/threads/123' })
+      expect(@connection.request).toHaveBeenCalledWith({ method: 'DELETE', qs: { }, path: '/n/test-namespace-id/threads/123' })
+
+    it "should include params in the request if they were passed in", ->
+      spyOn(@connection, 'request').andCallFake ->
+        Promise.resolve()
+      @collection.delete(@item.id, { foo: 'bar' })
+      expect(@connection.request).toHaveBeenCalledWith({ method: 'DELETE', qs: { foo: 'bar' }, path: '/n/test-namespace-id/threads/123' })
 
     describe "when the api request is successful", ->
       beforeEach ->


### PR DESCRIPTION
Added ability to pass in params to the event.save method in order to use them as a query-string value in the url. I followed similar implementation from restful-model-collection with the exception that I made the params optional. This way it also retains the backwards compatibility.

Also added tests for this feature.
