### PR TITLE
update tests with client id and client secret naming

### DIFF
--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -1,12 +1,12 @@
 import Nylas from '../src/nylas';
 
 describe('ManagementAccount', () => {
-  const APP_ID = 'abc';
+  const CLIENT_ID = 'abc';
   const ACCOUNT_ID = '8rilmlwuo4zmpjedz8bcplclk';
   beforeEach(() => {
     Nylas.config({
-      appId: APP_ID,
-      appSecret: 'xyz',
+      clientId: CLIENT_ID,
+      clientSecret: 'xyz',
     });
   });
 
@@ -36,7 +36,7 @@ describe('ManagementAccount', () => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 100, offset: 0 },
-            path: `/a/${APP_ID}/accounts`,
+            path: `/a/${CLIENT_ID}/accounts`,
           });
           done();
         })
@@ -71,11 +71,11 @@ describe('ManagementAccount', () => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
-            path: `/a/${APP_ID}/accounts`,
+            path: `/a/${CLIENT_ID}/accounts`,
           });
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
-            path: `/a/${APP_ID}/accounts/${ACCOUNT_ID}/upgrade`,
+            path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/upgrade`,
           });
           expect(resp.success).toBe('true');
           done();
@@ -111,11 +111,11 @@ describe('ManagementAccount', () => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
-            path: `/a/${APP_ID}/accounts`,
+            path: `/a/${CLIENT_ID}/accounts`,
           });
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
-            path: `/a/${APP_ID}/accounts/${ACCOUNT_ID}/downgrade`,
+            path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/downgrade`,
           });
           expect(resp.success).toBe('true');
           done();
@@ -151,11 +151,11 @@ describe('ManagementAccount', () => {
             expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
               method: 'GET',
               qs: { limit: 1, offset: 0 },
-              path: `/a/${APP_ID}/accounts`,
+              path: `/a/${CLIENT_ID}/accounts`,
             });
             expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
               method: 'POST',
-              path: `/a/${APP_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
+              path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
               body: { keep_access_token: undefined },
             });
             expect(resp.success).toBe('true');
@@ -190,11 +190,11 @@ describe('ManagementAccount', () => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
-            path: `/a/${APP_ID}/accounts`,
+            path: `/a/${CLIENT_ID}/accounts`,
           });
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
-            path: `/a/${APP_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
+            path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
             body: { keep_access_token: 'abc123' },
           });
           expect(resp.success).toBe('true');
@@ -241,7 +241,7 @@ describe('ManagementAccount', () => {
         .then( resp => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
-            path: `/a/${APP_ID}/ip_addresses`,
+            path: `/a/${CLIENT_ID}/ip_addresses`,
           });
           expect(resp.updated_at).toBe(1544658529);
           done();
@@ -282,11 +282,11 @@ describe('ManagementAccount', () => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
-            path: `/a/${APP_ID}/accounts`,
+            path: `/a/${CLIENT_ID}/accounts`,
           });
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
-            path: `/a/${APP_ID}/accounts/${ACCOUNT_ID}/token-info`,
+            path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/token-info`,
             body: { access_token: 'abc123' }, 
           });
           expect(resp.created_at).toBe(1563496685);
@@ -324,11 +324,11 @@ describe('ManagementAccount', () => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
-            path: `/a/${APP_ID}/accounts`,
+            path: `/a/${CLIENT_ID}/accounts`,
           });
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
-            path: `/a/${APP_ID}/accounts/${ACCOUNT_ID}/token-info`,
+            path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/token-info`,
             body: { access_token: undefined },
           });
           expect(resp).toBe('Error: No access_token passed.');

