### PR TITLE
Add status code to error handling

### DIFF
--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -141,6 +141,9 @@ module.exports = class NylasConnection {
           if (body.server_error) {
             error = `${error.message} (Server Error: ${body.server_error})`;
           }
+          if (response.statusCode) {
+            error.statusCode = response.statusCode;
+          }
           return reject(error);
         } else {
           if (options.downloadRequest) {


### PR DESCRIPTION
Summary: Add response status code to the error. This fixes the issue of the status code being swallowed and allows it to bubble up to the consumer.

Test Plan: manual

Reviewers: evan, halla

Differential Revision: https://phab.nylas.com/D6398