### PR TITLE
Contact groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Implement support for GET /contacts/groups
+
 ### 5.1.0 / 2020-06-04
 * Fix bug which was overwriting properties on message objects.
 * Support recurring events.

--- a/__tests__/contact-restful-model-collection-spec.js
+++ b/__tests__/contact-restful-model-collection-spec.js
@@ -1,0 +1,77 @@
+import request from 'request';
+
+import Nylas from '../src/nylas';
+import NylasConnection from '../src/nylas-connection';
+import RestfulModelCollection from '../src/models/restful-model-collection';
+import { Group } from '../src/models/contact';
+
+describe('RestfulModelCollection', () => {
+  let testContext;
+
+  beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+    });
+    testContext = {};
+    testContext.connection = new NylasConnection('test-access-token', {
+      clientId: 'foo',
+    });
+    testContext.apiResponse = [{
+      account_id: 'account123',
+      id: 'group123',
+      object: 'contact_group',
+      name: 'name123',
+      path: 'path123'
+    }];
+  });
+
+  describe('groups', () => {
+    test('should call API with correct authentication', done => {
+      expect.assertions(3);
+
+      request.Request = jest.fn(options => {
+        expect(options.url).toEqual('https://api.nylas.com/contacts/groups');
+        expect(options.method).toEqual('GET');
+        expect(options.auth.user).toEqual('test-access-token');
+        done();
+      });
+
+      testContext.connection.contacts.groups();
+    });
+
+    test('should call callback', done => {
+      expect.assertions(7);
+      testContext.connection.request = jest.fn(() => Promise.resolve(testContext.apiResponse));
+
+      const testCallback = (err, data) => {
+        expect(err).toBe(null);
+        expect(data[0].accountId).toBe('account123');
+        expect(data[0].id).toBe('group123');
+        expect(data[0].object).toBe('contact_group');
+        expect(data[0].name).toBe('name123');
+        expect(data[0].path).toBe('path123');
+        expect(data[0] instanceof Group).toBe(true);
+        done();
+      };
+
+      testContext.connection.contacts.groups(testCallback);
+    });
+
+    test('should resolve to group object', done => {
+      expect.assertions(6);
+      testContext.connection.request = jest.fn(() => Promise.resolve(testContext.apiResponse));
+
+      testContext.connection.contacts.groups().then(data => {
+        expect(data[0].accountId).toBe('account123');
+        expect(data[0].id).toBe('group123');
+        expect(data[0].object).toBe('contact_group');
+        expect(data[0].name).toBe('name123');
+        expect(data[0].path).toBe('path123');
+        expect(data[0] instanceof Group).toBe(true);
+        done();
+      });
+    });
+  });
+
+});

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -1,6 +1,6 @@
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
-import Contact from '../src/models/contact';
+import { Contact } from '../src/models/contact';
 
 describe('Contact', () => {
   let testContext;

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -1,4 +1,4 @@
-import { Contact, Groups } from './contact';
+import { Contact, Group } from './contact';
 import NylasConnection from '../nylas-connection';
 import RestfulModel from './restful-model';
 import RestfulModelCollection from './restful-model-collection';
@@ -20,11 +20,11 @@ export default class ContactRestfulModelCollection<Contact> extends RestfulModel
         path: `/contacts/groups`
       })
       .then(json => {
-        const group = new Groups(this.connection, json);
+        const groups = json.map((group: { [key: string]: any }) => { return new Group(this.connection, group); });
         if (callback) {
-          callback(null, group);
+          callback(null, groups);
         }
-        return Promise.resolve(group);
+        return Promise.resolve(groups);
       })
       .catch(err => {
         if (callback) {

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -1,0 +1,36 @@
+import { Contact, Groups } from './contact';
+import NylasConnection from '../nylas-connection';
+import RestfulModel from './restful-model';
+import RestfulModelCollection from './restful-model-collection';
+
+export default class ContactRestfulModelCollection<Contact> extends RestfulModelCollection<RestfulModel> {
+  connection: NylasConnection;
+  modelClass: typeof Contact;
+
+  constructor(connection: NylasConnection) {
+    super(Contact, connection);
+    this.connection = connection;
+    this.modelClass = Contact;
+  }
+
+  groups(callback?: (error: Error | null, data?: { [key: string]: any }) => void) {
+    return this.connection
+      .request({
+        method: 'GET',
+        path: `/contacts/groups`
+      })
+      .then(json => {
+        const group = new Groups(this.connection, json);
+        if (callback) {
+          callback(null, group);
+        }
+        return Promise.resolve(group);
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      });
+  }
+}

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -154,7 +154,7 @@ WebPage.attributes = {
   }),
 };
 
-export class Groups extends RestfulModel {
+export class Group extends RestfulModel {
   type?: string;
   path?: string;
 
@@ -165,8 +165,8 @@ export class Groups extends RestfulModel {
   }
 }
 
-Groups.collectionName = 'groups';
-Groups.attributes = {
+Group.collectionName = 'groups';
+Group.attributes = {
   ...RestfulModel.attributes,
   name: Attributes.String({
     modelKey: 'name',
@@ -193,7 +193,7 @@ export class Contact extends RestfulModel {
   physicalAddresses?: PhysicalAddress[];
   phoneNumbers?: PhoneNumber[];
   webPages?: WebPage[];
-  groups?: Groups[];
+  groups?: Group[];
   source?: string;
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
@@ -281,7 +281,7 @@ Contact.attributes = {
   }),
   groups: Attributes.Collection({
     modelKey: 'groups',
-    itemClass: Groups,
+    itemClass: Group,
   }),
   source: Attributes.String({
     modelKey: 'source',

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -154,7 +154,7 @@ WebPage.attributes = {
   }),
 };
 
-class Groups extends RestfulModel {
+export class Groups extends RestfulModel {
   type?: string;
   path?: string;
 
@@ -176,7 +176,7 @@ Groups.attributes = {
   }),
 };
 
-export default class Contact extends RestfulModel {
+export class Contact extends RestfulModel {
   givenName?: string;
   middleName?: string;
   surname?: string;

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -1,6 +1,6 @@
 import File from './file';
 import Message from './message';
-import Contact from './contact';
+import { Contact } from './contact';
 import Attributes from './attributes';
 import { SaveCallback } from './restful-model';
 

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -3,13 +3,14 @@ import request, { UrlOptions, CoreOptions } from 'request';
 
 import RestfulModel from './models/restful-model';
 import RestfulModelCollection from './models/restful-model-collection';
-import CalendarRestfulModelCollection from './models/calendar-restful-model-collection'
+import CalendarRestfulModelCollection from './models/calendar-restful-model-collection';
+import ContactRestfulModelCollection from './models/contact-restful-model-collection';
 import RestfulModelInstance from './models/restful-model-instance';
 import Account from './models/account';
 import ManagementAccount from './models/management-account';
 import ManagementModelCollection from './models/management-model-collection';
 import Thread from './models/thread';
-import Contact from './models/contact';
+import { Contact } from './models/contact';
 import Message from './models/message';
 import Draft from './models/draft';
 import File from './models/file';
@@ -27,7 +28,7 @@ export default class NylasConnection {
   clientId: string | null | undefined;
 
   threads = new RestfulModelCollection(Thread, this);
-  contacts = new RestfulModelCollection(Contact, this);
+  contacts = new ContactRestfulModelCollection(this);
   messages = new RestfulModelCollection(Message, this);
   drafts = new RestfulModelCollection(Draft, this);
   files = new RestfulModelCollection(File, this);


### PR DESCRIPTION
<!-- Add information about your PR here -->
Implementing support for [GET /contacts/groups](https://docs.nylas.com/reference#contactsgroups)

- Renamed `Groups` to `Group` (where `Groups` is an array of `Group` objects)
- Changed exports from contact.ts to also export `Group`
- Added `ContactRestfulModelCollection`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.