### PR TITLE
Update thread participants to use EmailParticipant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+* Update Thread participants to use EmailParticipant
+
 ### 4.8.0 / 2019-10-09
 
 * Add support for `/connect/token` endpoint

--- a/__tests__/thread-spec.js
+++ b/__tests__/thread-spec.js
@@ -5,6 +5,7 @@ import NylasConnection from '../src/nylas-connection';
 import Thread from '../src/models/thread';
 import Message from '../src/models/message';
 import { Label } from '../src/models/folder';
+import EmailParticipant from '../src/models/email-participant';
 
 describe('Thread', () => {
   let testContext;
@@ -89,6 +90,22 @@ describe('Thread', () => {
       expect(t.messages[1].id).toBe('m2');
       expect(t.drafts[0] instanceof Message).toBe(true);
       expect(t.drafts[0].id).toBe('m3');
+    });
+    test('should populate participants', () => {
+      const participants = [
+        {
+          "email": "anna@yahoo.com",
+          "name": "Anna"
+        }
+      ]
+      const t = testContext.thread.fromJSON({
+        participants: participants,
+      });
+
+      expect(t.participants).toBeDefined();
+      expect(t.participants[0] instanceof EmailParticipant).toBe(true);
+      expect(t.participants[0].email).toBe('anna@yahoo.com');
+      expect(t.participants[0].name).toBe('Anna');
     });
   });
 });

--- a/src/models/thread.js
+++ b/src/models/thread.js
@@ -1,7 +1,7 @@
 import Message from './message';
 import RestfulModel from './restful-model';
-import Contact from './contact';
 import * as Attributes from './attributes';
+import EmailParticipant from './email-participant';
 import { Label, Folder } from './folder';
 
 export default class Thread extends RestfulModel {
@@ -40,7 +40,7 @@ Thread.attributes = {
   }),
   participants: Attributes.Collection({
     modelKey: 'participants',
-    itemClass: Contact,
+    itemClass: EmailParticipant,
   }),
   lastMessageTimestamp: Attributes.DateTime({
     modelKey: 'lastMessageTimestamp',


### PR DESCRIPTION
Updating the Thread model to use EmailParticipant instead of Contact for the participants attribute. This is consistent with the Message model.

Re: https://github.com/nylas/nylas-nodejs/issues/162

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.