### PR TITLE
ES6 object spread

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["@babel/plugin-proposal-object-rest-spread"],
   "presets": ["@babel/preset-env"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,8 +14,9 @@
       "singleQuote": true,
       "trailingComma": "es5"
     }],
-    "prefer-const": "warn",
+    "prefer-const": "warn"
   },
+  "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module"
   }

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/file-spec.js
+++ b/__tests__/file-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/label-spec.js
+++ b/__tests__/label-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/nylas-connection-spec.js
+++ b/__tests__/nylas-connection-spec.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import NylasConnection from '../src/nylas-connection';
 
 import PACKAGE_JSON from '../package.json';

--- a/__tests__/restful-model-spec.js
+++ b/__tests__/restful-model-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/__tests__/restful-model-spec.js
+++ b/__tests__/restful-model-spec.js
@@ -12,7 +12,7 @@ class RestfulSubclassA extends RestfulModel {}
 class RestfulSubclassB extends RestfulModel {}
 
 class RestfulSubclassAttributes extends RestfulModel {}
-RestfulSubclassAttributes.attributes = _.extend({}, RestfulModel.attributes, {
+RestfulSubclassAttributes.attributes = { ...RestfulModel.attributes,
   testNumber: Attributes.Number({
     modelKey: 'testNumber',
     jsonKey: 'test_number',
@@ -21,7 +21,7 @@ RestfulSubclassAttributes.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'testBoolean',
     jsonKey: 'test_boolean',
   }),
-});
+};
 
 describe('RestfulModel', () => {
   let testContext;

--- a/__tests__/thread-spec.js
+++ b/__tests__/thread-spec.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import request from 'request';
-import _ from 'underscore';
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "lint": "eslint \"./src/**/*.js\"",
     "prettier": "prettier --single-quote --trailing-comma es5 --write \"./src/**/*.js\"",
-    "build": "babel src --presets @babel/preset-env --out-dir lib",
+    "build": "babel src --out-dir lib",
     "prepublish": "yarn build",
     "prepare": "yarn build",
     "watch": "nodemon -w src --exec npm run build"
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.3",
+    "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/preset-env": "^7.3.1",
     "eslint": "^5.14.0",
     "eslint-config-prettier": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/core": "^7.3.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/preset-env": "^7.3.1",
+    "babel-eslint": "^10.0.1",
     "eslint": "^5.14.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-prettier": "^3.0.1",

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -6,7 +6,8 @@ import Attributes from './attributes';
 export default class Account extends RestfulModel {}
 Account.collectionName = 'accounts';
 Account.endpointName = 'account';
-Account.attributes = _.extend({}, RestfulModel.attributes, {
+Account.attributes = {
+  ...RestfulModel.attributes,
   name: Attributes.String({
     modelKey: 'name',
   }),
@@ -33,4 +34,4 @@ Account.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'linkedAt',
     jsonKey: 'linked_at',
   }),
-});
+};

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
 

--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
 

--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -5,7 +5,8 @@ import Attributes from './attributes';
 
 export default class Calendar extends RestfulModel {}
 Calendar.collectionName = 'calendars';
-Calendar.attributes = _.extend({}, RestfulModel.attributes, {
+Calendar.attributes = {
+  ...RestfulModel.attributes,
   name: Attributes.String({
     modelKey: 'name',
   }),
@@ -16,4 +17,4 @@ Calendar.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'readOnly',
     jsonKey: 'read_only',
   }),
-});
+};

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
 

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -13,14 +13,15 @@ class EmailAddress extends RestfulModel {
   }
 }
 EmailAddress.collectionName = 'email_addresses';
