### PR TITLE
exchangeCodeForToken should reject when no access_token returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Update `exchangeCodeForToken` to reject when no `access_token` is returned.
 * Fix unhandled error when response is undefined.
 * Fix get contact picture request to correctly use callback, if provided.
 

--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -120,6 +120,25 @@ describe('Nylas', () => {
       });
     });
 
+    test('should reject with the api error', done => {
+      const apiError = { message: 'Unable to associate credentials', type: 'api_error' };
+      request.Request = jest.fn(options => options.callback(null, null, apiError));
+
+      Nylas.exchangeCodeForToken('code-from-server').catch(returnedError => {
+        expect(returnedError.message).toBe(apiError.message);
+        done();
+      });
+    });
+
+    test('should reject with default error', done => {
+      request.Request = jest.fn(options => options.callback(null, null, null));
+
+      Nylas.exchangeCodeForToken('code-from-server').catch(returnedError => {
+        expect(returnedError.message).toBe('No access token in response');
+        done();
+      });
+    });
+
     describe('when provided an optional callback', () => {
       test('should call it with the returned access_token', done => {
         request.Request = jest.fn(options =>

--- a/src/nylas.js
+++ b/src/nylas.js
@@ -161,6 +161,11 @@ class Nylas {
       };
 
       return request(options, (error, response, body) => {
+        if (!body || !body['access_token']) {
+          let errorMessage = 'No access token in response';
+          if (body && body.message) errorMessage = body.message;
+          error = error ? error : new Error(errorMessage);
+        }
         if (error) {
           reject(error);
           if (callback) {


### PR DESCRIPTION
<!-- Add information about your PR here -->
Re: https://github.com/nylas/nylas-nodejs/issues/176 we should be explicitly rejecting in `exchangeCodeForToken` if we don't receive a token in the response.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.