### PR TITLE
update thread.folders to use Folder itemClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add iCalUID attribute to Event model
 * Update SUPPORTED_API_VERSION to 2.1
 * Allow file streaming uploads
+* Update Thread.folder to use Folder model, and rename to Thread.folders
 
 ### 4.9.0 / 2020-01-24
 

--- a/__tests__/thread-spec.js
+++ b/__tests__/thread-spec.js
@@ -4,7 +4,7 @@ import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import Thread from '../src/models/thread';
 import Message from '../src/models/message';
-import { Label } from '../src/models/folder';
+import { Folder, Label } from '../src/models/folder';
 import EmailParticipant from '../src/models/email-participant';
 
 describe('Thread', () => {
@@ -61,7 +61,7 @@ describe('Thread', () => {
   });
 
   describe('fromJSON', () => {
-    test('should populate messages and draft fields when receiving expanded thread', () => {
+    test('should populate messages, draft & folder fields when receiving expanded thread', () => {
       const m1 = {
         id: 'm1',
         object: 'message',
@@ -77,10 +77,16 @@ describe('Thread', () => {
         object: 'draft',
         to: [{ name: 'Bob', email: 'bob@gmail.com' }],
       };
+      const folder = {
+        'display_name': 'Inbox',
+        'id': 'f1',
+        'name': 'inbox'
+      };
 
       const t = testContext.thread.fromJSON({
         messages: [m1, m2],
         drafts: [draft],
+        folders: [folder]
       });
 
       expect(t.messages).toBeDefined();
@@ -90,6 +96,8 @@ describe('Thread', () => {
       expect(t.messages[1].id).toBe('m2');
       expect(t.drafts[0] instanceof Message).toBe(true);
       expect(t.drafts[0].id).toBe('m3');
+      expect(t.folders[0] instanceof Folder).toBe(true);
+      expect(t.folders[0].id).toBe('f1');
     });
     test('should populate participants', () => {
       const participants = [

--- a/src/models/thread.js
+++ b/src/models/thread.js
@@ -31,6 +31,28 @@ export default class Thread extends RestfulModel {
   save(params = {}, callback = null) {
     return this._save(params, callback);
   }
+
+  get folder() {
+    process.emitWarning(
+      '"thread.folder" will be deprecated in version 5.0.0. Use "thread.folders" instead.',
+      {
+        code: 'Nylas',
+        type: 'DeprecationWarning',
+      }
+    );
+    return this.folders;
+  }
+
+  set folder(value) {
+    this.folders = value;
+    process.emitWarning(
+      '"thread.folder" will be deprecated in version 5.0.0. Use "thread.folders" instead.',
+      {
+        code: 'Nylas',
+        type: 'DeprecationWarning',
+      }
+    );
+  }
 }
 Thread.collectionName = 'threads';
 Thread.attributes = {
@@ -74,8 +96,8 @@ Thread.attributes = {
     modelKey: 'version',
     jsonKey: 'version',
   }),
-  folder: Attributes.Object({
-    modelKey: 'folder',
+  folders: Attributes.Collection({
+    modelKey: 'folders',
     itemClass: Folder,
     jsonKey: 'folders',
   }),


### PR DESCRIPTION
<!-- Add information about your PR here -->
Fixing a bug reported here: https://github.com/nylas/nylas-nodejs/pull/130

- Renaming the `thread.folder` attribute to `thread.folders`, consistent with the API response (a list of folders) and the edge case that different messages in a single thread can be in different folders.
- Emitting deprecation warnings when the the old `.folder` attribute is used, but still supporting it.
- Using `attributes.collection` instead of `attributes.object` for the thread folders, as it is an array of folders, not just a single folder object.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.