### PR TITLE
Update DeprecationWarning format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+* Update formatting for DeprecationWarnings
+
 ### 4.7.0 / 2019-08-20
 
 * Update app id and app secret to client id and client secret

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -37,7 +37,8 @@ class Nylas {
       process.emitWarning(
         '"appId" will be deprecated in version 5.0.0. Use "clientId" instead.',
         {
-          code: 'DeprecationWarning',
+          code: 'Nylas',
+          type: 'DeprecationWarning',
         }
       );
     }
@@ -45,9 +46,10 @@ class Nylas {
     if (appSecret) {
       this.clientSecret = appSecret;
       process.emitWarning(
-        '"appSecret" will be deprecated in version 5.0.0. Use "clientId" instead.',
+        '"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.',
         {
-          code: 'DeprecationWarning',
+          code: 'Nylas',
+          type: 'DeprecationWarning',
         }
       );
     }
@@ -84,7 +86,8 @@ class Nylas {
     process.emitWarning(
       '"appId" will be deprecated in version 5.0.0. Use "clientId" instead.',
       {
-        code: 'DeprecationWarning',
+        code: 'Nylas',
+        type: 'DeprecationWarning',
       }
     );
     return this.clientId;
@@ -95,7 +98,8 @@ class Nylas {
     process.emitWarning(
       '"appId" will be deprecated in version 5.0.0. Use "clientId" instead.',
       {
-        code: 'DeprecationWarning',
+        code: 'Nylas',
+        type: 'DeprecationWarning',
       }
     );
   }
@@ -104,7 +108,8 @@ class Nylas {
     process.emitWarning(
       '"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.',
       {
-        code: 'DeprecationWarning',
+        code: 'Nylas',
+        type: 'DeprecationWarning',
       }
     );
     return this.clientSecret;
@@ -115,7 +120,8 @@ class Nylas {
     process.emitWarning(
       '"appSecret" will be deprecated in version 5.0.0. Use "clientSecret" instead.',
       {
-        code: 'DeprecationWarning',
+        code: 'Nylas',
+        type: 'DeprecationWarning',
       }
     );
   }


### PR DESCRIPTION
Old: `(node:47191) [DeprecationWarning] Warning: "appId" will be deprecated in version 5.0.0. Use "clientId" instead.`

New: `(node:49330) [Nylas] DeprecationWarning: "appId" will be deprecated in version 5.0.0. Use "clientId" instead.`