### PR TITLE
Fix package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description":
     "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
+  "files": ["lib"],
   "scripts": {
     "test": "jest",
     "lint": "eslint \"./src/**/*.js\"",


### PR DESCRIPTION
Guys we are using this package and it's huge 100+Mb unpacked in node_modules, 
It's because it contains enormous amount of garbage like examples, and even log from developer machine, unpack and see https://registry.yarnpkg.com/nylas/-/nylas-4.2.2.tgz

This PR fixes this situation making your library small and beautiful.
Please merge and publish new version, as current highly increase build times and our app size.
 
