### PR TITLE
Be consistent about callback parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Refactor parameter ordering in `find()` and `draft.send()` methods [backwards compatible]
 * Add JobStatus model and collection
 
 ### 5.2.0 / 2020-07-27

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -201,10 +201,88 @@ describe('Draft', () => {
       });
     });
 
-    test('should send the draft JSON if the draft has no id and has a tracking object passed in as a parameter', done => {
+    test('should send the draft JSON if the draft has no id and has a tracking object passed in as the second parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
       testContext.draft.send(null, {"opens": true}).then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'draft',
+            account_id: undefined,
+            to: [],
+            cc: [],
+            bcc: [],
+            from: [],
+            date: null,
+            body: undefined,
+            files: [],
+            events: [],
+            unread: undefined,
+            snippet: undefined,
+            thread_id: undefined,
+            subject: 'Test Subject',
+            version: undefined,
+            folder: undefined,
+            labels: [],
+            file_ids: [],
+            headers: undefined,
+            reply_to: [],
+            reply_to_message_id: undefined,
+            tracking: {"opens": true}
+          },
+          path: '/send',
+          headers: {},
+          json: true,
+        });
+        done();
+      });
+    });
+
+    test('should send the draft JSON if the draft has a tracking object as the only parameter', done => {
+      testContext.draft.id = undefined;
+      testContext.draft.subject = 'Test Subject';
+      testContext.draft.send({"opens": true}).then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'draft',
+            account_id: undefined,
+            to: [],
+            cc: [],
+            bcc: [],
+            from: [],
+            date: null,
+            body: undefined,
+            files: [],
+            events: [],
+            unread: undefined,
+            snippet: undefined,
+            thread_id: undefined,
+            subject: 'Test Subject',
+            version: undefined,
+            folder: undefined,
+            labels: [],
+            file_ids: [],
+            headers: undefined,
+            reply_to: [],
+            reply_to_message_id: undefined,
+            tracking: {"opens": true}
+          },
+          path: '/send',
+          headers: {},
+          json: true,
+        });
+        done();
+      });
+    });
+
+    test('should send the draft JSON if the draft has no id and has a tracking object passed in as the first parameter', done => {
+      testContext.draft.id = undefined;
+      testContext.draft.subject = 'Test Subject';
+      testContext.draft.send({"opens": true}, (err, data) => {}).then(() => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           body: {
@@ -296,6 +374,26 @@ Would you like to grab coffee @ 2pm this Thursday?`;
           expect(message).toBeInstanceOf(Message);
           done();
         });
+      });
+
+      test('should call the callback when tracking object is passed as first argument', done => {
+        testContext.draft.send({"opens": true}, (err, message) => {
+          expect(err).toBe(null);
+          expect(message.id).toBe('id-1234');
+          expect(message.threadId).toBe('new-thread-id');
+          expect(message).toBeInstanceOf(Message);
+          done();
+        });
+      });
+
+      test('should call the callback when tracking object is passed as second argument', done => {
+        testContext.draft.send((err, message) => {
+          expect(err).toBe(null);
+          expect(message.id).toBe('id-1234');
+          expect(message.threadId).toBe('new-thread-id');
+          expect(message).toBeInstanceOf(Message);
+          done();
+        }, {"opens": true});
       });
     });
 

--- a/__tests__/restful-model-collection-spec.js
+++ b/__tests__/restful-model-collection-spec.js
@@ -312,8 +312,38 @@ describe('RestfulModelCollection', () => {
       done();
     });
 
-    test('should pass any additional params to the request', done => {
+    test('should pass additional params as third argument to the request when callback is null', done => {
       testContext.collection.find('123', null, { param: 1 });
+      expect(testContext.connection.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/threads/123',
+        qs: { param: 1 },
+      });
+      done();
+    });
+
+    test('should pass additional params as second argument to the request', done => {
+      testContext.collection.find('123', { param: 1 });
+      expect(testContext.connection.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/threads/123',
+        qs: { param: 1 },
+      });
+      done();
+    });
+
+    test('should pass additional params as second argument to the request when callback is null', done => {
+      testContext.collection.find('123', { param: 1 }, null);
+      expect(testContext.connection.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/threads/123',
+        qs: { param: 1 },
+      });
+      done();
+    });
+
+    test('should pass additional params as second argument to the request when callback is provided', done => {
+      testContext.collection.find('123', { param: 1 }, (err, data) => {});
       expect(testContext.connection.request).toHaveBeenCalledWith({
         method: 'GET',
         path: '/threads/123',
@@ -344,6 +374,22 @@ describe('RestfulModelCollection', () => {
           expect(item.id).toBe('123');
           done();
         });
+      });
+
+      test('should call the optional callback with the first item when params provided as second arg', done => {
+        testContext.collection.find('123', { param: 1 }, (err, item) => {
+          expect(item instanceof Thread).toBe(true);
+          expect(item.id).toBe('123');
+          done();
+        });
+      });
+
+      test('should call the optional callback with the first item when params provided as third arg', done => {
+        testContext.collection.find('123', (err, item) => {
+          expect(item instanceof Thread).toBe(true);
+          expect(item.id).toBe('123');
+          done();
+        }, { param: 1 });
       });
     });
 

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -1,4 +1,5 @@
 import RestfulModel, { SaveCallback } from './restful-model';
+import { GetCallback } from './restful-model-collection';
 import JobStatus from './job-status';
 import Attributes from './attributes';
 
@@ -25,7 +26,7 @@ export default class Calendar extends RestfulModel {
     };
   }
 
-  getJobStatus(callback?: (error: Error | null, model?: JobStatus) => void) {
+  getJobStatus(callback?: GetCallback) {
     if ( typeof this.jobStatusId === 'undefined' ) {
       const err = new Error('jobStatusId must be defined');
       if (callback) {

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -4,6 +4,8 @@ import { Contact } from './contact';
 import Attributes from './attributes';
 import { SaveCallback } from './restful-model';
 
+export type SendCallback = (err: Error | null, json?: { [key: string]: any }) => void;
+
 export default class Draft extends Message {
   rawMime?: string;
   replyToMessageId?: string;
@@ -54,9 +56,24 @@ export default class Draft extends Message {
   }
 
   send(
-    callback?: (err: Error | null, json?: { [key: string]: any }) => void,
-    tracking?: { [key: string]: any }
+    trackingArg?: { [key: string]: any } | SendCallback | null,
+    callbackArg?: SendCallback | { [key: string]: any } | null
   ) {
+
+    // callback used to be the first argument, and tracking was the second
+    let callback: SendCallback | undefined;
+    if (typeof callbackArg === 'function') {
+      callback = callbackArg as SendCallback;
+    } else if (typeof trackingArg === 'function') {
+      callback = trackingArg as SendCallback;
+    }
+    let tracking: { [key: string]: any } | undefined;
+    if (trackingArg && typeof trackingArg === 'object') {
+      tracking = trackingArg;
+    } else if (callbackArg && typeof callbackArg === 'object') {
+      tracking = callbackArg;
+    }
+
     let body: any = this.rawMime,
       headers: { [key: string]: any } = { 'Content-Type': 'message/rfc822' },
       json = false;


### PR DESCRIPTION
<!-- Add information about your PR here -->
We should consistently be passing callback as the last argument to public functions. Added tests for backwards compatibility, so users can still use the old parameter ordering if they want to.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.