### PR TITLE
add catch statement to range method in restful-model-collection

### DIFF
--- a/lib/models/restful-model-collection.js
+++ b/lib/models/restful-model-collection.js
@@ -171,6 +171,8 @@
               accumulated = accumulated.concat(models);
               finished = models.length < REQUEST_CHUNK_SIZE || accumulated.length >= limit;
               return chunkCallback();
+            })["catch"](function(err) {
+              return reject(err);
             });
           }, function(err) {
             if (err) {

--- a/lib/models/thread.js
+++ b/lib/models/thread.js
@@ -60,29 +60,10 @@
         modelKey: 'participants',
         itemClass: Contact
       }),
-      'firstMessageTimestamp': Attributes.DateTime({
-        queryable: true,
-        modelKey: 'firstMessageTimestamp',
-        jsonKey: 'first_message_timestamp'
-      }),
       'lastMessageTimestamp': Attributes.DateTime({
         queryable: true,
         modelKey: 'lastMessageTimestamp',
         jsonKey: 'last_message_timestamp'
-      }),
-      'lastMessageReceivedTimestamp': Attributes.DateTime({
-        queryable: true,
-        modelKey: 'lastMessageReceivedTimestamp',
-        jsonKey: 'last_message_received_timestamp'
-      }),
-      'lastMessageSentTimestamp': Attributes.DateTime({
-        queryable: true,
-        modelKey: 'lastMessageSentTimestamp',
-        jsonKey: 'last_message_sent_timestamp'
-      }),
-      'hasAttachments': Attributes.Boolean({
-        queryable: true,
-        modelKey: 'has_attachments'
       }),
       'labels': Attributes.Collection({
         modelKey: 'labels',

--- a/lib/nylas-connection.js
+++ b/lib/nylas-connection.js
@@ -112,7 +112,6 @@
       if ((base = options.headers)['User-Agent'] == null) {
         base['User-Agent'] = "Nylas Node SDK v" + SDK_VERSION;
       }
-
       return options;
     };
 

--- a/src/models/restful-model-collection.coffee
+++ b/src/models/restful-model-collection.coffee
@@ -81,6 +81,8 @@ class RestfulModelCollection
           accumulated = accumulated.concat(models)
           finished = models.length < REQUEST_CHUNK_SIZE or accumulated.length >= limit
           chunkCallback()
+        .catch (err) ->
+          reject(err)
       , (err) ->
         if err
           callback(err) if callback
@@ -133,4 +135,3 @@ class RestfulModelCollection
       models = jsonArray.map (json) =>
         new @modelClass(@connection, json)
       Promise.resolve(models)
-


### PR DESCRIPTION
closes #56 

Errors thrown inside the range method (`RestfulModelCollection.prototype.range`) do not get returned back to the list method.
Added a catch statement to this so that it will work properly.

I am not sure why there are changes to the `lib/models/thread` file (they were made when I ran the default `grunt` command). If this is undesired I can modify the PR so just let me know.