### PR TITLE
Replace lodash with native tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1353,12 +1353,6 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
-    },
     "@types/node": {
       "version": "13.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "prepare": "npm run build",
     "watch": "nodemon -w src --exec npm run build"
   },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",
     "globals": {
@@ -42,7 +46,6 @@
     "JSONStream": "^1.3.5",
     "async": "^2.6.2",
     "backoff": "^2.5.0",
-    "lodash": "^4.17.13",
     "request": "^2.88.0"
   },
   "devDependencies": {
@@ -53,7 +56,6 @@
     "@types/async": "^3.0.8",
     "@types/backoff": "^2.5.1",
     "@types/jest": "^25.1.4",
-    "@types/lodash": "^4.14.149",
     "@types/request": "^2.48.4",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -1,4 +1,3 @@
-import omit from 'lodash/omit';
 import backoff from 'backoff';
 import JSONStream from 'JSONStream';
 import request, { ResponseRequest } from 'request';
@@ -46,7 +45,11 @@ export default class Delta {
     return this._startStream(request, cursor, params);
   }
 
-  _startStream(createRequest: CreateRequestType, cursor: string, params: { [key: string]: any }) {
+  _startStream(
+    createRequest: CreateRequestType,
+    cursor: string,
+    params: { [key: string]: any }
+  ) {
     const stream = new DeltaStream(
       createRequest,
       this.connection,
@@ -75,9 +78,9 @@ class DeltaStream extends EventEmitter {
   connection: NylasConnection;
   cursor?: string;
   params: {
-    includeTypes?: string[],
-    excludeTypes?: string[],
-    expanded?: boolean
+    includeTypes?: string[];
+    excludeTypes?: string[];
+    expanded?: boolean;
   };
   request?: ResponseRequest;
   restartBackoff = backoff.exponential({
@@ -134,13 +137,10 @@ class DeltaStream extends EventEmitter {
   open() {
     this.close();
     const path = '/delta/streaming';
-    const excludeTypes =
-      this.params.excludeTypes != null ? this.params.excludeTypes : [];
-    const includeTypes =
-      this.params.includeTypes != null ? this.params.includeTypes : [];
+    const { excludeTypes = [], includeTypes = [], ...params } = this.params;
 
     const queryObj: { [key: string]: any } = {
-      ...omit(this.params, ['excludeTypes', 'includeTypes']),
+      ...params,
       cursor: this.cursor,
     };
     if (excludeTypes.length > 0) {

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -1,6 +1,3 @@
-import union from 'lodash/union';
-import values from 'lodash/values';
-
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 import File from './file';
@@ -33,7 +30,10 @@ export default class Message extends RestfulModel {
   // from more dependencies.
   participants() {
     const participants: { [key: string]: EmailParticipant } = {};
-    const contacts = union(this.to, this.cc, this.from);
+    const to = this.to || [];
+    const cc = this.cc || [];
+    const from = this.from || [];
+    const contacts = Array.from(new Set([...to, ...cc, ...from]));
     for (const contact of contacts) {
       if (contact && (contact.email ? contact.email.length : '') > 0) {
         if (contact) {
@@ -45,7 +45,7 @@ export default class Message extends RestfulModel {
         }
       }
     }
-    return values(participants);
+    return Object.values(participants);
   }
 
   fileIds() {

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -1,5 +1,4 @@
 import async from 'async';
-import isFunction from 'lodash/isFunction';
 
 import Message from './message';
 import NylasConnection from '../nylas-connection';
@@ -26,7 +25,8 @@ export default class RestfulModelCollection<T extends RestfulModel> {
   forEach(
     params: { [key: string]: any } = {},
     eachCallback: (item: T) => void,
-    completeCallback?: (err?: Error | null | undefined) => void) {
+    completeCallback?: (err?: Error | null | undefined) => void
+  ) {
     if (params.view == 'count') {
       const err = new Error('forEach() cannot be called with the count view');
       if (completeCallback) {
@@ -128,7 +128,11 @@ export default class RestfulModelCollection<T extends RestfulModel> {
     return this._range({ params, offset, limit, callback });
   }
 
-  find(id: string, callback?: (error: Error | null, model?: T) => void, params: { [key: string]: any } = {}) {
+  find(
+    id: string,
+    callback?: (error: Error | null, model?: T) => void,
+    params: { [key: string]: any } = {}
+  ) {
     if (!id) {
       const err = new Error('find() must be called with an item id');
       if (callback) {
@@ -162,7 +166,11 @@ export default class RestfulModelCollection<T extends RestfulModel> {
       });
   }
 
-  search(query: string, params: { [key: string]: any } = {}, callback?: (error: Error | null) => void) {
+  search(
+    query: string,
+    params: { [key: string]: any } = {},
+    callback?: (error: Error | null) => void
+  ) {
     if (this.modelClass != Message && this.modelClass != Thread) {
       const err = new Error(
         'search() can only be called for messages and threads'
@@ -189,7 +197,11 @@ export default class RestfulModelCollection<T extends RestfulModel> {
     return this._range({ params, offset, limit, path });
   }
 
-  delete(itemOrId: T | string, params: { [key: string]: any } = {}, callback?: (error: Error | null) => void) {
+  delete(
+    itemOrId: T | string,
+    params: { [key: string]: any } = {},
+    callback?: (error: Error | null) => void
+  ) {
     if (!itemOrId) {
       const err = new Error('delete() requires an item or an id');
       if (callback) {
@@ -198,12 +210,13 @@ export default class RestfulModelCollection<T extends RestfulModel> {
       return Promise.reject(err);
     }
 
-    if (isFunction(params)) {
-      callback = params;
+    if (typeof params === 'function') {
+      callback = params as (error: Error | null) => void;
       params = {};
     }
 
-    const item = typeof itemOrId === 'string' ? this.build({ id: itemOrId }) : itemOrId;
+    const item =
+      typeof itemOrId === 'string' ? this.build({ id: itemOrId }) : itemOrId;
 
     const options: { [key: string]: any } = item.deleteRequestOptions(params);
     options.item = item;

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -1,5 +1,3 @@
-import isFunction from 'lodash/isFunction';
-
 import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 
@@ -106,7 +104,7 @@ export default class RestfulModel {
   // do shouldn't have to reimplement the same boilerplate.
   // They should instead define a save() function which calls _save.
   _save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
-    if (isFunction(params)) {
+    if (typeof params === 'function') {
       callback = params as SaveCallback;
       params = {};
     }

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -1,4 +1,3 @@
-import clone from 'lodash/clone';
 import request, { UrlOptions, CoreOptions } from 'request';
 
 import RestfulModel from './models/restful-model';
@@ -39,7 +38,10 @@ export default class NylasConnection {
   folders = new RestfulModelCollection(Folder, this);
   account = new RestfulModelInstance(Account, this);
 
-  constructor(accessToken: string | null | undefined, { clientId }: { clientId: string | null | undefined}) {
+  constructor(
+    accessToken: string | null | undefined,
+    { clientId }: { clientId: string | null | undefined }
+  ) {
     this.accessToken = accessToken;
     this.clientId = clientId;
   }
@@ -48,7 +50,7 @@ export default class NylasConnection {
     if (!options) {
       options = {};
     }
-    options = clone(options);
+    options = { ...options };
     const Nylas = require('./nylas');
     if (!options.method) {
       options.method = 'GET';
@@ -140,7 +142,9 @@ export default class NylasConnection {
           return reject(error);
         }
         // node headers are lowercase so this refers to `Nylas-Api-Version`
-        const apiVersion = response.headers['nylas-api-version'] as string | undefined;
+        const apiVersion = response.headers['nylas-api-version'] as
+          | string
+          | undefined;
 
         const warning = this._getWarningForVersion(
           SUPPORTED_API_VERSION,
@@ -182,4 +186,4 @@ export default class NylasConnection {
       });
     });
   }
-};
+}


### PR DESCRIPTION
Lodash is quite big package and often used for things supported
natively.

This diff will allow to cut some bytes from node_modules.
https://packagephobia.com/result?p=nylas

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.