--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -5,41 +5,41 @@ import NylasConnection from '../src/nylas-connection';
 
 describe('Nylas', () => {
   beforeEach(() => {
-    Nylas.appId = undefined;
-    Nylas.appSecret = undefined;
+    Nylas.clientId = undefined;
+    Nylas.clientSecret = undefined;
     Nylas.apiServer = 'https://api.nylas.com';
   });
 
   describe('config', () => {
-    test('should allow you to populate the appId, appSecret, apiServer and authServer options', () => {
+    test('should allow you to populate the clientId, clientSecret, apiServer and authServer options', () => {
       const newConfig = {
-        appId: 'newId',
-        appSecret: 'newSecret',
+        clientId: 'newId',
+        clientSecret: 'newSecret',
         apiServer: 'https://api-staging.nylas.com/',
       };
 
       Nylas.config(newConfig);
-      expect(Nylas.appId).toBe(newConfig.appId);
-      expect(Nylas.appSecret).toBe(newConfig.appSecret);
+      expect(Nylas.clientId).toBe(newConfig.clientId);
+      expect(Nylas.clientSecret).toBe(newConfig.clientSecret);
       expect(Nylas.apiServer).toBe(newConfig.apiServer);
     });
 
     test('should not override existing values unless new values are provided', () => {
       const newConfig = {
-        appId: 'newId',
-        appSecret: 'newSecret',
+        clientId: 'newId',
+        clientSecret: 'newSecret',
       };
 
       Nylas.config(newConfig);
-      expect(Nylas.appId).toBe(newConfig.appId);
-      expect(Nylas.appSecret).toBe(newConfig.appSecret);
+      expect(Nylas.clientId).toBe(newConfig.clientId);
+      expect(Nylas.clientSecret).toBe(newConfig.clientSecret);
       expect(Nylas.apiServer).toBe('https://api.nylas.com');
     });
 
     test('should throw an exception if the server options do not contain ://', () => {
       const newConfig = {
-        appId: 'newId',
-        appSecret: 'newSecret',
+        clientId: 'newId',
+        clientSecret: 'newSecret',
         apiServer: 'dontknowwhatImdoing.nylas.com',
       };
 
@@ -53,8 +53,8 @@ describe('Nylas', () => {
 
     test('should return an NylasConnection for making requests with the access token', () => {
       Nylas.config({
-        appId: 'newId',
-        appSecret: 'newSecret',
+        clientId: 'newId',
+        clientSecret: 'newSecret',
       });
 
       const conn = Nylas.with('test-access-token');
@@ -65,17 +65,17 @@ describe('Nylas', () => {
   describe('exchangeCodeForToken', () => {
     beforeEach(() =>
       Nylas.config({
-        appId: 'newId',
-        appSecret: 'newSecret',
+        clientId: 'newId',
+        clientSecret: 'newSecret',
       })
     );
 
     test('should throw an exception if no code is provided', () =>
       expect(() => Nylas.exchangeCodeForToken()).toThrow());
 
-    test('should throw an exception if the app id and secret have not been configured', () => {
-      Nylas.appId = undefined;
-      Nylas.appSecret = undefined;
+    test('should throw an exception if the client id and secret have not been configured', () => {
+      Nylas.clientId = undefined;
+      Nylas.clientSecret = undefined;
       expect(() => Nylas.exchangeCodeForToken('code-from-server')).toThrow();
     });
 
@@ -154,22 +154,22 @@ describe('Nylas', () => {
   describe('urlForAuthentication', () => {
     beforeEach(() =>
       Nylas.config({
-        appId: 'newId',
-        appSecret: 'newSecret',
+        clientId: 'newId',
+        clientSecret: 'newSecret',
       })
     );
 
     test('should require a redirectURI', () =>
       expect(() => Nylas.urlForAuthentication()).toThrow());
 
-    test('should throw an exception if the app id has not been configured', () => {
-      Nylas.appId = undefined;
+    test('should throw an exception if the client id has not been configured', () => {
+      Nylas.clientId = undefined;
       const options = { redirectURI: 'https://localhost/callback' };
       expect(() => Nylas.urlForAuthentication(options)).toThrow();
     });
 
-    test('should not throw an exception if the app secret has not been configured', () => {
-      Nylas.appSecret = undefined;
+    test('should not throw an exception if the client secret has not been configured', () => {
+      Nylas.clientSecret = undefined;
       const options = { redirectURI: 'https://localhost/callback' };
       expect(Nylas.urlForAuthentication(options)).toEqual(
         'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=&redirect_uri=https://localhost/callback'

--- a/__tests__/restful-model-collection-spec.js
+++ b/__tests__/restful-model-collection-spec.js
@@ -12,8 +12,8 @@ describe('RestfulModelCollection', () => {
 
   beforeEach(() => {
     Nylas.config({
-      appId: '123',
-      appSecret: '123',
+      clientId: '123',
+      clientSecret: '123',
     });
     testContext = {};
     testContext.connection = new NylasConnection('test-access-token', {

--- a/__tests__/webhook-spec.js
+++ b/__tests__/webhook-spec.js
@@ -1,11 +1,11 @@
 import Nylas from '../src/nylas';
 
 describe('Webhook', () => {
-  const APP_ID = 'abc';
+  const CLIENT_ID = 'abc';
   const WEBHOOK_ID = '5rilmlwuo4zmpjedz8bcplclk';
   const webhookJSON = {
     id: WEBHOOK_ID,
-    application_id: APP_ID,
+    application_id: CLIENT_ID,
     callback_url: 'https://wwww.myapp.com/webhook',
     state: 'active',
     triggers: ['message.opened', 'message.link_clicked'],
@@ -13,8 +13,8 @@ describe('Webhook', () => {
   };
   beforeEach(() => {
     Nylas.config({
-      appId: APP_ID,
-      appSecret: 'xyz',
+      clientId: CLIENT_ID,
+      clientSecret: 'xyz',
     });
   });
 
@@ -31,7 +31,7 @@ describe('Webhook', () => {
           expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 100, offset: 0 },
-            path: `/a/${APP_ID}/webhooks`,
+            path: `/a/${CLIENT_ID}/webhooks`,
           });
           done();
         })
@@ -39,7 +39,7 @@ describe('Webhook', () => {
   });
 
   describe('Get an existing webhook', () => {
-    test('Should do a GET request to /a/<app_id>/webhooks/<id>', done => {
+    test('Should do a GET request to /a/<client_id>/webhooks/<id>', done => {
       expect.assertions(2);
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
@@ -48,7 +48,7 @@ describe('Webhook', () => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'GET',
-          path: `/a/${APP_ID}/webhooks/${WEBHOOK_ID}`,
+          path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {}
         });
         done();
@@ -57,13 +57,13 @@ describe('Webhook', () => {
   });
 
   describe('Create a new webhook', () => {
-    test('Should do a POST request to /a/<app_id>/webhooks', done => {
+    test('Should do a POST request to /a/<client_id>/webhooks', done => {
       expect.assertions(2);
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
       );
       const webhook = Nylas.webhooks.build({
-        applicationId: APP_ID,
+        applicationId: CLIENT_ID,
         callbackUrl: 'https://wwww.myapp.com/webhook',
         state: 'active',
         triggers: ['message.opened', 'message.link_clicked'],
@@ -73,7 +73,7 @@ describe('Webhook', () => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'POST',
-          path: `/a/${APP_ID}/webhooks`,
+          path: `/a/${CLIENT_ID}/webhooks`,
           qs: {},
           body: {
             callback_url: 'https://wwww.myapp.com/webhook',
@@ -87,14 +87,14 @@ describe('Webhook', () => {
   });
 
   describe('Update an existing webhook', () => {
-    test('Should do a PUT request to /a/<app_id>/webhooks/<id>', done => {
+    test('Should do a PUT request to /a/<client_id>/webhooks/<id>', done => {
       expect.assertions(2);
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
       );
       const webhook = Nylas.webhooks.build({
         id: WEBHOOK_ID,
-        applicationId: APP_ID,
+        applicationId: CLIENT_ID,
         callbackUrl: 'https://wwww.myapp.com/webhook',
         state: 'active',
         triggers: ['message.opened', 'message.link_clicked'],
@@ -104,7 +104,7 @@ describe('Webhook', () => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'PUT',
-          path: `/a/${APP_ID}/webhooks/${WEBHOOK_ID}`,
+          path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},
           body: {state: 'active'},
         });
@@ -114,14 +114,14 @@ describe('Webhook', () => {
   });
 
   describe('Delete an existing webhook', () => {
-    test('Should do a DELETE request to /a/<app_id>/webhooks/<id>', done => {
+    test('Should do a DELETE request to /a/<client_id>/webhooks/<id>', done => {
       expect.assertions(1);
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(null)
       );
       const webhook = Nylas.webhooks.build({
         id: WEBHOOK_ID,
-        applicationId: APP_ID,
+        applicationId: CLIENT_ID,
         callbackUrl: 'https://wwww.myapp.com/webhook',
         state: 'active',
         triggers: ['message.opened', 'message.link_clicked'],
@@ -130,7 +130,7 @@ describe('Webhook', () => {
       Nylas.webhooks.delete(webhook).then(webhookResp => {
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'DELETE',
-          path: `/a/${APP_ID}/webhooks/${WEBHOOK_ID}`,
+          path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},
           body: {},
         });
@@ -146,7 +146,7 @@ describe('Webhook', () => {
       Nylas.webhooks.delete(WEBHOOK_ID).then(webhookResp => {
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'DELETE',
-          path: `/a/${APP_ID}/webhooks/${WEBHOOK_ID}`,
+          path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},
           body: {},
         });


### PR DESCRIPTION
I was getting tired of seeing the deprecation warnings when running the tests so I figured I'd just get this out 😅 