### PR TITLE
migrate to client_id and client_secret naming 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Install the Nylas SDK:
 API Overview
 ------------
 
-Every resource (i.e., messages, events, contacts) is accessed via an instance of `Nylas`. Before making any requests, be sure to call `config` and initialize the `Nylas` instance with your `appId` and `appSecret`. Then, call `with` and pass it your `accessToken`. The `accessToken` allows `Nylas` to make requests for a given account's resources.
+Every resource (i.e., messages, events, contacts) is accessed via an instance of `Nylas`. Before making any requests, be sure to call `config` and initialize the `Nylas` instance with your `clientId` and `clientSecret`. Then, call `with` and pass it your `accessToken`. The `accessToken` allows `Nylas` to make requests for a given account's resources.
 
 ```javascript
 const Nylas = require('nylas');
 
 Nylas.config({
-  appId: APP_ID,
-  appSecret: APP_SECRET,
+  clientId: CLIENT_ID,
+  clientSecret: CLIENT_SECRET,
 });
 
 const nylas = Nylas.with(ACCESS_TOKEN);
@@ -66,8 +66,8 @@ The Nylas REST API uses server-side (three-legged) OAuth, and the Node.js bindin
 const Nylas = require('nylas');
 
 Nylas.config({
-  appId: APP_ID,
-  appSecret: APP_SECRET,
+  clientId: CLIENT_ID,
+  clientSecret: CLIENT_SECRET,
 });
 
 router.get('/connect', (req, res, next) => {
@@ -509,8 +509,8 @@ It requires us to "auth" to it by passing the account id as an auth token. Here'
 const Nylas = require('nylas');
 
 Nylas.config({
-  appId: 'appId', // Doesn't matter when running locally
-  appSecret: 'appSecret', // Doesn't matter when running locally
+  clientId: 'clientId', // Doesn't matter when running locally
+  clientSecret: 'clientSecret', // Doesn't matter when running locally
   apiServer: 'http://localhost:5555',
 });
 

--- a/example/sample-app/app.js
+++ b/example/sample-app/app.js
@@ -23,9 +23,9 @@ var nylasAppConfigs = {
 };
 
 assert.notEqual(
-  nylasAppConclients.clientId,
+  nylasAppConfigs.clientId,
   '<client ID here>',
-  'Please replace with you Nylas Client ID'
+  'Please replace with your Nylas Client ID'
 );
 assert.notEqual(
   nylasAppConfigs.clientSecret,

--- a/example/sample-app/app.js
+++ b/example/sample-app/app.js
@@ -18,19 +18,19 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
 
 var nylasAppConfigs = {
-  appId: '<app ID here>',
-  appSecret: '<app secret here>',
+  clientId: '<client ID here>',
+  clientSecret: '<client secret here>',
 };
 
 assert.notEqual(
-  nylasAppConfigs.appId,
-  '<app ID here>',
-  'Please replace with you Nylas App ID'
+  nylasAppConclients.clientId,
+  '<client ID here>',
+  'Please replace with you Nylas Client ID'
 );
 assert.notEqual(
-  nylasAppConfigs.appSecret,
-  '<app secret here>',
-  'Please replace with your Nylas App Secret'
+  nylasAppConfigs.clientSecret,
+  '<client secret here>',
+  'Please replace with your Nylas Client Secret'
 );
 
 // setup the Nylas API

--- a/src/models/attributes.js
+++ b/src/models/attributes.js
@@ -64,7 +64,9 @@ class AttributeDate extends Attribute {
     }
     if (!(val instanceof Date)) {
       throw new Error(
-        `Attempting to toJSON AttributeDate which is not a date: ${this.modelKey} = ${val}`
+        `Attempting to toJSON AttributeDate which is not a date:
+          ${this.modelKey}
+         = ${val}`
       );
     }
     return val.toISOString();
@@ -85,7 +87,9 @@ class AttributeDateTime extends Attribute {
     }
     if (!(val instanceof Date)) {
       throw new Error(
-        `Attempting to toJSON AttributeDateTime which is not a date: ${this.modelKey} = ${val}`
+        `Attempting to toJSON AttributeDateTime which is not a date: 
+          ${this.modelKey} 
+        = ${val}`
       );
     }
     return val.getTime() / 1000.0;

--- a/src/models/delta.js
+++ b/src/models/delta.js
@@ -89,7 +89,9 @@ class DeltaStream extends EventEmitter {
       .on('fail', () => {
         return this.emit(
           'error',
-          `Nylas DeltaStream failed to reconnect after ${DeltaStream.MAX_RESTART_RETRIES} retries.`
+          `Nylas DeltaStream failed to reconnect after 
+          ${DeltaStream.MAX_RESTART_RETRIES}
+          retries.`
         );
       });
   }

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -6,7 +6,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.appId}/${this.constructor.collectionName}/${this.id}/upgrade`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/upgrade`,
       })
       .catch(err => Promise.reject(err));
   }
@@ -15,7 +15,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.appId}/${this.constructor.collectionName}/${this.id}/downgrade`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/downgrade`,
       })
       .catch(err => Promise.reject(err));
   }
@@ -24,7 +24,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.appId}/${this.constructor.collectionName}/${this.id}/revoke-all`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/revoke-all`,
         body: { keep_access_token: keep_access_token },
       })
       .catch(err => Promise.reject(err));
@@ -33,7 +33,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'GET',
-        path: `/a/${this.appId}/ip_addresses`,
+        path: `/a/${this.clientId}/ip_addresses`,
       })
       .catch(err => Promise.reject(err));
   }

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -6,9 +6,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.clientId}/${this.constructor.collectionName}/${
-          this.id
-        }/upgrade`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/upgrade`,
       })
       .catch(err => Promise.reject(err));
   }
@@ -17,9 +15,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.clientId}/${this.constructor.collectionName}/${
-          this.id
-        }/downgrade`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/downgrade`,
       })
       .catch(err => Promise.reject(err));
   }
@@ -28,9 +24,7 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.clientId}/${this.constructor.collectionName}/${
-          this.id
-        }/revoke-all`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/revoke-all`,
         body: { keep_access_token: keep_access_token },
       })
       .catch(err => Promise.reject(err));

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -6,7 +6,9 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/upgrade`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${
+          this.id
+        }/upgrade`,
       })
       .catch(err => Promise.reject(err));
   }
@@ -15,7 +17,9 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/downgrade`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${
+          this.id
+        }/downgrade`,
       })
       .catch(err => Promise.reject(err));
   }
@@ -24,7 +28,9 @@ export default class ManagementAccount extends ManagementModel {
     return this.connection
       .request({
         method: 'POST',
-        path: `/a/${this.clientId}/${this.constructor.collectionName}/${this.id}/revoke-all`,
+        path: `/a/${this.clientId}/${this.constructor.collectionName}/${
+          this.id
+        }/revoke-all`,
         body: { keep_access_token: keep_access_token },
       })
       .catch(err => Promise.reject(err));

--- a/src/models/management-model-collection.js
+++ b/src/models/management-model-collection.js
@@ -1,16 +1,16 @@
 import RestfulModelCollection from './restful-model-collection';
 
 export default class ManagementModelCollection extends RestfulModelCollection {
-  constructor(modelClass, connection, appId) {
+  constructor(modelClass, connection, clientId) {
     super(modelClass, connection);
-    this.appId = appId;
+    this.clientId = clientId;
   }
 
   path() {
-    return `/a/${this.appId}/${this.modelClass.collectionName}`;
+    return `/a/${this.clientId}/${this.modelClass.collectionName}`;
   }
 
   _createModel(json) {
-    return new this.modelClass(this.connection, this.appId, json);
+    return new this.modelClass(this.connection, this.clientId, json);
   }
 }

--- a/src/models/management-model.js
+++ b/src/models/management-model.js
@@ -1,8 +1,8 @@
 import RestfulModel from './restful-model';
 
 export default class ManagementModel extends RestfulModel {
-  constructor(connection, appId, json = null) {
+  constructor(connection, clientId, json = null) {
     super(connection, json);
-    this.appId = appId;
+    this.clientId = clientId;
   }
 }

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -148,7 +148,9 @@ module.exports = class NylasConnection {
             error = new Error(body.message);
           }
           if (body.server_error) {
-            error.message = `${error.message} (Server Error: ${body.server_error})`;
+            error.message = `${error.message} (Server Error: 
+              ${body.server_error}
+            )`;
           }
           if (response.statusCode) {
             error.statusCode = response.statusCode;

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -22,7 +22,7 @@ class Nylas {
     let appId;
     let appSecret;
 
-    for (let key in appNames) {
+    for (const key in appNames) {
       if (key === 'appId') {
         appId = appNames[key];
       } else if (key === 'appSecret') {
@@ -32,16 +32,22 @@ class Nylas {
 
     if (appId) {
       this.clientId = appId;
-      process.emitWarning('"appId" will be deprecated in version 5.0.0. Use "clientId" instead.', {
-        code: 'DeprecationWarning'
-      });
+      process.emitWarning(
+        '"appId" will be deprecated in version 5.0.0. Use "clientId" instead.',
+        {
+          code: 'DeprecationWarning',
+        }
+      );
     }
 
     if (appSecret) {
       this.clientSecret = appSecret;
-      process.emitWarning('"appSecret" will be deprecated in version 5.0.0. Use "clientId" instead.', {
-        code: 'DeprecationWarning'
-      });
+      process.emitWarning(
+        '"appSecret" will be deprecated in version 5.0.0. Use "clientId" instead.',
+        {
+          code: 'DeprecationWarning',
+        }
+      );
     }
 
     if (clientId) {
@@ -56,14 +62,18 @@ class Nylas {
 
     let conn;
     if (this.hostedAPI()) {
-      conn = new NylasConnection(this.clientSecret, { clientId: this.clientId });
+      conn = new NylasConnection(this.clientSecret, {
+        clientId: this.clientId,
+      });
       this.accounts = new ManagementModelCollection(
         ManagementAccount,
         conn,
         this.clientId
       );
     } else {
-      conn = new NylasConnection(this.clientSecret, { clientId: this.clientId });
+      conn = new NylasConnection(this.clientSecret, {
+        clientId: this.clientId,
+      });
       this.accounts = new RestfulModelCollection(Account, conn, this.clientId);
     }
 
@@ -71,31 +81,43 @@ class Nylas {
   }
 
   static get appId() {
-    process.emitWarning('"appId" will be deprecated in version 5.0.0. Use "clientId" instead.', {
-      code: 'DeprecationWarning'
-    });
-    return this.clientId
+    process.emitWarning(
+      '"appId" will be deprecated in version 5.0.0. Use "clientId" instead.',
+      {
+        code: 'DeprecationWarning',
+      }
+    );
+    return this.clientId;
   }
 
   static set appId(value) {
     this.clientId = value;
-    process.emitWarning('"appId" will be deprecated in version 5.0.0. Use "clientId" instead.', {
-      code: 'DeprecationWarning'
-    });
+    process.emitWarning(
+      '"appId" will be deprecated in version 5.0.0. Use "clientId" instead.',
+      {
+        code: 'DeprecationWarning',
+      }
+    );
   }
 
   static get appSecret() {
-    process.emitWarning('"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.', {
-      code: 'DeprecationWarning'
-    });
-    return this.clientSecret
+    process.emitWarning(
+      '"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.',
+      {
+        code: 'DeprecationWarning',
+      }
+    );
+    return this.clientSecret;
   }
 
   static set appSecret(value) {
     this.clientSecret = value;
-    process.emitWarning('"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.', {
-      code: 'DeprecationWarning'
-    });
+    process.emitWarning(
+      '"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.',
+      {
+        code: 'DeprecationWarning',
+      }
+    );
   }
 
   static hostedAPI() {

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -12,7 +12,7 @@ class Nylas {
     this.clientSecret = null;
   }
 
-  static config({ clientId, clientSecret, apiServer, ...appNames }) {
+  static config({ clientId, clientSecret, apiServer, ...deprecatingParams }) {
     if (apiServer && apiServer.indexOf('://') === -1) {
       throw new Error(
         'Please specify a fully qualified URL for the API Server.'
@@ -22,11 +22,11 @@ class Nylas {
     let appId;
     let appSecret;
 
-    for (const key in appNames) {
+    for (const key in deprecatingParams) {
       if (key === 'appId') {
-        appId = appNames[key];
+        appId = deprecatingParams[key];
       } else if (key === 'appSecret') {
-        appSecret = appNames[key];
+        appSecret = deprecatingParams[key];
       }
     }
 

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -182,11 +182,7 @@ class Nylas {
     if (!options.loginHint) {
       options.loginHint = '';
     }
-    let url = `${this.apiServer}/oauth/authorize?client_id=${
-      this.clientId
-    }&response_type=code&login_hint=${options.loginHint}&redirect_uri=${
-      options.redirectURI
-    }`;
+    let url = `${this.apiServer}/oauth/authorize?client_id=${this.clientId}&response_type=code&login_hint=${options.loginHint}&redirect_uri=${options.redirectURI}`;
     if (options.state != null) {
       url += `&state=${options.state}`;
     }

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -182,7 +182,7 @@ class Nylas {
     if (!options.loginHint) {
       options.loginHint = '';
     }
-    let url = `${this.apiServer}/oauth/authorize?client_id=${this.appId}&response_type=code&login_hint=${options.loginHint}&redirect_uri=${options.redirectURI}`;
+    let url = `${this.apiServer}/oauth/authorize?client_id=${this.clientId}&response_type=code&login_hint=${options.loginHint}&redirect_uri=${options.redirectURI}`;
     if (options.state != null) {
       url += `&state=${options.state}`;
     }

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -61,7 +61,7 @@ class Nylas {
     }
 
     let conn;
-    if (this.hostedAPI()) {
+    if (this.clientCredentials()) {
       conn = new NylasConnection(this.clientSecret, {
         clientId: this.clientId,
       });
@@ -120,7 +120,7 @@ class Nylas {
     );
   }
 
-  static hostedAPI() {
+  static clientCredentials() {
     return this.clientId != null && this.clientSecret != null;
   }
 
@@ -182,7 +182,11 @@ class Nylas {
     if (!options.loginHint) {
       options.loginHint = '';
     }
-    let url = `${this.apiServer}/oauth/authorize?client_id=${this.clientId}&response_type=code&login_hint=${options.loginHint}&redirect_uri=${options.redirectURI}`;
+    let url = `${this.apiServer}/oauth/authorize?client_id=${
+      this.clientId
+    }&response_type=code&login_hint=${options.loginHint}&redirect_uri=${
+      options.redirectURI
+    }`;
     if (options.state != null) {
       url += `&state=${options.state}`;
     }


### PR DESCRIPTION
Migrates to `client_id` and `client_secret` naming. Adds a deprecation warning.