### PR TITLE
implement /connect/authorize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Update formatting for DeprecationWarnings
 * Update package-lock.json
-
+* Add support for `/connect/authorize` endpoint
 
 ### 4.7.0 / 2019-08-20
 

--- a/__tests__/connect-spec.js
+++ b/__tests__/connect-spec.js
@@ -1,0 +1,117 @@
+import Nylas from '../src/nylas';
+
+describe('Connect', () => {
+
+  const name = 'Connect Test';
+  const password = 'connecting123';
+  const scopes = 'email, calendar, contacts';
+  const exchangeEmail = 'connect_test@outlook.com';
+  const gmailEmail = 'connect_test@gmail.com';
+  const imapEmail = 'connect_test@yahoo.com';
+  const o365Email = 'connect_test@nylatest.onmicrosoft.com';
+  const CLIENT_ID = 'abc';
+  const authorizeParams = ((email, provider, settings, reauthAccountId) => {
+  	return {
+	  	name: 'Connect Test',
+	  	emailAddress: email,
+	  	provider: provider,
+	  	settings: settings,
+	  	scopes: scopes,
+	  	reauthAccountId: reauthAccountId,	
+  	}
+  });
+  const authorizeJSON = {
+  	code: 'bOjq4Wt9ZAlCy0CSbVeDGDQ5PquytC',
+  }
+  beforeEach(() => {
+    Nylas.config({
+      clientId: CLIENT_ID,
+      clientSecret: 'xyz',
+    });
+  });
+
+  describe('authorize', () => {
+    test('Should throw an error when the clientId is not passed in to Nylas.config()', done => {
+      // expect.assertions(1);
+      Nylas.config({});
+      Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
+        console.log('RESP: ', resp)
+        // expect(resp).toThrow();
+        done();
+        })
+    });
+
+    test('Should do a POST request to /connect/authorize', done => {
+      expect.assertions(2);
+      Nylas.connect.connection.request = jest.fn(() =>
+        Promise.resolve(authorizeJSON)
+      );
+      Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password }, '1234xyz')).then(resp => {
+        expect(resp).toEqual(authorizeJSON);
+        expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/connect/authorize',
+          body: {
+          	client_id: CLIENT_ID,
+          	name: name,
+          	email_address: exchangeEmail,
+          	provider: 'exchange',
+          	settings: { username: exchangeEmail, password: password },
+          	scopes: scopes,
+          	reauth_account_id: '1234xyz', 
+          }
+        });
+        done();
+        })
+    });
+
+    test('Should be successful if no reauthAccountId param is passed in', done => {
+      expect.assertions(2);
+	  Nylas.connect.connection.request = jest.fn(() =>
+	   Promise.resolve(authorizeJSON)
+	  );
+	  Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
+	   expect(resp).toEqual(authorizeJSON);
+	   expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
+	     method: 'POST',
+	     path: '/connect/authorize',
+	     body: {
+	     	client_id: CLIENT_ID,
+	     	name: name,
+	     	email_address: exchangeEmail,
+	     	provider: 'exchange',
+	     	settings: { username: exchangeEmail, password: password },
+	     	scopes: scopes,
+	     	reauth_account_id: undefined, 
+	     }
+	   });
+	   done();
+	   })
+    });
+
+    // test('Should authorize any provider', done => {
+    //   expect.assertions(2);
+  	 //  Nylas.connect.connection.request = jest.fn(() =>
+  	 //   Promise.resolve(authorizeJSON)
+  	 //  );
+  	 //  Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
+  	 //   expect(resp).toEqual(authorizeJSON);
+  	 //   expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
+  	 //     method: 'POST',
+  	 //     path: '/connect/authorize',
+  	 //     body: {
+  	 //     	client_id: CLIENT_ID,
+  	 //     	name: name,
+  	 //     	email_address: exchangeEmail,
+  	 //     	provider: 'exchange',
+  	 //     	settings: { username: exchangeEmail, password: password },
+  	 //     	scopes: scopes,
+  	 //     	reauth_account_id: undefined, 
+  	 //     }
+  	 //   });
+  	 //   done();
+  	 //   })
+    // });
+  
+  });
+});

--- a/__tests__/connect-spec.js
+++ b/__tests__/connect-spec.js
@@ -4,7 +4,7 @@ describe('Connect', () => {
 
   const name = 'Connect Test';
   const password = 'connecting123';
-  const scopes = 'email, calendar, contacts';
+  const scopes = 'email.modify,email.send,calendar,contacts';
   const exchangeEmail = 'connect_test@outlook.com';
   const gmailEmail = 'connect_test@gmail.com';
   const imapEmail = 'connect_test@yahoo.com';
@@ -12,7 +12,7 @@ describe('Connect', () => {
   const CLIENT_ID = 'abc';
   const authorizeOptions = ((email, provider, settings) => {
   	return {
-	  	name: 'Connect Test',
+	  	name: name,
 	  	email_address: email,
 	  	provider: provider,
 	  	settings: settings,
@@ -64,7 +64,7 @@ describe('Connect', () => {
           }
         });
         done();
-        })
+      })
     });
   });
 });

