### PR TITLE
Bump delta stream reconnect timeout to 15s, reduce verbosity of reconnect logging

### DIFF
--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -199,7 +199,8 @@
     };
 
     DeltaStream.prototype._restartConnection = function(n) {
-      console.log("Restarting Nylas DeltaStream connection (attempt " + (n + 1) + ")", this);
+      var ref;
+      console.log("Restarting Nylas DeltaStream connection (attempt " + (n + 1) + "):", (ref = this.request) != null ? ref.href : void 0);
       this.close();
       return this.open();
     };

--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -1,5 +1,5 @@
 (function() {
-  var Delta, DeltaStream, EventEmitter, JSONStream, Promise, STREAMING_TIMEOUT_MS, backoff, querystring, request,
+  var Delta, DeltaStream, EventEmitter, JSONStream, Promise, backoff, querystring, request,
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
@@ -15,9 +15,9 @@
 
   request = require('request');
 
-  STREAMING_TIMEOUT_MS = 5000;
-
   module.exports = Delta = (function() {
+    Delta.streamingTimeoutMs = 15000;
+
     function Delta(connection) {
       this.connection = connection;
       if (!(this.connection instanceof require('../nylas-connection'))) {
@@ -189,7 +189,7 @@
     DeltaStream.prototype._onDataReceived = function(data) {
       clearTimeout(this.timeoutId);
       this.restartBackoff.reset();
-      return this.timeoutId = setTimeout(this.restartBackoff.backoff.bind(this.restartBackoff), STREAMING_TIMEOUT_MS);
+      return this.timeoutId = setTimeout(this.restartBackoff.backoff.bind(this.restartBackoff), Delta.streamingTimeoutMs);
     };
 
     DeltaStream.prototype._onError = function(err) {

--- a/models/delta.coffee
+++ b/models/delta.coffee
@@ -137,6 +137,6 @@ class DeltaStream extends EventEmitter
     @emit('error', err)
 
   _restartConnection: (n) ->
-    console.log "Restarting Nylas DeltaStream connection (attempt #{n + 1})", @
+    console.log "Restarting Nylas DeltaStream connection (attempt #{n + 1}):", @request?.href
     @close()
     @open()

--- a/models/delta.coffee
+++ b/models/delta.coffee
@@ -5,9 +5,9 @@ Promise = require 'bluebird'
 querystring = require 'querystring'
 request = require 'request'
 
-STREAMING_TIMEOUT_MS = 5000
-
 module.exports = class Delta
+  @streamingTimeoutMs = 15000
+
   constructor: (@connection) ->
     throw new Error("Connection object not provided") unless @connection instanceof require '../nylas-connection'
     @
@@ -123,13 +123,13 @@ class DeltaStream extends EventEmitter
       .on 'error', @_onError.bind(@)
 
   _onDataReceived: (data) ->
-    # Nylas sends a newline heartbeat in the raw data stream once per second.
+    # Nylas sends a newline heartbeat in the raw data stream once every 5 seconds.
     # Automatically restart the connection if we haven't gotten any data in
-    # STREAMING_TIMEOUT_MS. The connection will restart with the last
+    # Delta.streamingTimeoutMs. The connection will restart with the last
     # received cursor.
     clearTimeout(@timeoutId)
     @restartBackoff.reset()
-    @timeoutId = setTimeout @restartBackoff.backoff.bind(@restartBackoff), STREAMING_TIMEOUT_MS
+    @timeoutId = setTimeout @restartBackoff.backoff.bind(@restartBackoff), Delta.streamingTimeoutMs
 
   _onError: (err) ->
     console.error 'Nylas DeltaStream error:', err

--- a/spec/delta-spec.coffee
+++ b/spec/delta-spec.coffee
@@ -56,7 +56,7 @@ describe 'Delta', ->
       expect(stream.request).toEqual(undefined)
 
       # Make sure the stream doesn't auto-restart if explicitly closed.
-      jasmine.Clock.tick(5500)
+      jasmine.Clock.tick(Delta.streamingTimeoutMs + 500)
       expect(stream.request).toEqual(undefined)
 
     it 'stream response parsing', ->
@@ -123,24 +123,24 @@ describe 'Delta', ->
       expectRequestNotAborted = (request) ->
         expect(request.abort.calls.length).toEqual(0)
 
-      # Server sends a heartbeat every second.
+      # Server sends a heartbeat every 5 seconds.
       response.write('\n')
-      jasmine.Clock.tick(1000)
+      jasmine.Clock.tick(5000)
       expect(request.abort.calls.length).toEqual(0)
       response.write('\n')
       expect(request.abort.calls.length).toEqual(0)
 
       # Actual response packets also reset the timeout.
-      jasmine.Clock.tick(1000)
+      jasmine.Clock.tick(5000)
       delta1 =
         cursor: 'deltacursor1'
       response.write(JSON.stringify(delta1))
       expect(stream.cursor).toEqual('deltacursor1')
-      jasmine.Clock.tick(1500)
+      jasmine.Clock.tick(5500)
       expect(request.abort.calls.length).toEqual(0)
 
       # If the timeout has elapsed since the last data received, the stream is restarted.
-      jasmine.Clock.tick(4000)
+      jasmine.Clock.tick(Delta.streamingTimeoutMs)
       # The old request should have been aborted, and a new request created.
       expect(request.abort.calls.length).toEqual(1)
       expect(stream.request).not.toBe(request)


### PR DESCRIPTION
@khamidou 

It seems like the Nylas server has recently changed to send heartbeats on the streaming delta connection only every 5 seconds, increased from every 1 second. This client library happens to have been configured to time out and reconnect after 5 seconds with no heartbeat.

Things do still work. However, that's more requests to the Nylas server than needed, plus it results in a lot of log spam.

This PR:
- Increases the default reconnect timeout to 15 seconds, up from 5 seconds. (2-3 missed 5s heartbeats, instead of 4-5 missed 1s heartbeats)
- Puts the reconnect timeout onto `Delta. streamingTimeoutMs` so it can be changed by clients in the future without needing to change this library.
- Reduces internal logging on reconnects to only log the URL, instead of the entire DeltaStream object.