### PR TITLE
run travis builds for Node 11 & 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - 8
   - 9
   - 10
+  - 11
+  - 12
 
 script: npm test
 


### PR DESCRIPTION
<img width="377" alt="Screen Shot 2019-07-24 at 10 15 47 AM" src="https://user-images.githubusercontent.com/9885864/61832779-0f96a800-ae27-11e9-9499-6265df1c57d7.png">

Versions 11 & 12 are currently supported, so we should run travis builds on them.