### PR TITLE
makes webhook parsing middleware fully async, adds error handling

### DIFF
--- a/example/webhooks/index.js
+++ b/example/webhooks/index.js
@@ -15,13 +15,21 @@ const bodyParser = require('body-parser');
 // signature
 app.use(function(req, res, next) {
   req.rawBody = '';
-  req.on('data', function(chunk) {
-    req.rawBody += chunk;
+  req.on('data', (chunk) => (req.rawBody += chunk));
+  req.on('error', (err) => res.status(500).send('Error parsing body'));
+
+  req.on('end', () => {
+    // because the stream has been consumed, other parsers like bodyParser.json 
+    // cannot stream the request data and will time out so we must explicitly parse the body
+    try {
+      req.body = JSON.parse(req.rawBody);
+      next();
+    } catch (err) {
+      res.status(500).send('Error parsing body');
+    }
   });
-  next();
 });
-app.use(bodyParser.json({ limit: '50000mb' })); // support json encoded bodies
-app.use(bodyParser.urlencoded({ limit: '50000mb', extended: true })); // support encoded bodies
+app.use(bodyParser.urlencoded({ limit: '5mb', extended: true })); // support encoded bodies
 
 app.get('/webhook', function(req, res) {
   // Nylas will check to make sure your webhook is valid by making a GET


### PR DESCRIPTION
Hi all! I recently tried implementing this example and ran into a couple of issues, so thought I would submit a PR with what worked for me :)

The main issue I ran into is that the rawBody parsing middleware processes asynchronous streaming data, but calls `next` immediately. This leads to a race condition where the rawBody may not be fully parsed before the webhook consumer logic is called. I added an event handler for `end` to call the `next` callback so that the function is fully asynchronous and rawBody will be complete before moving on to the next middleware. I also added some error handling for good measure, though this wasn't strictly needed.

A second issue, once I had that resolved, is that the `bodyParser.json` parsing library relies on streaming the same request that we processed in the rawBody middleware. I'm not very familiar with streams, but I saw this method hang and time out. I believe because the stream is consumed by the rawBody middleware and the stream has been closed by the time `bodyParser.json` takes over. I added a `JSON.parse` to the rawBody middleware to add a parsed `body` property to the request since we can't rely `bodyParser.json`. 

I also sets body parser limits to a more reasonable threshold just for kicks :)

Let me know if you need anything else to get this PR in shape. Thanks for all your hard work!