### PR TITLE
Parse body into JSON if its a string

### DIFF
--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -137,6 +137,12 @@ module.exports = class NylasConnection {
           console.warn(warning);
         }
 
+        // raw MIMI emails have json === false and the body is a string so
+        // we need to turn into JSON before we can access fields
+        if (options.json === false) {
+          body = JSON.parse(body);
+        }
+
         if (error || response.statusCode > 299) {
           if (!error) {
             error = new Error(body.message);
@@ -151,8 +157,6 @@ module.exports = class NylasConnection {
         } else {
           if (options.downloadRequest) {
             return resolve(response);
-          } else if (options.json === false) {
-            return resolve(JSON.parse(body));
           } else {
             return resolve(body);
           }


### PR DESCRIPTION
This commit adds a check for if the body is a string, and if so converts it to JSON. Originally, we were just doing the conversion in the case that it was not an error. @jylauril suggested adding it to the error case to enable `error.message` to actually work.   I moved this conversion outside the if/else because it is necessary in both cases. 


Fixes #69 