### PR TITLE
add knownLength to file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+* Allow file streaming uploads
+
 ### 4.9.0 / 2020-01-24
 
 * Remove error handling in /connect models

--- a/__tests__/file-spec.js
+++ b/__tests__/file-spec.js
@@ -63,6 +63,28 @@ describe('File', () => {
       });
     });
 
+    test('should add knownLength to the request formData', done => {
+      testContext.file.size = 12345;
+      testContext.file.upload().catch(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          json: false,
+          path: '/files',
+          formData: {
+            file: {
+              value: 'Sample data',
+              options: {
+                filename: 'sample.txt',
+                contentType: 'text/plain',
+                knownLength: 12345
+              },
+            },
+          },
+        });
+        done();
+      });
+    });
+
     describe('when the request succeeds', () => {
       beforeEach(() => {
         testContext.connection.request = jest.fn(() => {

--- a/src/models/file.js
+++ b/src/models/file.js
@@ -19,6 +19,15 @@ export default class File extends RestfulModel {
       throw new Error('Please define a content-type');
     }
 
+    const formOptions = {
+      filename: this.filename,
+      contentType: this.contentType,
+    };
+
+    if (this.size) {
+      formOptions.knownLength = this.size;
+    }
+
     return this.connection
       .request({
         method: 'POST',
@@ -27,10 +36,7 @@ export default class File extends RestfulModel {
         formData: {
           file: {
             value: this.data,
-            options: {
-              filename: this.filename,
-              contentType: this.contentType,
-            },
+            options: formOptions,
           },
         },
       })


### PR DESCRIPTION
<!-- Add information about your PR here -->
Adding `knownLength` to the formData allows us to accept streaming uploads from S3.

Re: https://github.com/request/request/issues/2800#issuecomment-427378925
>  form-data (https://github.com/form-data/form-data) automatically detects the size it needs to send when using fs.createReadStream. That does not work for streams from s3, thus you need to supply it yourself

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.