### PR TITLE
Refactor: Use event to emit DeltaStream retry status

### DIFF
--- a/lib/models/delta.js
+++ b/lib/models/delta.js
@@ -103,6 +103,7 @@
   - `response` when the connection is established, with one argument, a `http.IncomingMessage`
   - `delta` for each delta received
   - `error` when an error occurs in the connection
+  - `info` when the connection status changes
    */
 
   DeltaStream = (function(superClass) {
@@ -198,13 +199,14 @@
 
     DeltaStream.prototype._onError = function(err) {
       console.error('Nylas DeltaStream error:', err);
-      this.restartBackoff.reset();
-      return this.emit('error', err);
+      this.emit('error', err);
+      return this.restartBackoff.reset();
     };
 
     DeltaStream.prototype._restartConnection = function(n) {
-      var ref;
+      var ref, ref1;
       console.log("Restarting Nylas DeltaStream connection (attempt " + (n + 1) + "):", (ref = this.request) != null ? ref.href : void 0);
+      this.emit('info', "Restarting Nylas DeltaStream connection (attempt " + (n + 1) + "): " + ((ref1 = this.request) != null ? ref1.href : void 0));
       this.close();
       return this.open();
     };

--- a/src/models/delta.coffee
+++ b/src/models/delta.coffee
@@ -57,6 +57,7 @@ Emits the following events:
 - `response` when the connection is established, with one argument, a `http.IncomingMessage`
 - `delta` for each delta received
 - `error` when an error occurs in the connection
+- `info` when the connection status changes
 ###
 class DeltaStream extends EventEmitter
   # Max number of times to retry a connection if we receive no data heartbeats
@@ -141,10 +142,11 @@ class DeltaStream extends EventEmitter
 
   _onError: (err) ->
     console.error 'Nylas DeltaStream error:', err
-    @restartBackoff.reset()
     @emit('error', err)
+    @restartBackoff.reset()
 
   _restartConnection: (n) ->
     console.log "Restarting Nylas DeltaStream connection (attempt #{n + 1}):", @request?.href
+    @emit('info', "Restarting Nylas DeltaStream connection (attempt #{n + 1}): #{@request?.href}")
     @close()
     @open()


### PR DESCRIPTION
This shouldn't be logging to console if it's an `EventEmitter`.
- [x] removed a redundant `emit(error)`
- [x] added a new event called `info` to deal with the re-connection info