-EmailAddress.attributes = _.extend({}, RestfulModel.attributes, {
+EmailAddress.attributes = {
+  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
   email: Attributes.String({
     modelKey: 'email',
   }),
-});
+};
 
 class IMAddress extends RestfulModel {
   toJSON() {
@@ -32,7 +33,8 @@ class IMAddress extends RestfulModel {
   }
 }
 IMAddress.collectionName = 'im_addresses';
-IMAddress.attributes = _.extend({}, RestfulModel.attributes, {
+IMAddress.attributes = {
+  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -40,7 +42,7 @@ IMAddress.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'imAddress',
     jsonKey: 'im_address',
   }),
-});
+};
 
 class PhysicalAddress extends RestfulModel {
   toJSON() {
@@ -61,7 +63,8 @@ class PhysicalAddress extends RestfulModel {
   }
 }
 PhysicalAddress.collectionName = 'physical_addresses';
-PhysicalAddress.attributes = _.extend({}, RestfulModel.attributes, {
+PhysicalAddress.attributes = {
+  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -88,7 +91,7 @@ PhysicalAddress.attributes = _.extend({}, RestfulModel.attributes, {
   country: Attributes.String({
     modelKey: 'country',
   }),
-});
+};
 
 class PhoneNumber extends RestfulModel {
   toJSON() {
@@ -101,14 +104,15 @@ class PhoneNumber extends RestfulModel {
 }
 
 PhoneNumber.collectionName = 'phone_numbers';
-PhoneNumber.attributes = _.extend({}, RestfulModel.attributes, {
+PhoneNumber.attributes = {
+  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
   number: Attributes.String({
     modelKey: 'number',
   }),
-});
+};
 
 class WebPage extends RestfulModel {
   toJSON() {
@@ -120,14 +124,15 @@ class WebPage extends RestfulModel {
   }
 }
 WebPage.collectionName = 'web_pages';
-WebPage.attributes = _.extend({}, RestfulModel.attributes, {
+WebPage.attributes = {
+  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
   url: Attributes.String({
     modelKey: 'url',
   }),
-});
+};
 
 export default class Contact extends RestfulModel {
   save(params = {}, callback = null) {
@@ -139,7 +144,8 @@ export default class Contact extends RestfulModel {
   }
 }
 Contact.collectionName = 'contacts';
-Contact.attributes = _.extend({}, RestfulModel.attributes, {
+Contact.attributes = {
+  ...RestfulModel.attributes,
   givenName: Attributes.String({
     modelKey: 'givenName',
     jsonKey: 'given_name',
@@ -208,4 +214,4 @@ Contact.attributes = _.extend({}, RestfulModel.attributes, {
     jsonKey: 'web_pages',
     itemClass: WebPage,
   }),
-});
+};

--- a/src/models/delta.js
+++ b/src/models/delta.js
@@ -115,13 +115,10 @@ class DeltaStream extends EventEmitter {
     const includeTypes =
       this.params.includeTypes != null ? this.params.includeTypes : [];
 
-    const queryObj = _.extend(
-      {},
-      _.omit(this.params, 'excludeTypes', 'includeTypes'),
-      {
-        cursor: this.cursor,
-      }
-    );
+    const queryObj = {
+      ..._.omit(this.params, 'excludeTypes', 'includeTypes'),
+      cursor: this.cursor,
+    };
     if (excludeTypes.length > 0) {
       queryObj.exclude_types = excludeTypes.join(',');
     }

--- a/src/models/draft.js
+++ b/src/models/draft.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import Promise from 'bluebird';
 
 import File from './file';

--- a/src/models/draft.js
+++ b/src/models/draft.js
@@ -96,7 +96,8 @@ export default class Draft extends Message {
   }
 }
 Draft.collectionName = 'drafts';
-Draft.attributes = _.extend({}, Message.attributes, {
+Draft.attributes = {
+  ...Message.attributes,
   version: Attributes.Number({
     modelKey: 'version',
   }),
@@ -104,4 +105,4 @@ Draft.attributes = _.extend({}, Message.attributes, {
     modelKey: 'replyToMessageId',
     jsonKey: 'reply_to_message_id',
   }),
-});
+};

--- a/src/models/email-participant.js
+++ b/src/models/email-participant.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
 

--- a/src/models/event-participant.js
+++ b/src/models/event-participant.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
 

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -1,5 +1,4 @@
 import Promise from 'bluebird';
-import _ from 'underscore';
 
 import RestfulModel from './restful-model';
 import Attributes from './attributes';

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -66,7 +66,8 @@ export default class Event extends RestfulModel {
   }
 }
 Event.collectionName = 'events';
-Event.attributes = _.extend({}, RestfulModel.attributes, {
+Event.attributes = {
+  ...RestfulModel.attributes,
   calendarId: Attributes.String({
     modelKey: 'calendarId',
     jsonKey: 'calendar_id',
@@ -112,4 +113,4 @@ Event.attributes = _.extend({}, RestfulModel.attributes, {
   status: Attributes.String({
     modelKey: 'status',
   }),
-});
+};

--- a/src/models/file.js
+++ b/src/models/file.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
 

--- a/src/models/file.js
+++ b/src/models/file.js
@@ -71,7 +71,7 @@ export default class File extends RestfulModel {
       })
       .then(response => {
         let filename;
-        const file = _.extend(response.headers, { body: response.body });
+        const file = { ...response.headers, body: response.body };
         if ('content-disposition' in file) {
           filename =
             /filename=([^;]*)/.exec(file['content-disposition'])[1] ||
@@ -112,7 +112,8 @@ export default class File extends RestfulModel {
   }
 }
 File.collectionName = 'files';
-File.attributes = _.extend({}, RestfulModel.attributes, {
+File.attributes = {
+  ...RestfulModel.attributes,
   contentType: Attributes.String({
     modelKey: 'contentType',
     jsonKey: 'content_type',
@@ -134,4 +135,4 @@ File.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'contentId',
     jsonKey: 'content_id',
   }),
-});
+};

--- a/src/models/folder.js
+++ b/src/models/folder.js
@@ -17,7 +17,8 @@ export class Label extends RestfulModel {
   }
 }
 Label.collectionName = 'labels';
-Label.attributes = _.extend({}, RestfulModel.attributes, {
+Label.attributes = {
+  ...RestfulModel.attributes,
   name: Attributes.String({
     modelKey: 'name',
     jsonKey: 'name',
@@ -26,7 +27,7 @@ Label.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'displayName',
     jsonKey: 'display_name',
   }),
-});
+};
 
 export class Folder extends Label {}
 Folder.collectionName = 'folders';

--- a/src/models/folder.js
+++ b/src/models/folder.js
@@ -1,5 +1,4 @@
 import Promise from 'bluebird';
-import _ from 'underscore';
 
 import RestfulModel from './restful-model';
 import Attributes from './attributes';

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -27,7 +27,8 @@ export default class ManagementAccount extends ManagementModel {
   }
 }
 ManagementAccount.collectionName = 'accounts';
-ManagementAccount.attributes = _.extend({}, ManagementModel.attributes, {
+ManagementAccount.attributes = {
+  ...ManagementModel.attributes,
   billingState: Attributes.String({
     modelKey: 'billingState',
     jsonKey: 'billing_state',
@@ -43,4 +44,4 @@ ManagementAccount.attributes = _.extend({}, ManagementModel.attributes, {
   trial: Attributes.Boolean({
     modelKey: 'trial',
   }),
-});
+};

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import ManagementModel from './management-model';
 import Attributes from './attributes';
 

--- a/src/models/message.js
+++ b/src/models/message.js
@@ -103,7 +103,8 @@ export default class Message extends RestfulModel {
   }
 }
 Message.collectionName = 'messages';
-Message.attributes = _.extend({}, RestfulModel.attributes, {
+Message.attributes = {
+  ...RestfulModel.attributes,
   subject: Attributes.String({
     modelKey: 'subject',
   }),
@@ -166,4 +167,4 @@ Message.attributes = _.extend({}, RestfulModel.attributes, {
   headers: Attributes.Object({
     modelKey: 'headers',
   }),
-});
+};

--- a/src/models/restful-model-collection.js
+++ b/src/models/restful-model-collection.js
@@ -58,7 +58,7 @@ export default class RestfulModelCollection {
       .request({
         method: 'GET',
         path: this.path(),
-        qs: _.extend({ view: 'count' }, params),
+        qs: { view: 'count', ...params },
       })
       .then(json => {
         if (callback) {
@@ -278,7 +278,7 @@ export default class RestfulModelCollection {
       return this.connection.request({
         method: 'GET',
         path,
-        qs: _.extend({}, params, { offset, limit }),
+        qs: { ...params, offset, limit },
       });
     }
 
@@ -307,7 +307,7 @@ export default class RestfulModelCollection {
       .request({
         method: 'GET',
         path,
-        qs: _.extend({}, params, { offset, limit }),
+        qs: { ...params, offset, limit },
       })
       .then(jsonArray => {
         const models = jsonArray.map(json => {

--- a/src/models/thread.js
+++ b/src/models/thread.js
@@ -35,7 +35,8 @@ export default class Thread extends RestfulModel {
   }
 }
 Thread.collectionName = 'threads';
-Thread.attributes = _.extend({}, RestfulModel.attributes, {
+Thread.attributes = {
+  ...RestfulModel.attributes,
   subject: Attributes.String({
     modelKey: 'subject',
   }),
@@ -101,4 +102,4 @@ Thread.attributes = _.extend({}, RestfulModel.attributes, {
     modelKey: 'drafts',
     itemClass: Message,
   }),
-});
+};

--- a/src/models/thread.js
+++ b/src/models/thread.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import Message from './message';
 import RestfulModel from './restful-model';
 import Contact from './contact';

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import clone from 'clone';
 import request from 'request';
 import Promise from 'bluebird';

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import request from 'request';
 import Promise from 'bluebird';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,7 +252,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.3.1":
+"@babel/plugin-proposal-object-rest-spread@^7.3.1", "@babel/plugin-proposal-object-rest-spread@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz#6d1859882d4d778578e41f82cc5d7bf3d5daf6c1"
   integrity sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,6 +827,18 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 babel-jest@^24.1.0:
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.1.0.tgz#441e23ef75ded3bd547e300ac3194cef87b55190"
@@ -1422,6 +1434,14 @@ eslint-plugin-prettier@^3.0.1:
   integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We can use [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) to replace `_.extend()`, and make the code clearer as well.