### PR TITLE
Fixed calendar model not exposing readOnly state of a calendar

### DIFF
--- a/lib/models/calendar.js
+++ b/lib/models/calendar.js
@@ -24,6 +24,10 @@
       }),
       'description': Attributes.String({
         modelKey: 'description'
+      }),
+      'readOnly': Attributes.Boolean({
+        modelKey: 'readOnly',
+        jsonKey: 'read_only'
       })
     });
 

--- a/models/calendar.coffee
+++ b/models/calendar.coffee
@@ -2,7 +2,7 @@ RestfulModel = require './restful-model'
 Attributes = require './attributes'
 _ = require 'underscore'
 
-module.exports = 
+module.exports =
 class Calendar extends RestfulModel
 
   @collectionName: 'calendars'
@@ -12,3 +12,6 @@ class Calendar extends RestfulModel
       modelKey: 'name'
     'description': Attributes.String
       modelKey: 'description'
+    'readOnly': Attributes.Boolean
+      modelKey: 'readOnly'
+      jsonKey: 'read_only'


### PR DESCRIPTION
Noticed that the calendar model wasn't exposing the read_only property from the response json. This is very essential to determine if you can create an event to a calendar, so I added it.