### PR TITLE
Changed fileIds method on message model

### DIFF
--- a/models/message.coffee
+++ b/models/message.coffee
@@ -110,7 +110,9 @@ class Message extends RestfulModel
     return _.values(participants)
 
   fileIds: ->
-    _.map @files, (file) -> file.id
+    idsFromFiles = _.map @files, (file) -> file.id
+    idsFromFileIds = @file_ids || []
+    return idsFromFileIds.concat idsFromFiles
 
   saveRequestBody: ->
     # It's possible to update most of the fields of a draft.


### PR DESCRIPTION
The `fileIds` method on the Message model (used by drafts on send) pulls IDs from the `files` property and overwrites the `fileIds` property with them. This change combines the two sets of IDs instead.