### PR TITLE
Drop async

### DIFF
--- a/example/sample-app/package.json
+++ b/example/sample-app/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "assert": "^1.4.1",
-    "async": "^0.9.0",
     "bluebird": "^2.9.13",
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,12 +1238,6 @@
         }
       }
     },
-    "@types/async": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.0.8.tgz",
-      "integrity": "sha512-wIM8bCrHeQHCUyDqJYXyvG8P98YeERaOB1NeOvcjnjlM32pn21S13j6tZqhiWX+nkpU3EvhtE/nuO1ItCpZ+HQ==",
-      "dev": true
-    },
     "@types/babel__core": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -1687,14 +1681,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "async-each": {
       "version": "1.0.3",
@@ -5562,7 +5548,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "license": "MIT",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "async": "^2.6.2",
     "backoff": "^2.5.0",
     "request": "^2.88.0"
   },
@@ -53,7 +52,6 @@
     "@babel/core": "^7.3.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/preset-env": "^7.3.1",
-    "@types/async": "^3.0.8",
     "@types/backoff": "^2.5.1",
     "@types/jest": "^25.1.4",
     "@types/request": "^2.48.4",


### PR DESCRIPTION
Async package is quite big (especially v2 with lodash in dependencies).
In this diff I replaced it with simple promise flow.

https://packagephobia.com/result?p=async

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.