### PR TITLE
Make connection.request types more strict

### DIFF
--- a/__tests__/delta-spec.js
+++ b/__tests__/delta-spec.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 
+import * as config from '../src/config.ts';
 import Delta from '../src/models/delta';
 import NylasConnection from '../src/nylas-connection';
 
@@ -43,7 +44,7 @@ describe('Delta', () => {
       const { request } = stream;
 
       expect(request.origOpts.method).toBe('GET');
-      expect(request.origOpts.path).toBe('/delta/streaming');
+      expect(request.origOpts.url).toBe(`${config.apiServer}/delta/streaming`);
       expect(request.origOpts.qs).toEqual({ cursor: 'deltacursor0' });
 
       const response = createResponse(200);
@@ -72,7 +73,7 @@ describe('Delta', () => {
       const { request } = stream;
 
       expect(request.origOpts.method).toBe('GET');
-      expect(request.origOpts.path).toBe('/delta/streaming');
+      expect(request.origOpts.url).toBe(`${config.apiServer}/delta/streaming`);
       expect(request.origOpts.qs).toEqual({
         cursor: 'deltacursor0',
         view: 'expanded',
@@ -179,7 +180,9 @@ describe('Delta', () => {
       expect(request.abort.mock.calls.length).toEqual(1);
       expect(stream.request).not.toBe(request);
       // The new request should be using the last delta cursor received prior to timeout.
-      expect(stream.request.origOpts.path).toBe('/delta/streaming');
+      expect(stream.request.origOpts.url).toBe(
+        `${config.apiServer}/delta/streaming`
+      );
       expect(stream.request.origOpts.qs).toEqual({ cursor: 'deltacursor1' });
 
       stream.close();

--- a/__tests__/file-spec.js
+++ b/__tests__/file-spec.js
@@ -160,7 +160,6 @@ describe('File', () => {
       testContext.file.download().catch(() => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           path: '/files/fileId/download',
-          encoding: null,
           downloadRequest: true,
         });
         done();

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -34,8 +34,8 @@ export default class File extends RestfulModel {
     return this.connection
       .request({
         method: 'POST',
-        json: false,
         path: `/${File.collectionName}`,
+        json: false,
         formData: {
           file: {
             value: this.data,
@@ -73,7 +73,6 @@ export default class File extends RestfulModel {
     return this.connection
       .request({
         path: `/files/${this.id}/download`,
-        encoding: null,
         downloadRequest: true,
       })
       .then(response => {

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -385,9 +385,9 @@ export default class RestfulModelCollection<T extends RestfulModel> {
 
   _getModelCollection(
     params: { [key: string]: any },
-    offset?: number,
-    limit?: number,
-    path?: string
+    offset: number,
+    limit: number,
+    path: string
   ): Promise<T[]> {
     return this.connection
       .request({

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -1,6 +1,6 @@
 import request from 'request';
 import * as config from './config';
-import NylasConnection from './nylas-connection';
+import NylasConnection, { RequestOptions } from './nylas-connection';
 import ManagementAccount from './models/management-account';
 import Account from './models/account';
 import Connect from './models/connect';
@@ -103,7 +103,7 @@ class Nylas {
     }
 
     const connection = new NylasConnection(null, { clientId: this.clientId });
-    const requestOptions: { [key: string]: any } = {
+    const requestOptions: RequestOptions = {
       path: `/a/${this.clientId}`,
     };
 


### PR DESCRIPTION
Currently types are specified as weak type `{[string]: any }`. Such type
make it quite hard to replace deprecated "request" with something else
(I'm planning to use node-fetch).  In this diff I specified all fields
explicitly and made `path` a mandatory field.

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.