### PR TITLE
rm deprecated field in google auth

### DIFF
--- a/example/authentication/routes/index.js
+++ b/example/authentication/routes/index.js
@@ -29,7 +29,7 @@ const GOOGLE_OAUTH_ACCESS_TOKEN_URL =
 function get_email_from_access_token(google_access_token) {
   const data = {
     access_token: google_access_token,
-    fields: 'email',
+    fields: ['email'],
   };
   return request
     .post({ url: GOOGLE_OAUTH_TOKEN_VALIDATION_URL, form: data })


### PR DESCRIPTION
Was getting `400: "Error expanding 'fields' parameter. Cannot find matching fields for path 'email'"` responses from google, because the fields param no longer works; dropping it. 

See: https://meta.stackoverflow.com/questions/376116/cannot-sign-in-with-google-error-expanding-fields-parameter-cannot-find-matc