### PR TITLE
fix: Append server_error to error.message and not reassign variable

### DIFF
--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -142,9 +142,6 @@ module.exports = class NylasConnection {
         if (options.json === false) {
           body = JSON.parse(body);
         }
-        if (typeof error === 'string') {
-          error = new Error(error);
-        }
 
         if (error || response.statusCode > 299) {
           if (!error) {

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -142,13 +142,18 @@ module.exports = class NylasConnection {
         if (options.json === false) {
           body = JSON.parse(body);
         }
+        if (typeof error === 'string') {
+          error = new Error(error);
+        }
 
         if (error || response.statusCode > 299) {
           if (!error) {
             error = new Error(body.message);
           }
           if (body.server_error) {
-            error = `${error.message} (Server Error: ${body.server_error})`;
+            error.message = `${error.message} (Server Error: ${
+              body.server_error
+            })`;
           }
           if (response.statusCode) {
             error.statusCode = response.statusCode;

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -111,9 +111,9 @@ class Nylas {
     }
     let url = `${this.apiServer}/oauth/authorize?client_id=${
       this.appId
-    }&response_type=code&login_hint=${
-      options.loginHint
-    }&redirect_uri=${options.redirectURI}`;
+    }&response_type=code&login_hint=${options.loginHint}&redirect_uri=${
+      options.redirectURI
+    }`;
     if (options.state != null) {
       url += `&state=${options.state}`;
     }


### PR DESCRIPTION
Fixing the error "Cannot create property 'statusCode' on string" when we 
set the `server_error` and we get a `statusCode`.

Fixes #81 