### PR TITLE
Support 'email' and 'provider' on ManagementAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Unreleased
 
-nothing yet
+* Add contentDisposition to File
+* Add emailAddress to ManagementAccount
+* Add provider to ManagementAccount
 
 ### 4.6.1 / 2019-07-10
 

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -12,12 +12,13 @@ describe('ManagementAccount', () => {
 
   describe('list', () => {
     test('should do a GET request to get the account list', done => {
-      expect.assertions(4);
+      expect.assertions(5);
       Nylas.accounts.connection.request = jest.fn(() =>
         Promise.resolve([
           {
             account_id: '8rilmlwuo4zmpjedz8bcplclk',
             billing_state: 'paid',
+            email: 'margaret@hamilton.com',
             id: ACCOUNT_ID,
             sync_state: 'running',
             trial: false,
@@ -28,7 +29,8 @@ describe('ManagementAccount', () => {
         .list({}, (err, accounts) => {
           expect(accounts.length).toEqual(1);
           expect(accounts[0].id).toEqual('8rilmlwuo4zmpjedz8bcplclk');
-          expect(accounts[0].billingState).toBe('paid');
+          expect(accounts[0].billingState).toEqual('paid');
+          expect(accounts[0].emailAddress).toEqual('margaret@hamilton.com');
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 100, offset: 0 },

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -12,7 +12,7 @@ describe('ManagementAccount', () => {
 
   describe('list', () => {
     test('should do a GET request to get the account list', done => {
-      expect.assertions(5);
+      expect.assertions(6);
       Nylas.accounts.connection.request = jest.fn(() =>
         Promise.resolve([
           {
@@ -20,6 +20,7 @@ describe('ManagementAccount', () => {
             billing_state: 'paid',
             email: 'margaret@hamilton.com',
             id: ACCOUNT_ID,
+            provider: 'gmail',
             sync_state: 'running',
             trial: false,
           },
@@ -31,6 +32,7 @@ describe('ManagementAccount', () => {
           expect(accounts[0].id).toEqual('8rilmlwuo4zmpjedz8bcplclk');
           expect(accounts[0].billingState).toEqual('paid');
           expect(accounts[0].emailAddress).toEqual('margaret@hamilton.com');
+          expect(accounts[0].provider).toEqual('gmail');
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 100, offset: 0 },

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -59,6 +59,9 @@ ManagementAccount.attributes = {
     modelKey: 'namespaceId',
     jsonKey: 'namespace_id',
   }),
+  provider: Attributes.String({
+    modelKey: 'provider',
+  }),
   syncState: Attributes.String({
     modelKey: 'syncState',
     jsonKey: 'sync_state',

--- a/src/models/management-account.js
+++ b/src/models/management-account.js
@@ -51,6 +51,10 @@ ManagementAccount.attributes = {
     modelKey: 'billingState',
     jsonKey: 'billing_state',
   }),
+  emailAddress: Attributes.String({
+    modelKey: 'emailAddress',
+    jsonKey: 'email',
+  }),
   namespaceId: Attributes.String({
     modelKey: 'namespaceId',
     jsonKey: 'namespace_id',


### PR DESCRIPTION
The account management [GET /accounts](https://docs.nylas.com/reference#aclient_idaccounts) endpoint returns an `email` attribute on the account object, which we should persist on the `ManagementAccount` object. 

I named this attribute `emailAddress` for consistency with the `Account` object. 