### PR TITLE
Move warning to print only if both sdk version and api version exist

### DIFF
--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -98,10 +98,13 @@ module.exports = class NylasConnection {
   }
   _getWarningForVersion(sdkApiVersion = null, apiVersion = null) {
     let warning = '';
+
     if (sdkApiVersion != apiVersion) {
-      warning += `WARNING: SDK version may not support your Nylas API version.`;
       if (sdkApiVersion && apiVersion) {
-        warning += ` SDK supports version ${sdkApiVersion} of the API and your application is currently running on version ${apiVersion} of the API.`;
+        warning +=
+          `WARNING: SDK version may not support your Nylas API version.` +
+          ` SDK supports version ${sdkApiVersion} of the API and your application` +
+          ` is currently running on version ${apiVersion} of the API.`;
 
         const apiNum = parseInt(apiVersion.split('-')[0]);
         const sdkNum = parseInt(sdkApiVersion.split('-')[0]);


### PR DESCRIPTION
Our code has a warning for when the api version that the application is using and the api version that the sdk supports are mismatched. Initially, we had a version agnostic warning for when the versions were mismatched. This warning could show even when a version was missing and there were complaints that it was spamming the console without being helpful. It could be the case that the versions are the same, however the application just has not sent its api version and because it is null, this warning will show.

This commit makes it so a warning only displays if both the api version and the sdk version are present. 

Resolves #72 