### PR TITLE
check for undefined response and reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Fix unhandled error when response is undefined.
 * Fix get contact picture request to correctly use callback, if provided.
 
 ### 4.10.0 / 2020-02-24

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -129,6 +129,10 @@ module.exports = class NylasConnection {
 
     return new Promise((resolve, reject) => {
       return request(options, (error, response, body = {}) => {
+        if (typeof response === 'undefined') {
+          error = new Error('Response is undefined');
+          return reject(error);
+        }
         // node headers are lowercase so this refers to `Nylas-Api-Version`
         const apiVersion = response.headers['nylas-api-version'];
 

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -130,7 +130,7 @@ module.exports = class NylasConnection {
     return new Promise((resolve, reject) => {
       return request(options, (error, response, body = {}) => {
         if (typeof response === 'undefined') {
-          error = new Error('Response is undefined');
+          error = error || new Error('No response');
           return reject(error);
         }
         // node headers are lowercase so this refers to `Nylas-Api-Version`


### PR DESCRIPTION
<!-- Add information about your PR here -->
Re: https://github.com/nylas/nylas-nodejs/issues/172 users reporting bug where application crashes due to an undefined response. 

Taking this as a another reason to prioritize moving off of request, re: https://github.com/nylas/nylas-nodejs/issues/174

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.