### PR TITLE
sample-app: bump nylas dependency version

### DIFF
--- a/example/sample-app/package.json
+++ b/example/sample-app/package.json
@@ -17,7 +17,7 @@
     "express": "^4.17.1",
     "express-session": "^1.15.6",
     "morgan": "^1.9.1",
-    "nylas": "^2.1.0",
+    "nylas": "^4.7.0",
     "opn": "^5.2.0",
     "pug": "^2.0.0-rc.4",
     "serve-favicon": "^2.5.0"


### PR DESCRIPTION
The example app fails to start up. There's an error about the appId and secret being missing, even though I set the client ID, client secret, and session secret. Bumping the version to `^4.7.0` fixes that error. I don't know if any other code needs to be changed; I can't see from Releases what the breaking changes were between version 2 to 3 and 3 to 4.