### PR TITLE
Avoid commonjs and circular dependencies

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,9 @@
+export let apiServer: string | null = null;
+export function setApiServer(newApiServer: string | null) {
+  apiServer = newApiServer;
+}
+
+export let clientSecret = '';
+export function setClientSecret(newClientSecret: string) {
+  clientSecret = newClientSecret;
+}

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -1,5 +1,6 @@
 import request, { UrlOptions, CoreOptions } from 'request';
 
+import * as config from './config';
 import RestfulModel from './models/restful-model';
 import RestfulModelCollection from './models/restful-model-collection';
 import CalendarRestfulModelCollection from './models/calendar-restful-model-collection';
@@ -55,13 +56,12 @@ export default class NylasConnection {
       options = {};
     }
     options = { ...options };
-    const Nylas = require('./nylas');
     if (!options.method) {
       options.method = 'GET';
     }
     if (options.path) {
       if (!options.url) {
-        options.url = `${Nylas.apiServer}${options.path}`;
+        options.url = `${config.apiServer}${options.path}`;
       }
     }
     if (!options.formData) {
@@ -87,7 +87,7 @@ export default class NylasConnection {
 
     const user =
       options.path.substr(0, 3) === '/a/'
-        ? Nylas.clientSecret
+        ? config.clientSecret
         : this.accessToken;
 
     if (user) {


### PR DESCRIPTION
"require" was used in nylas connection to get options from static
class properties.

In this diff I moved the source of data to separate module which can be
imported by any module and refactored static properties with getters and
setters to preserve existing behaviour.

This is necessary simplification before replacing "request" with `node-fetch`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.