### PR TITLE
add billing_state to Account obj

### DIFF
--- a/__tests__/account-spec.js
+++ b/__tests__/account-spec.js
@@ -24,18 +24,25 @@ describe('account', () => {
     );
   });
 
-  test('should fetch an account model', () => {
+  test('should fetch an account model', done => {
     testContext.connection.account.get();
     expect(testContext.connection.request).toHaveBeenCalledWith({
       method: 'GET',
       path: '/account',
       qs: {},
     });
+    done();
   });
 
-  test('linkedAt exists on account', () => {
+  test('account attributes should resolve', done => {
     testContext.connection.account.get().then(function(account) {
-      expect(account.linkedAt);
+      expect(account.id).toBe('hecea680y4sborshkiraj17c');
+      expect(account.emailAddress).toBe('jeremy@emmerge.com');
+      expect(account.organizationUnit).toBe('folder');
+      expect(account.provider).toBe('eas');
+      expect(account.syncState).toBe('running');
+      expect(account.linkedAt).toEqual(new Date(linkedAtNum * 1000));
     });
+    done();
   });
 });

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -12,12 +12,12 @@ describe('ManagementAccount', () => {
 
   describe('list', () => {
     test('should do a GET request to get the account list', done => {
-      expect.assertions(3);
+      expect.assertions(4);
       Nylas.accounts.connection.request = jest.fn(() =>
         Promise.resolve([
           {
             account_id: '8rilmlwuo4zmpjedz8bcplclk',
-            billing_state: 'free',
+            billing_state: 'paid',
             id: ACCOUNT_ID,
             sync_state: 'running',
             trial: false,
@@ -28,6 +28,7 @@ describe('ManagementAccount', () => {
         .list({}, (err, accounts) => {
           expect(accounts.length).toEqual(1);
           expect(accounts[0].id).toEqual('8rilmlwuo4zmpjedz8bcplclk');
+          expect(accounts[0].billingState).toBe('paid');
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 100, offset: 0 },

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -28,6 +28,12 @@ Account.attributes = {
     modelKey: 'syncState',
     jsonKey: 'sync_state',
   }),
+
+  billingState: Attributes.String({
+    modelKey: 'billingState',
+    jsonKey: 'billing_state',
+  }),
+
   linkedAt: Attributes.DateTime({
     modelKey: 'linkedAt',
     jsonKey: 'linked_at',


### PR DESCRIPTION
note: billing_state doesn't exist yet on GET [/account](https://docs.nylas.com/reference#account), so only asserting on GET [.../accounts](https://docs.nylas.com/reference#aclient_idaccounts)