--- a/__tests__/connect-spec.js
+++ b/__tests__/connect-spec.js
@@ -10,43 +10,46 @@ describe('Connect', () => {
   const imapEmail = 'connect_test@yahoo.com';
   const o365Email = 'connect_test@nylatest.onmicrosoft.com';
   const CLIENT_ID = 'abc';
-  const authorizeParams = ((email, provider, settings, reauthAccountId) => {
+  const authorizeOptions = ((email, provider, settings) => {
   	return {
 	  	name: 'Connect Test',
-	  	emailAddress: email,
+	  	email_address: email,
 	  	provider: provider,
 	  	settings: settings,
 	  	scopes: scopes,
-	  	reauthAccountId: reauthAccountId,	
   	}
   });
   const authorizeJSON = {
   	code: 'bOjq4Wt9ZAlCy0CSbVeDGDQ5PquytC',
   }
-  beforeEach(() => {
-    Nylas.config({
-      clientId: CLIENT_ID,
-      clientSecret: 'xyz',
+
+  describe('authorize without clientId', () => {
+  	beforeEach(() => {
+  	  Nylas.config({});  		
+  	});
+
+    test('Should throw an error when the clientId is not passed in to Nylas.config()', () => {
+      expect.assertions(1);
+      expect(() => {
+	      Nylas.connect.authorize(authorizeOptions(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => done())
+      }).toThrow()
     });
   });
 
-  describe('authorize', () => {
-    test('Should throw an error when the clientId is not passed in to Nylas.config()', done => {
-      // expect.assertions(1);
-      Nylas.config({});
-      Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
-        console.log('RESP: ', resp)
-        // expect(resp).toThrow();
-        done();
-        })
-    });
+  describe('authorize with clientId', () => {
+  	beforeEach(() => {
+  	  Nylas.config({
+  	    clientId: CLIENT_ID,
+  	    clientSecret: 'xyz',
+  	  });  		
+  	});
 
     test('Should do a POST request to /connect/authorize', done => {
       expect.assertions(2);
       Nylas.connect.connection.request = jest.fn(() =>
         Promise.resolve(authorizeJSON)
       );
-      Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password }, '1234xyz')).then(resp => {
+      Nylas.connect.authorize(authorizeOptions(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
         expect(resp).toEqual(authorizeJSON);
         expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
           method: 'POST',
@@ -58,60 +61,10 @@ describe('Connect', () => {
           	provider: 'exchange',
           	settings: { username: exchangeEmail, password: password },
           	scopes: scopes,
-          	reauth_account_id: '1234xyz', 
           }
         });
         done();
         })
     });
-
-    test('Should be successful if no reauthAccountId param is passed in', done => {
-      expect.assertions(2);
-	  Nylas.connect.connection.request = jest.fn(() =>
-	   Promise.resolve(authorizeJSON)
-	  );
-	  Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
-	   expect(resp).toEqual(authorizeJSON);
-	   expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
-	     method: 'POST',
-	     path: '/connect/authorize',
-	     body: {
-	     	client_id: CLIENT_ID,
-	     	name: name,
-	     	email_address: exchangeEmail,
-	     	provider: 'exchange',
-	     	settings: { username: exchangeEmail, password: password },
-	     	scopes: scopes,
-	     	reauth_account_id: undefined, 
-	     }
-	   });
-	   done();
-	   })
-    });
-
-    // test('Should authorize any provider', done => {
-    //   expect.assertions(2);
-  	 //  Nylas.connect.connection.request = jest.fn(() =>
-  	 //   Promise.resolve(authorizeJSON)
-  	 //  );
-  	 //  Nylas.connect.authorize(authorizeParams(exchangeEmail, 'exchange', { username: exchangeEmail, password: password })).then(resp => {
-  	 //   expect(resp).toEqual(authorizeJSON);
-  	 //   expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
-  	 //     method: 'POST',
-  	 //     path: '/connect/authorize',
-  	 //     body: {
-  	 //     	client_id: CLIENT_ID,
-  	 //     	name: name,
-  	 //     	email_address: exchangeEmail,
-  	 //     	provider: 'exchange',
-  	 //     	settings: { username: exchangeEmail, password: password },
-  	 //     	scopes: scopes,
-  	 //     	reauth_account_id: undefined, 
-  	 //     }
-  	 //   });
-  	 //   done();
-  	 //   })
-    // });
-  
   });
 });

--- a/src/models/connect.js
+++ b/src/models/connect.js
@@ -1,7 +1,7 @@
 export default class Connect {
   constructor(connection, clientId) {
     this.connection = connection;
-    this.clientId = clientId; 
+    this.clientId = clientId;
   }
 
   authorize(options = {}) {
@@ -11,12 +11,11 @@ export default class Connect {
         'connect.authorize() cannot be called until you provide a clientId via Nylas.config()'
       );
     }
-    
     return this.connection
       .request({
         method: 'POST',
         path: '/connect/authorize',
-        body: { 
+        body: {
           client_id: this.clientId,
           name: options.name,
           email_address: options.email_address,

--- a/src/models/connect.js
+++ b/src/models/connect.js
@@ -1,13 +1,33 @@
 export default class Connect {
-  constructor(connection) {
+  constructor(connection, clientId) {
     this.connection = connection;
-    if (!(this.connection instanceof require('../nylas-connection'))) {
+    if (!(this.connection instanceof require('../nylas-connection'))) { // will this ever be hit? i don't think we need this
       throw new Error('Connection object not provided');
     }
+    this.clientId = clientId; 
   }
 
-  authorize() {
+  authorize(params = {}) {
     // https://docs.nylas.com/reference#connectauthorize
+    if (!this.clientId) {
+      throw new Error('connect.authorize() cannot be called until you provide a clientId via Nylas.config()');
+    }
+    
+    return this.connection
+      .request({
+        method: 'POST',
+        path: '/connect/authorize',
+        body: { 
+          client_id: this.clientId,
+          name: params.name,
+          email_address: params.emailAddress,
+          provider: params.provider,
+          settings: params.settings,
+          scopes: params.scopes,
+          reauth_account_id: params.reauthAccountId, // optional existing account ID to re-auth
+        },
+      })
+      .catch(err => Promise.reject(err));
   }
 
   token() {

--- a/src/models/connect.js
+++ b/src/models/connect.js
@@ -1,16 +1,15 @@
 export default class Connect {
   constructor(connection, clientId) {
     this.connection = connection;
-    if (!(this.connection instanceof require('../nylas-connection'))) { // will this ever be hit? i don't think we need this
-      throw new Error('Connection object not provided');
-    }
     this.clientId = clientId; 
   }
 
-  authorize(params = {}) {
+  authorize(options = {}) {
     // https://docs.nylas.com/reference#connectauthorize
     if (!this.clientId) {
-      throw new Error('connect.authorize() cannot be called until you provide a clientId via Nylas.config()');
+      throw new Error(
+        'connect.authorize() cannot be called until you provide a clientId via Nylas.config()'
+      );
     }
     
     return this.connection
@@ -19,15 +18,15 @@ export default class Connect {
         path: '/connect/authorize',
         body: { 
           client_id: this.clientId,
-          name: params.name,
-          email_address: params.emailAddress,
-          provider: params.provider,
-          settings: params.settings,
-          scopes: params.scopes,
-          reauth_account_id: params.reauthAccountId, // optional existing account ID to re-auth
+          name: options.name,
+          email_address: options.email_address,
+          provider: options.provider,
+          settings: options.settings,
+          scopes: options.scopes,
         },
       })
-      .catch(err => Promise.reject(err));
+      .then(resp => resp)
+      .catch(err => Promise.resolve(err));
   }
 
   token() {

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -147,7 +147,7 @@ module.exports = class NylasConnection {
 
         if (error || response.statusCode > 299) {
           if (!error) {
-            error = new Error(JSON.stringify(body)); 
+            error = new Error(JSON.stringify(body));
           }
           if (body.server_error) {
             error.message = `${error.message} (Server Error: 

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -147,7 +147,7 @@ module.exports = class NylasConnection {
 
         if (error || response.statusCode > 299) {
           if (!error) {
-            error = new Error(body.message);
+            error = new Error(JSON.stringify(body)); 
           }
           if (body.server_error) {
             error.message = `${error.message} (Server Error: 

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -147,7 +147,10 @@ module.exports = class NylasConnection {
 
         if (error || response.statusCode > 299) {
           if (!error) {
-            error = new Error(JSON.stringify(body));
+            error = new Error(body.message);
+          }
+          if (body.missing_fields) {
+            error.message = `${body.message}: ${body.missing_fields}`;
           }
           if (body.server_error) {
             error.message = `${error.message} (Server Error: 

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -67,7 +67,7 @@ class Nylas {
     const conn = new NylasConnection(this.clientSecret, {
       clientId: this.clientId,
     });
-    this.connect = new Connect(conn);
+    this.connect = new Connect(conn, this.clientId);
     this.webhooks = new ManagementModelCollection(Webhook, conn, this.clientId);
     if (this.clientCredentials()) {
       this.accounts = new ManagementModelCollection(


### PR DESCRIPTION
I initially was going to have a test that tested compatibility with every provider, which is why there are so many email credential variables. But then didn't really see the benefit of it - what are your thoughts?

Also, while implementing this, I didn't see the point of the if statement you put in the Connect class constructor. Since the connection is instantiated in `nylas.js` from NylasConnection, won't the connection always be an instance of NylasConnection? 