### PR TITLE
support time, date, start_date, and end_date for creating and updating events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### UNRELEASED
 
 * Add support for `/connect/token` endpoint
+* Fix events so that is supports all time subojects
 
 ### 4.7.1 / 2019-09-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### UNRELEASED
 
 * Add support for `/connect/token` endpoint
-* Fix events so that is supports all time subojects
+* Fix events so that they support all time subojects
 
 ### 4.7.1 / 2019-09-18
 

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -94,6 +94,7 @@ describe('Event', () => {
     });
 
     test('should create event with time when start and end are the same UNIX timestamp', done => {
+      testContext.event.when = {};
       testContext.event.start = 1408875644;
       testContext.event.end = 1408875644;
       testContext.event.save().then(() => {
@@ -125,6 +126,7 @@ describe('Event', () => {
     });
 
     test('should create event with start_time and end_time when start and end are different UNIX timestamps', done => {
+      testContext.event.when = {};
       testContext.event.start = 1409594400
       testContext.event.end = 1409598000
       testContext.event.save().then(() => {
@@ -157,6 +159,7 @@ describe('Event', () => {
     });
 
     test('should create event with date when start and end are same ISO date', done => {
+      testContext.event.when = {};
       testContext.event.start = '1912-06-23';
       testContext.event.end = '1912-06-23';
       testContext.event.save().then(() => {
@@ -188,8 +191,131 @@ describe('Event', () => {
     });
 
     test('should create event with start_date and end_date when start and end are different ISO date', done => {
+      testContext.event.when = {};
       testContext.event.start = '1815-12-10';
       testContext.event.end = '1852-11-27';
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              start_date: '1815-12-10',
+              end_date: '1852-11-27',
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with time event param `when` is updated with time', done => {
+      testContext.event.when = { time: 1408875644 };
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              time: 1408875644,
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with start_time and end_time when event param `when` is updated with start_time and end_time', done => {
+      testContext.event.when = { start_time: 1409594400, end_time: 1409598000 };
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              start_time: 1409594400,
+              end_time: 1409598000,
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with date when the event param `when` is updated with date', done => {
+      testContext.event.when = { date: '1912-06-23' };
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              date: '1912-06-23',
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with start_date and end_date when the event param `when` is updated with start_date and end_date', done => {
+      testContext.event.when = { start_date: '1815-12-10', end_date: '1852-11-27' };
       testContext.event.save().then(() => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'POST',
@@ -240,9 +366,6 @@ describe('Event', () => {
         testContext.event.save().then(event => {
           expect(event.id).toBe('id-1234');
           expect(event.title).toBe('test event');
-          expect(event.start).toBe(1409594400);
-          expect(event.end).toBe(1409594400);
-          console.log('event.when: ', Object.getPrototypeOf(event.when))
           expect(event.when.time).toEqual(1409594400);
           let participant = event.participants[0];
           expect(participant.toJSON()).toEqual(

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -93,13 +93,141 @@ describe('Event', () => {
       });
     });
 
+    test('should create event with time when start and end are the same UNIX timestamp', done => {
+      testContext.event.start = 1408875644;
+      testContext.event.end = 1408875644;
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              time: 1408875644,
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with start_time and end_time when start and end are different UNIX timestamps', done => {
+      testContext.event.start = 1409594400
+      testContext.event.end = 1409598000
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              start_time: 1409594400,
+              end_time: 1409598000,
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with date when start and end are same ISO date', done => {
+      testContext.event.start = '1912-06-23';
+      testContext.event.end = '1912-06-23';
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              date: '1912-06-23',
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create event with start_date and end_date when start and end are different ISO date', done => {
+      testContext.event.start = '1815-12-10';
+      testContext.event.end = '1852-11-27';
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            message_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            owner: undefined,
+            location: undefined,
+            when: {
+              start_date: '1815-12-10',
+              end_date: '1852-11-27',
+            },
+            participants: [],
+            read_only: undefined,
+            status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
     describe('when the request succeeds', () => {
       beforeEach(() => {
         testContext.connection.request = jest.fn(() => {
           const eventJSON = {
             id: 'id-1234',
             title: 'test event',
-            when: {},
+            start: 1409594400,
+            end: 1409594400,
+            when: { time: 1409594400 },
             participants: [
               {'name': 'foo', 'email': 'bar', 'status': 'noreply'}
             ],
@@ -112,6 +240,10 @@ describe('Event', () => {
         testContext.event.save().then(event => {
           expect(event.id).toBe('id-1234');
           expect(event.title).toBe('test event');
+          expect(event.start).toBe(1409594400);
+          expect(event.end).toBe(1409594400);
+          console.log('event.when: ', Object.getPrototypeOf(event.when))
+          expect(event.when.time).toEqual(1409594400);
           let participant = event.participants[0];
           expect(participant.toJSON()).toEqual(
             {'name': 'foo', 'email': 'bar', 'status': 'noreply'});

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -223,9 +223,9 @@ describe('Event', () => {
       });
     });
 
-    test('should create event with time event param `when` is updated with time', done => {
+    test('should create event with time when event param `when` is updated with time', done => {
       testContext.event.when = { time: 1408875644 };
-      testContext.event.save().then(() => {
+      testContext.event.save().then(event => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           body: {
@@ -249,13 +249,15 @@ describe('Event', () => {
           qs: {},
           path: '/events',
         });
+        expect(event.start).toBe(1408875644);
+        expect(event.end).toBe(1408875644);
         done();
       });
     });
 
     test('should create event with start_time and end_time when event param `when` is updated with start_time and end_time', done => {
       testContext.event.when = { start_time: 1409594400, end_time: 1409598000 };
-      testContext.event.save().then(() => {
+      testContext.event.save().then(event => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           body: {
@@ -280,13 +282,15 @@ describe('Event', () => {
           qs: {},
           path: '/events',
         });
+        expect(event.start).toBe(1409594400);
+        expect(event.end).toBe(1409598000);
         done();
       });
     });
 
     test('should create event with date when the event param `when` is updated with date', done => {
       testContext.event.when = { date: '1912-06-23' };
-      testContext.event.save().then(() => {
+      testContext.event.save().then(event => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           body: {
@@ -310,13 +314,15 @@ describe('Event', () => {
           qs: {},
           path: '/events',
         });
+        expect(event.start).toBe('1912-06-23');
+        expect(event.end).toBe('1912-06-23');
         done();
       });
     });
 
     test('should create event with start_date and end_date when the event param `when` is updated with start_date and end_date', done => {
       testContext.event.when = { start_date: '1815-12-10', end_date: '1852-11-27' };
-      testContext.event.save().then(() => {
+      testContext.event.save().then(event => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           body: {
@@ -341,6 +347,8 @@ describe('Event', () => {
           qs: {},
           path: '/events',
         });
+        expect(event.start).toBe('1815-12-10');
+        expect(event.end).toBe('1852-11-27');
         done();
       });
     });

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -351,8 +351,6 @@ describe('Event', () => {
           const eventJSON = {
             id: 'id-1234',
             title: 'test event',
-            start: 1409594400,
-            end: 1409594400,
             when: { time: 1409594400 },
             participants: [
               {'name': 'foo', 'email': 'bar', 'status': 'noreply'}

--- a/src/models/attributes.js
+++ b/src/models/attributes.js
@@ -137,6 +137,21 @@ class AttributeCollection extends Attribute {
   }
 }
 
+class AttributeNumberOrString extends Attribute {
+  toJSON(val) {
+    return val;
+  }
+  fromJSON(val, parent) {
+    if (isNaN(Number(val))) {
+      return val || '';
+    } else if (!isNaN(val)) {
+      return Number(val);
+    } else {
+      return null;
+    }
+  }
+}
+
 module.exports = {
   Number() {
     return new AttributeNumber(...arguments);
@@ -162,6 +177,9 @@ module.exports = {
   Object() {
     return new Attribute(...arguments);
   },
+  NumberOrString() {
+    return new AttributeNumberOrString(...arguments);
+  },
 
   AttributeNumber,
   AttributeString,
@@ -170,4 +188,5 @@ module.exports = {
   AttributeCollection,
   AttributeBoolean,
   AttributeDate,
+  AttributeNumberOrString,
 };

--- a/src/models/attributes.js
+++ b/src/models/attributes.js
@@ -137,21 +137,6 @@ class AttributeCollection extends Attribute {
   }
 }
 
-class AttributeNumberOrString extends Attribute {
-  toJSON(val) {
-    return val;
-  }
-  fromJSON(val, parent) {
-    if (isNaN(Number(val))) {
-      return val || '';
-    } else if (!isNaN(val)) {
-      return Number(val);
-    } else {
-      return null;
-    }
-  }
-}
-
 module.exports = {
   Number() {
     return new AttributeNumber(...arguments);
@@ -177,9 +162,6 @@ module.exports = {
   Object() {
     return new Attribute(...arguments);
   },
-  NumberOrString() {
-    return new AttributeNumberOrString(...arguments);
-  },
 
   AttributeNumber,
   AttributeString,
@@ -188,5 +170,4 @@ module.exports = {
   AttributeCollection,
   AttributeBoolean,
   AttributeDate,
-  AttributeNumberOrString,
 };

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -4,17 +4,21 @@ import EventParticipant from './event-participant';
 
 export default class Event extends RestfulModel {
   get start() {
-    return this.when.start_time || // eslint-disable-line
+    const start =
+      this.when.start_time ||
       this.when.start_date ||
       this.when.time ||
-      this.when.date; // eslint-disable-line
+      this.when.date;
+    return start;
   }
 
   get end() {
-    return this.when.end_time || // eslint-disable-line
+    const end =
+      this.when.end_time ||
       this.when.end_date ||
       this.when.time ||
-      this.when.date; // eslint-disable-line
+      this.when.date;
+    return end;
   }
 
   set start(val) {

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -3,60 +3,63 @@ import Attributes from './attributes';
 import EventParticipant from './event-participant';
 
 export default class Event extends RestfulModel {
-  static set when(when) {
-    this.start =
-      when.start_time ||
-      when.start_date ||
-      when.time ||
-      when.date;
-    this.end =
-      when.end_time ||
-      when.end_date ||
-      when.time ||
-      when.date;
+  
+  get start() {
+    return 
+      this.when.start_time ||
+      this.when.start_date ||
+      this.when.time ||
+      this.when.date;
   }
 
-  static set start(val) {
-    console.log('typeof val: ', typeof val)
-    if (typeof val === 'number') {
-      if (val === this.end) {
-        this.when = {
-          time: val,
-        }
-      } else {
-        this.when.start_time = val;
-      }
-    }  
-    if (typeof val === 'string') {
-      if (val === this.end) {
-        this.when = {
-          date: val,
-        }
-      } else {
-        this.when.start_date = val;
-      }
-    }
+  get end() {
+    return
+      this.when.end_time ||
+      this.when.end_date ||
+      this.when.time ||
+      this.when.date;
   }
 
-  static set end(val) {
-    if (typeof val === 'number') {
-      if (this.start === val) {
-        this.when = {
-          time: val,
-        }
-      } else {
-        this.when.end_time = val;
+  set start(val) {
+    if (this.when) {
+      if (typeof val === 'number') {
+        if (val === this.when.end_time) {
+          this.when = { time: val }
+        } else {
+          delete this.when.time;
+          this.when.start_time = val;        
+        }   
       }
-    }  
-    if (typeof val === 'string') {
-      if (this.start === val) {
-        this.when = {
-          date: val,
-        }
-      } else {
-        this.when.end_date = val;
+      if (typeof val === 'string') {
+        if (val === this.when.end_date) {
+          this.when = { date: val }
+        } else {
+          delete this.when.date;
+          this.when.start_date = val;
+        } 
       }
-    }
+    } 
+  }
+
+  set end(val) {
+    if (this.when) {
+      if (typeof val === 'number') {
+        if (val === this.when.start_time) {
+          this.when = { time: val }
+        } else {
+          delete this.when.time;
+          this.when.end_time = val;        
+        }   
+      }
+      if (typeof val === 'string') {
+        if (val === this.when.start_date) {
+          this.when = { date: val }
+        } else {
+          delete this.when.date;
+          this.when.end_date = val;
+        } 
+      }
+    } 
   }
 
   saveRequestBody() {
@@ -82,16 +85,6 @@ export default class Event extends RestfulModel {
     super.fromJSON(json);
 
     if (this.when) {
-      this.start =
-        this.when.start_time ||
-        this.when.start_date ||
-        this.when.time ||
-        this.when.date;
-      this.end =
-        this.when.end_time ||
-        this.when.end_date ||
-        this.when.time ||
-        this.when.date;
       delete this.when.object;
     }
     return this;
@@ -152,14 +145,6 @@ Event.attributes = {
   }),
   when: Attributes.Object({
     modelKey: 'when',
-  }),
-  start: Attributes.NumberOrString({
-    modelKey: 'start',
-    jsonKey: '_start',
-  }),
-  end: Attributes.NumberOrString({
-    modelKey: 'end',
-    jsonKey: '_end',
   }),
   busy: Attributes.Boolean({
     modelKey: 'busy',

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -4,19 +4,17 @@ import EventParticipant from './event-participant';
 
 export default class Event extends RestfulModel {
   get start() {
-    return
-      this.when.start_time ||
+    return this.when.start_time || // eslint-disable-line
       this.when.start_date ||
       this.when.time ||
-      this.when.date;
+      this.when.date; // eslint-disable-line
   }
 
   get end() {
-    return
-      this.when.end_time ||
+    return this.when.end_time || // eslint-disable-line
       this.when.end_date ||
       this.when.time ||
-      this.when.date;
+      this.when.date; // eslint-disable-line
   }
 
   set start(val) {

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -3,16 +3,17 @@ import Attributes from './attributes';
 import EventParticipant from './event-participant';
 
 export default class Event extends RestfulModel {
-
   get start() {
-    return this.when.start_time ||
+    return
+      this.when.start_time ||
       this.when.start_date ||
       this.when.time ||
       this.when.date;
   }
 
   get end() {
-    return this.when.end_time ||
+    return
+      this.when.end_time ||
       this.when.end_date ||
       this.when.time ||
       this.when.date;

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -3,18 +3,16 @@ import Attributes from './attributes';
 import EventParticipant from './event-participant';
 
 export default class Event extends RestfulModel {
-  
+
   get start() {
-    return 
-      this.when.start_time ||
+    return this.when.start_time ||
       this.when.start_date ||
       this.when.time ||
       this.when.date;
   }
 
   get end() {
-    return
-      this.when.end_time ||
+    return this.when.end_time ||
       this.when.end_date ||
       this.when.time ||
       this.when.date;
@@ -24,49 +22,50 @@ export default class Event extends RestfulModel {
     if (this.when) {
       if (typeof val === 'number') {
         if (val === this.when.end_time) {
-          this.when = { time: val }
+          this.when = { time: val };
         } else {
           delete this.when.time;
-          this.when.start_time = val;        
-        }   
+          delete this.when.start_date;
+          delete this.when.date;
+          this.when.start_time = val;
+        }
       }
       if (typeof val === 'string') {
         if (val === this.when.end_date) {
-          this.when = { date: val }
+          this.when = { date: val };
         } else {
           delete this.when.date;
+          delete this.when.start_time;
+          delete this.when.time;
           this.when.start_date = val;
-        } 
+        }
       }
-    } 
+    }
   }
 
   set end(val) {
     if (this.when) {
       if (typeof val === 'number') {
         if (val === this.when.start_time) {
-          this.when = { time: val }
+          this.when = { time: val };
         } else {
           delete this.when.time;
-          this.when.end_time = val;        
-        }   
+          delete this.when.end_date;
+          delete this.when.date;
+          this.when.end_time = val;
+        }
       }
       if (typeof val === 'string') {
         if (val === this.when.start_date) {
-          this.when = { date: val }
+          this.when = { date: val };
         } else {
           delete this.when.date;
+          delete this.when.time;
+          delete this.when.end_time;
           this.when.end_date = val;
-        } 
+        }
       }
-    } 
-  }
-
-  saveRequestBody() {
-    const dct = this.toJSON();
-    delete dct['_start'];
-    delete dct['_end'];
-    return dct;
+    }
   }
 
   deleteRequestQueryString(params) {


### PR DESCRIPTION
This is to address issue #146 

I'm unsure how we should deal with the Event attributes b/c it seems as though only one attribute type can be associated to a param. Also, I don't think we can support updating and creating events using the `when` param as well as the `start` and `end` params b/c then we wouldn't know which param to use to create/update the event. Open to suggestions or ideas that I might've overlooked though!