### PR TITLE
Update Server Side Auth Endpoint

### DIFF
--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -55,9 +55,6 @@
 
     Delta.prototype.latestCursor = function(callback) {
       var reqOpts;
-      if (callback == null) {
-        callback = null;
-      }
       reqOpts = {
         method: 'POST',
         path: "/delta/latest_cursor"

--- a/lib/nylas.js
+++ b/lib/nylas.js
@@ -18,16 +18,11 @@
 
     Nylas.apiServer = 'https://api.nylas.com';
 
-    Nylas.authServer = 'https://www.nylas.com';
-
     Nylas.config = function(arg) {
-      var apiServer, appId, appSecret, authServer, ref;
-      ref = arg != null ? arg : {}, appId = ref.appId, appSecret = ref.appSecret, apiServer = ref.apiServer, authServer = ref.authServer;
+      var apiServer, appId, appSecret, ref;
+      ref = arg != null ? arg : {}, appId = ref.appId, appSecret = ref.appSecret, apiServer = ref.apiServer;
       if ((apiServer != null ? apiServer.indexOf('://') : void 0) === -1) {
         throw new Error("Please specify a fully qualified URL for the API Server.");
-      }
-      if ((authServer != null ? authServer.indexOf('://') : void 0) === -1) {
-        throw new Error("Please specify a fully qualified URL for the Auth Server.");
       }
       if (appId) {
         this.appId = appId;
@@ -37,9 +32,6 @@
       }
       if (apiServer) {
         this.apiServer = apiServer;
-      }
-      if (authServer) {
-        this.authServer = authServer;
       }
       return this;
     };
@@ -69,7 +61,7 @@
           options = {
             method: 'GET',
             json: true,
-            url: _this.authServer + "/oauth/token",
+            url: _this.apiServer + "/oauth/token",
             qs: {
               'client_id': _this.appId,
               'client_secret': _this.appSecret,
@@ -110,7 +102,7 @@
       if (options.trial == null) {
         options.trial = false;
       }
-      return this.authServer + "/oauth/authorize?client_id=" + this.appId + "&trial=" + options.trial + "&response_type=code&scope=email&login_hint=" + options.loginHint + "&redirect_uri=" + options.redirectURI;
+      return this.apiServer + "/oauth/authorize?client_id=" + this.appId + "&trial=" + options.trial + "&response_type=code&scope=email&login_hint=" + options.loginHint + "&redirect_uri=" + options.redirectURI;
     };
 
     return Nylas;

--- a/nylas.coffee
+++ b/nylas.coffee
@@ -7,16 +7,13 @@ class Nylas
   @appId: null
   @appSecret: null
   @apiServer: 'https://api.nylas.com'
-  @authServer: 'https://www.nylas.com'
 
-  @config: ({appId, appSecret, apiServer, authServer} = {}) ->
+  @config: ({appId, appSecret, apiServer} = {}) ->
     throw new Error("Please specify a fully qualified URL for the API Server.") if apiServer?.indexOf('://') == -1
-    throw new Error("Please specify a fully qualified URL for the Auth Server.") if authServer?.indexOf('://') == -1
 
     @appId = appId if appId
     @appSecret = appSecret if appSecret
     @apiServer = apiServer if apiServer
-    @authServer = authServer if authServer
     @
 
   @hostedAPI: ->
@@ -34,7 +31,7 @@ class Nylas
       options =
         method: 'GET'
         json: true
-        url: "#{@authServer}/oauth/token"
+        url: "#{@apiServer}/oauth/token"
         qs:
           'client_id': @appId
           'client_secret': @appSecret
@@ -54,6 +51,6 @@ class Nylas
     throw new Error("urlForAuthentication() requires options.redirectURI") unless options.redirectURI?
     options.loginHint ?= ''
     options.trial ?= false
-    "#{@authServer}/oauth/authorize?client_id=#{@appId}&trial=#{options.trial}&response_type=code&scope=email&login_hint=#{options.loginHint}&redirect_uri=#{options.redirectURI}"
+    "#{@apiServer}/oauth/authorize?client_id=#{@appId}&trial=#{options.trial}&response_type=code&scope=email&login_hint=#{options.loginHint}&redirect_uri=#{options.redirectURI}"
 
 module.exports = Nylas

--- a/spec/nylas-api-spec.coffee
+++ b/spec/nylas-api-spec.coffee
@@ -15,25 +15,22 @@ describe "Nylas", ->
     Nylas.appId = undefined
     Nylas.appSecret = undefined
     Nylas.apiServer = 'https://api.nylas.com'
-    Nylas.authServer = 'https://www.nylas.com'
     Promise.onPossiblyUnhandledRejection (e, promise) ->
 
   describe "config", ->
     it "should allow you to populate the appId, appSecret, apiServer and authServer options", ->
-      newConfig = 
+      newConfig =
         appId: 'newId'
         appSecret: 'newSecret'
         apiServer: 'https://api-staging.nylas.com/'
-        authServer: 'https://www-staging.nylas.com/'
 
       Nylas.config(newConfig)
       expect(Nylas.appId).toBe(newConfig.appId)
       expect(Nylas.appSecret).toBe(newConfig.appSecret)
       expect(Nylas.apiServer).toBe(newConfig.apiServer)
-      expect(Nylas.authServer).toBe(newConfig.authServer)
 
     it "should not override existing values unless new values are provided", ->
-      newConfig = 
+      newConfig =
         appId: 'newId'
         appSecret: 'newSecret'
 
@@ -41,10 +38,9 @@ describe "Nylas", ->
       expect(Nylas.appId).toBe(newConfig.appId)
       expect(Nylas.appSecret).toBe(newConfig.appSecret)
       expect(Nylas.apiServer).toBe('https://api.nylas.com')
-      expect(Nylas.authServer).toBe('https://www.nylas.com')
 
     it "should throw an exception if the server options do not contain ://", ->
-      newConfig = 
+      newConfig =
         appId: 'newId'
         appSecret: 'newSecret'
         apiServer: 'dontknowwhatImdoing.nylas.com'
@@ -83,7 +79,7 @@ describe "Nylas", ->
 
     it "should make a request to /oauth/token with the correct grant_type and client params", ->
       spyOn(request, 'Request').andCallFake (options) ->
-        expect(options.url).toEqual('https://www.nylas.com/oauth/token')
+        expect(options.url).toEqual('https://api.nylas.com/oauth/token')
         expect(options.qs).toEqual({
           "client_id":"newId",
           "client_secret":"newSecret",
@@ -148,18 +144,17 @@ describe "Nylas", ->
     it "should generate the correct authentication URL", ->
       options =
         redirectURI: 'https://localhost/callback'
-      expect(Nylas.urlForAuthentication(options)).toEqual('https://www.nylas.com/oauth/authorize?client_id=newId&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=https://localhost/callback')
+      expect(Nylas.urlForAuthentication(options)).toEqual('https://api.nylas.com/oauth/authorize?client_id=newId&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=https://localhost/callback')
 
     it "should use a login hint when provided in the options", ->
       options =
         loginHint: 'ben@nylas.com'
         redirectURI: 'https://localhost/callback'
-      expect(Nylas.urlForAuthentication(options)).toEqual('https://www.nylas.com/oauth/authorize?client_id=newId&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback')
+      expect(Nylas.urlForAuthentication(options)).toEqual('https://api.nylas.com/oauth/authorize?client_id=newId&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback')
 
     it "should use trial = true when provided in the options", ->
       options =
         loginHint: 'ben@nylas.com'
         redirectURI: 'https://localhost/callback'
         trial: true
-      expect(Nylas.urlForAuthentication(options)).toEqual('https://www.nylas.com/oauth/authorize?client_id=newId&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback')
-
+      expect(Nylas.urlForAuthentication(options)).toEqual('https://api.nylas.com/oauth/authorize?client_id=newId&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback')


### PR DESCRIPTION
Looking at the Nylas API docs, the oauth enpoint has changed to `https://api.nylas.com`

Edit: Signed the CLA