### PR TITLE
Calendar CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Implement support for GET /contacts/groups
 * Update lodash import
 * Support GET /resources
+* Support POST, PUT and DELETE for calendars, and add location, timezone and isPrimary attributes.
 
 ### 5.1.0 / 2020-06-04
 * Fix bug which was overwriting properties on message objects.

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -4,7 +4,7 @@ import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import RestfulModelCollection from '../src/models/restful-model-collection';
 
-describe('RestfulModelCollection', () => {
+describe('CalendarRestfulModelCollection', () => {
   let testContext;
 
   beforeEach(() => {
@@ -14,52 +14,63 @@ describe('RestfulModelCollection', () => {
     });
     testContext = {};
     testContext.connection = new NylasConnection('test-access-token', {
-      clientId: 'foo',
+      clientId: 'myClientId',
     });
   });
 
-  describe('free-busy', () => {
-    test('should fetch free-busy results with snakecase params', () => {
-      const params = {
+  test('[FREE BUSY] should fetch results with snakecase params', () => {
+    const params = {
+      start_time: '1590454800',
+      end_time: '1590780800',
+      emails: ['jane@email.com']
+    };
+
+    request.Request = jest.fn(options => {
+      expect(options.url).toEqual('https://api.nylas.com/calendars/free-busy');
+      expect(options.method).toEqual('POST');
+      expect(options.body).toEqual({
         start_time: '1590454800',
         end_time: '1590780800',
-        emails: ['jane@email.com']
-      };
-
-      request.Request = jest.fn(options => {
-        expect(options.url).toEqual('https://api.nylas.com/calendars/free-busy');
-        expect(options.method).toEqual('POST');
-        expect(options.body).toEqual({
-          start_time: '1590454800',
-          end_time: '1590780800',
-          emails: [ 'jane@email.com' ]
-        });
-        expect(options.auth.user).toEqual('test-access-token');
+        emails: [ 'jane@email.com' ]
       });
-
-      testContext.connection.calendars.freeBusy(params);
+      expect(options.auth.user).toEqual('test-access-token');
     });
 
-    test('should fetch free-busy results with camelcase params', () => {
-      const params = {
-        startTime: '1590454800',
-        endTime: '1590780800',
-        emails: ['jane@email.com']
-      };
-
-      request.Request = jest.fn(options => {
-        expect(options.url).toEqual('https://api.nylas.com/calendars/free-busy');
-        expect(options.method).toEqual('POST');
-        expect(options.body).toEqual({
-          start_time: '1590454800',
-          end_time: '1590780800',
-          emails: [ 'jane@email.com' ]
-        });
-        expect(options.auth.user).toEqual('test-access-token');
-      });
-
-      testContext.connection.calendars.freeBusy(params);
-    });
-
+    testContext.connection.calendars.freeBusy(params);
   });
+
+  test('[FREE BUSY] should fetch results with camelcase params', () => {
+    const params = {
+      startTime: '1590454800',
+      endTime: '1590780800',
+      emails: ['jane@email.com']
+    };
+
+    request.Request = jest.fn(options => {
+      expect(options.url).toEqual('https://api.nylas.com/calendars/free-busy');
+      expect(options.method).toEqual('POST');
+      expect(options.body).toEqual({
+        start_time: '1590454800',
+        end_time: '1590780800',
+        emails: [ 'jane@email.com' ]
+      });
+      expect(options.auth.user).toEqual('test-access-token');
+    });
+
+    testContext.connection.calendars.freeBusy(params);
+  });
+
+  test('[DELETE] should use correct route, method and auth', done => {
+    expect.assertions(3);
+    const calendarId = 'id123';
+    request.Request = jest.fn(options => {
+      expect(options.url).toEqual(`https://api.nylas.com/calendars/${calendarId}`);
+      expect(options.method).toEqual('DELETE');
+      expect(options.auth.user).toEqual('test-access-token');
+    });
+
+    testContext.connection.calendars.delete(calendarId);
+    done();
+  });
+
 });

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -1,0 +1,55 @@
+import request from 'request';
+
+import Nylas from '../src/nylas';
+import NylasConnection from '../src/nylas-connection';
+import Calendar from '../src/models/calendar';
+
+describe('Calendar', () => {
+  let testContext;
+
+  beforeEach(() => {
+    testContext = {};
+    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection.request = jest.fn(() => Promise.resolve());
+    testContext.calendar = new Calendar(testContext.connection);
+    testContext.calendar.name = 'Holidays';
+    testContext.calendar.description = 'All the holidays';
+  });
+
+  test('should do a POST request if the calendar has no id', done => {
+    testContext.calendar.id = undefined;
+    testContext.calendar.save().then(() => {
+      expect(testContext.connection.request).toHaveBeenCalledWith({
+        method: 'POST',
+        body: {
+          name: 'Holidays',
+          description: 'All the holidays',
+          location: undefined,
+          timezone: undefined
+        },
+        qs: {},
+        path: '/calendars',
+      });
+      done();
+    });
+  });
+
+  test('should do a PUT request if the event has an id', done => {
+    testContext.calendar.id = 'id-1234';
+    testContext.calendar.description = 'Updated description';
+    testContext.calendar.save().then(() => {
+      expect(testContext.connection.request).toHaveBeenCalledWith({
+        method: 'PUT',
+        body: {
+          name: 'Holidays',
+          description: 'Updated description',
+          location: undefined,
+          timezone: undefined
+        },
+        qs: {},
+        path: '/calendars/id-1234',
+      });
+      done();
+    });
+  });
+});

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -10,45 +10,96 @@ describe('Calendar', () => {
   beforeEach(() => {
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-    testContext.connection.request = jest.fn(() => Promise.resolve());
-    testContext.calendar = new Calendar(testContext.connection);
-    testContext.calendar.name = 'Holidays';
-    testContext.calendar.description = 'All the holidays';
+    const calendarJSON = {
+      account_id: "eof2wrhqkl7kdwhy9hylpv9o9",
+      description: "All the holidays",
+      id: "8e570s302fdazx9zqwiuk9jqn",
+      is_primary: false,
+      job_status_id: "48pp6ijzrxpw9jors9ylnsxnf",
+      location: "Santa Monica, CA",
+      name: "Holidays",
+      object: "calendar",
+      read_only: false,
+      timezone: "America/Los_Angeles"
+    };
+    testContext.connection.request = jest.fn(() => Promise.resolve(calendarJSON));
+    testContext.calendar = testContext.connection.calendars.build(calendarJSON);
   });
 
-  test('should do a POST request if the calendar has no id', done => {
+  test('[SAVE] should do a POST request if the calendar has no id', done => {
+    expect.assertions(10);
     testContext.calendar.id = undefined;
-    testContext.calendar.save().then(() => {
+    testContext.calendar.save().then((calendar) => {
       expect(testContext.connection.request).toHaveBeenCalledWith({
         method: 'POST',
         body: {
           name: 'Holidays',
           description: 'All the holidays',
-          location: undefined,
-          timezone: undefined
+          location: 'Santa Monica, CA',
+          timezone: 'America/Los_Angeles'
         },
         qs: {},
         path: '/calendars',
       });
+      expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
+      expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
+      expect(calendar.description).toEqual('All the holidays');
+      expect(calendar.isPrimary).toEqual(false);
+      expect(calendar.location).toEqual('Santa Monica, CA');
+      expect(calendar.name).toEqual('Holidays');
+      expect(calendar.object).toEqual('calendar');
+      expect(calendar.timezone).toEqual('America/Los_Angeles');
+      expect(calendar.readOnly).toEqual(false);
       done();
     });
   });
 
-  test('should do a PUT request if the event has an id', done => {
-    testContext.calendar.id = 'id-1234';
+  test('[SAVE] should do a PUT request if the event has an id', done => {
+    expect.assertions(10);
+    testContext.calendar.id = '8e570s302fdazx9zqwiuk9jqn';
     testContext.calendar.description = 'Updated description';
-    testContext.calendar.save().then(() => {
+    testContext.calendar.save().then((calendar) => {
       expect(testContext.connection.request).toHaveBeenCalledWith({
         method: 'PUT',
         body: {
           name: 'Holidays',
           description: 'Updated description',
-          location: undefined,
-          timezone: undefined
+          location: 'Santa Monica, CA',
+          timezone: 'America/Los_Angeles'
         },
         qs: {},
-        path: '/calendars/id-1234',
+        path: '/calendars/8e570s302fdazx9zqwiuk9jqn',
       });
+      expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
+      expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
+      expect(calendar.description).toEqual('All the holidays');
+      expect(calendar.isPrimary).toEqual(false);
+      expect(calendar.location).toEqual('Santa Monica, CA');
+      expect(calendar.name).toEqual('Holidays');
+      expect(calendar.object).toEqual('calendar');
+      expect(calendar.timezone).toEqual('America/Los_Angeles');
+      expect(calendar.readOnly).toEqual(false);
+      done();
+    });
+  });
+
+  test('[FIND] should use correct method and route', done => {
+    expect.assertions(10);
+    testContext.connection.calendars.find('8e570s302fdazx9zqwiuk9jqn').then((calendar) => {
+      expect(testContext.connection.request).toHaveBeenCalledWith({
+        method: 'GET',
+        qs: {},
+        path: '/calendars/8e570s302fdazx9zqwiuk9jqn',
+      });
+      expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
+      expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
+      expect(calendar.description).toEqual('All the holidays');
+      expect(calendar.isPrimary).toEqual(false);
+      expect(calendar.location).toEqual('Santa Monica, CA');
+      expect(calendar.name).toEqual('Holidays');
+      expect(calendar.object).toEqual('calendar');
+      expect(calendar.timezone).toEqual('America/Los_Angeles');
+      expect(calendar.readOnly).toEqual(false);
       done();
     });
   });

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -5,6 +5,9 @@ export default class Calendar extends RestfulModel {
   name?: string;
   description?: string;
   readOnly?: boolean;
+  location?: string;
+  timezone?: string;
+  isPrimary?: boolean;
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
     return this._save(params, callback);
@@ -33,5 +36,15 @@ Calendar.attributes = {
   readOnly: Attributes.Boolean({
     modelKey: 'readOnly',
     jsonKey: 'read_only',
+  }),
+  location: Attributes.String({
+    modelKey: 'location',
+  }),
+  timezone: Attributes.String({
+    modelKey: 'timezone',
+  }),
+  isPrimary: Attributes.Boolean({
+    modelKey: 'isPrimary',
+    jsonKey: 'is_primary',
   }),
 };

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -1,11 +1,26 @@
-import RestfulModel from './restful-model';
+import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 
 export default class Calendar extends RestfulModel {
   name?: string;
   description?: string;
   readOnly?: boolean;
+
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+    return this._save(params, callback);
+  }
+
+  saveRequestBody() {
+    const calendarJSON = this.toJSON();
+    return {
+      name: calendarJSON.name,
+      description: calendarJSON.description,
+      location: calendarJSON.location,
+      timezone: calendarJSON.timezone
+    };
+  }
 }
+
 Calendar.collectionName = 'calendars';
 Calendar.attributes = {
   ...RestfulModel.attributes,

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -233,7 +233,7 @@ export default class RestfulModelCollection<T extends RestfulModel> {
         if (callback) {
           callback(null, data);
         }
-        return Promise.resolve();
+        return Promise.resolve(data);
       })
       .catch((err: Error) => {
         if (callback) {

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -229,9 +229,9 @@ export default class RestfulModelCollection<T extends RestfulModel> {
         body: body,
         path: `${this.path()}/${item.id}`,
       })
-      .then(() => {
+      .then((data) => {
         if (callback) {
-          callback(null);
+          callback(null, data);
         }
         return Promise.resolve();
       })


### PR DESCRIPTION
<!-- Add information about your PR here -->
- Supporting POST & PUT for calendars. 
    - Adds isPrimary, location and timezone attributes.
    - Expand test coverage
- Supporting DELETE for calendars
    - Refactor delete message to return JSON response (previous delete responses were empty, so this was not needed)
    - Expand test coverage

Will address job statuses in a follow-up PR

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.