### PR TITLE
Fix handling of error when not a JSON request

### DIFF
--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -103,6 +103,9 @@ module.exports = class NylasConnection {
     return new Promise((resolve, reject) => {
       return request(options, (error, response, body = {}) => {
         if (error || response.statusCode > 299) {
+          if (_.isString(body)) {
+            body = JSON.parse(body);
+          }
           if (!error) {
             error = new Error(body.message);
           }


### PR DESCRIPTION
When sending raw MIME emails, the `json` request option is `false`, which means that the body is still a stringified JSON instead of an object. This means that when ever there was a failure, the error object never included any information about what happened because it was referencing a `.message` property on a string.

This specific request callback might need some more love as it seems to be behaving a little inconsistently. For example, if there is a `body.server_error`, the `error` is suddenly turned into a string instead of an Error instance. Also maybe it would be better to move the `JSON.parse` part on top and figure out what type the body is instead of relying on the request option's `json` value, and then use it in both cases (error & success).