### PR TITLE
Fix: Throwing on connect error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2626,8 +2626,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2648,14 +2647,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2670,20 +2667,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2800,8 +2794,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2813,7 +2806,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2828,7 +2820,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2836,14 +2827,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2862,7 +2851,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2943,8 +2931,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2956,7 +2943,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3042,8 +3028,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3079,7 +3064,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3099,7 +3083,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3143,14 +3126,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3584,8 +3565,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/src/models/connect.js
+++ b/src/models/connect.js
@@ -24,9 +24,7 @@ export default class Connect {
           settings: options.settings,
           scopes: options.scopes,
         },
-      })
-      .then(resp => resp)
-      .catch(err => Promise.resolve(err));
+      });
   }
 
   token(code) {
@@ -50,9 +48,7 @@ export default class Connect {
           client_secret: this.clientSecret,
           code: code,
         },
-      })
-      .then(resp => resp)
-      .catch(err => Promise.resolve(err));
+      });
   }
 
   newAccount() {

--- a/src/models/connect.js
+++ b/src/models/connect.js
@@ -12,19 +12,18 @@ export default class Connect {
         'connect.authorize() cannot be called until you provide a clientId via Nylas.config()'
       );
     }
-    return this.connection
-      .request({
-        method: 'POST',
-        path: '/connect/authorize',
-        body: {
-          client_id: this.clientId,
-          name: options.name,
-          email_address: options.email_address,
-          provider: options.provider,
-          settings: options.settings,
-          scopes: options.scopes,
-        },
-      });
+    return this.connection.request({
+      method: 'POST',
+      path: '/connect/authorize',
+      body: {
+        client_id: this.clientId,
+        name: options.name,
+        email_address: options.email_address,
+        provider: options.provider,
+        settings: options.settings,
+        scopes: options.scopes,
+      },
+    });
   }
 
   token(code) {
@@ -39,16 +38,15 @@ export default class Connect {
         'connect.token() cannot be called until you provide a clientSecret via Nylas.config()'
       );
     }
-    return this.connection
-      .request({
-        method: 'POST',
-        path: '/connect/token',
-        body: {
-          client_id: this.clientId,
-          client_secret: this.clientSecret,
-          code: code,
-        },
-      });
+    return this.connection.request({
+      method: 'POST',
+      path: '/connect/token',
+      body: {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code: code,
+      },
+    });
   }
 
   newAccount() {


### PR DESCRIPTION
# Description

Currently, the `/connect/authorize` and `/connect/token` don't really throw an error.
The error is resolved, but this is not very practical at all, because we end up having a code like that when using the endpoints in order to catch errors :

```js
return Nylas.connect.authorize(options)
   .then(res => {
     if (res instanceof Error) handleError(res);
     return Nylas.connect.token(res.code);
   })
   .then(res => {
     if (res instanceof Error) handleError(res);
     return res;
   });
```
Where we would normally just do :
```js
return Nylas.connect.authorize(options)
   .then(res => Nylas.connect.token(res.code))
   .catch(e => handleError(e));
```

# Changes

- `Fix` Removed useless then an catch in `/connect/authorize` and `/connect/token`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.