### PR TITLE
Fix the file_ids array reading of toJSON method

### DIFF
--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -14,7 +14,7 @@ export default class Draft extends Message {
       throw Error('toJSON() cannot be called for raw MIME drafts');
     }
     const json = super.toJSON();
-    json.file_ids = this.fileIds();
+    json.file_ids = this.fileIds;
     json.object = 'draft';
 
     return json;


### PR DESCRIPTION
While trying to send the fileIds array in an draft instance, I've catched the error: error:  "TypeError: this.fileIds is not a function" on Draft.toJSON method. 
The error is solved by taking the fileIds parameter on the method and not the fileIds() (function).

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.