### PR TITLE
Add option to support view=expanded api param

### DIFF
--- a/models/restful-model-collection.coffee
+++ b/models/restful-model-collection.coffee
@@ -54,13 +54,13 @@ class RestfulModelCollection
 
     @range(params, 0, limit, callback)
 
-  find: (id, callback = null) ->
+  find: (id, callback = null, params = {}) ->
     if not id
       err = new Error("find() must be called with an item id")
       callback(err) if callback
       return Promise.reject(err)
 
-    @getModel(id).then (model) ->
+    @getModel(id, params).then (model) ->
       callback(null, model) if callback
       Promise.resolve(model)
     .catch (err) ->
@@ -115,10 +115,11 @@ class RestfulModelCollection
 
   # Internal
 
-  getModel: (id) ->
+  getModel: (id, params = {}) ->
     @connection.request
       method: 'GET'
       path: "#{@path()}/#{id}"
+      qs: params
     .then (json) =>
       model = new @modelClass(@connection, json)
       Promise.resolve(model)

--- a/models/restful-model-instance.coffee
+++ b/models/restful-model-instance.coffee
@@ -11,10 +11,11 @@ class RestfulModelInstance
   path: ->
     "/#{@modelClass.endpointName}"
 
-  get: ->
+  get: (params = {}) ->
     @connection.request
       method: 'GET'
       path: @path()
+      qs: params
     .then (json) =>
       model = new @modelClass(@connection, json)
       Promise.resolve(model)

--- a/models/thread.coffee
+++ b/models/thread.coffee
@@ -55,6 +55,14 @@ class Thread extends RestfulModel
       modelKey: 'folder'
       itemClass: Folder
 
+    'messages': Attributes.Collection
+      modelKey: 'messages'
+      itemClass: Message
+
+    'drafts': Attributes.Collection
+      modelKey: 'drafts'
+      itemClass: Message
+
   fromJSON: (json) =>
     super(json)
     @unread = @isUnread()

--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -49,6 +49,12 @@ class NylasConnection
     options.json ?= true
     options.downloadRequest ?= false
 
+    # For convenience, If `expanded` param is provided, convert to view:
+    # 'expanded' api option
+    if options.qs?.expanded?
+      options.qs.view = 'expanded' if options.qs.expanded is true
+      delete options.qs.expanded
+
     user = if options.path.substr(0,3) == '/a/' then Nylas.appSecret else @accessToken
 
     if user

--- a/spec/account-spec.coffee
+++ b/spec/account-spec.coffee
@@ -24,4 +24,5 @@ describe "account", ->
     expect(@connection.request).toHaveBeenCalledWith({
       method : 'GET',
       path : '/account'
+      qs: {}
     })

--- a/spec/delta-spec.coffee
+++ b/spec/delta-spec.coffee
@@ -46,7 +46,8 @@ describe 'Delta', ->
       request = stream.request
 
       expect(request.origOpts.method).toBe('GET')
-      expect(request.origOpts.path).toBe('/delta/streaming?cursor=deltacursor0')
+      expect(request.origOpts.path).toBe('/delta/streaming')
+      expect(request.origOpts.qs).toEqual({cursor: 'deltacursor0'})
 
       response = createResponse(200)
       request.emit('response', response)
@@ -146,7 +147,8 @@ describe 'Delta', ->
       expect(request.abort.calls.length).toEqual(1)
       expect(stream.request).not.toBe(request)
       # The new request should be using the last delta cursor received prior to timeout.
-      expect(stream.request.origOpts.path).toBe('/delta/streaming?cursor=deltacursor1')
+      expect(stream.request.origOpts.path).toBe('/delta/streaming')
+      expect(stream.request.origOpts.qs).toEqual({cursor: 'deltacursor1'})
 
       stream.close()
 

--- a/spec/nylas-connection-spec.coffee
+++ b/spec/nylas-connection-spec.coffee
@@ -1,0 +1,13 @@
+_ = require 'underscore'
+NylasConnection = require '../nylas-connection'
+
+describe "NylasConnection", ->
+  beforeEach ->
+    @connection = new NylasConnection('test-access-token')
+
+  describe 'requestOptions', ->
+    it "should pass view='expanded' when expanded param is provided", ->
+      options = { method : 'GET', path : '/threads/123', qs: {expanded: true} }
+      result = @connection.requestOptions(options)
+      expect(result.qs.expanded).toBeUndefined()
+      expect(result.qs.view).toEqual('expanded')

--- a/spec/restful-model-collection-spec.coffee
+++ b/spec/restful-model-collection-spec.coffee
@@ -194,7 +194,14 @@ describe "RestfulModelCollection", ->
       spyOn(@connection, 'request').andCallFake => Promise.resolve({})
       testUntil (done) =>
         @collection.find('123')
-        expect(@connection.request).toHaveBeenCalledWith({ method : 'GET', path : '/threads/123' })
+        expect(@connection.request).toHaveBeenCalledWith({ method : 'GET', path : '/threads/123', qs: {} })
+        done()
+
+    it "should pass any additional params to the request", ->
+      spyOn(@connection, 'request').andCallFake => Promise.resolve({})
+      testUntil (done) =>
+        @collection.find('123', null, {param: 1})
+        expect(@connection.request).toHaveBeenCalledWith({ method : 'GET', path : '/threads/123', qs: {param: 1} })
         done()
 
     describe "when the request succeeds", ->

--- a/spec/thread-spec.coffee
+++ b/spec/thread-spec.coffee
@@ -1,6 +1,7 @@
 Nylas = require '../nylas'
 NylasConnection = require '../nylas-connection'
 Thread = require '../models/thread'
+Message = require '../models/message'
 Label = require('../models/folder').Label
 Promise = require 'bluebird'
 request = require 'request'
@@ -56,3 +57,19 @@ describe "Thread", ->
         qs : {}
         path : '/threads/4333'
       })
+
+  describe "fromJSON", ->
+    it "should populate messages and draft fields when receiving expanded thread", ->
+      m1 = {id: 'm1', object: 'message', to: [{name: 'Ben Bitdiddle', email: 'ben.bitdiddle@gmail.com'}]}
+      m2 = {id: 'm2', object: 'message', to: [{name: 'Alice', email: 'alice@gmail.com'}]}
+      draft = {id: 'm3', object: 'draft', to: [{name: 'Bob', email: 'bob@gmail.com'}]}
+
+      t = @thread.fromJSON({messages: [m1, m2], drafts: [draft]})
+      expect(t.messages).toBeDefined()
+      expect(t.messages[0] instanceof Message).toBe(true)
+      expect(t.messages[0].id).toBe('m1')
+      expect(t.messages[1] instanceof Message).toBe(true)
+      expect(t.messages[1].id).toBe('m2')
+      expect(t.drafts[0] instanceof Message).toBe(true)
+      expect(t.drafts[0].id).toBe('m3')
+      expect(t.drafts[0].draft).toBe(true)


### PR DESCRIPTION
Currently, for all methods on `RestfulModelCollection` except `find`,
users can manually pass `{view: 'expanded'}` as parameter.
This commit allows request params to be passed to `RestfulModelCollection::find`
and `RestfulModelInstance::get` too, so users can pass any params they
want when fetching individual models.

Additionaly, updates nylas-connection to support the option `expanded: true`
for all requests and transforms it to `view: 'expanded'` for convenience