### PR TITLE
typing fixes

### DIFF
--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -29,18 +29,18 @@ export default class NylasConnection {
   accessToken: string | null | undefined;
   clientId: string | null | undefined;
 
-  threads = new RestfulModelCollection(Thread, this);
-  contacts = new ContactRestfulModelCollection(this);
-  messages = new RestfulModelCollection(Message, this);
-  drafts = new RestfulModelCollection(Draft, this);
-  files = new RestfulModelCollection(File, this);
-  calendars = new CalendarRestfulModelCollection(this);
-  jobStatuses = new RestfulModelCollection(JobStatus, this);
-  events = new RestfulModelCollection(Event, this);
-  resources = new RestfulModelCollection(Resource, this);
+  threads: RestfulModelCollection<Thread> = new RestfulModelCollection(Thread, this);
+  contacts: ContactRestfulModelCollection<Contact> = new ContactRestfulModelCollection(this);
+  messages: RestfulModelCollection<Message> = new RestfulModelCollection(Message, this);
+  drafts: RestfulModelCollection<Draft> = new RestfulModelCollection(Draft, this);
+  files: RestfulModelCollection<File> = new RestfulModelCollection(File, this);
+  calendars: CalendarRestfulModelCollection<Calendar> = new CalendarRestfulModelCollection(this);
+  jobStatuses: RestfulModelCollection<JobStatus> = new RestfulModelCollection(JobStatus, this);
+  events: RestfulModelCollection<Event> = new RestfulModelCollection(Event, this);
+  resources: RestfulModelCollection<Resource> = new RestfulModelCollection(Resource, this);
   deltas = new Delta(this);
-  labels = new RestfulModelCollection(Label, this);
-  folders = new RestfulModelCollection(Folder, this);
+  labels: RestfulModelCollection<Label> = new RestfulModelCollection(Label, this);
+  folders: RestfulModelCollection<Folder> = new RestfulModelCollection(Folder, this);
   account = new RestfulModelInstance(Account, this);
 
   constructor(


### PR DESCRIPTION
Fixing a user-reported issue where `nylas.drafts.build({})` was returning the `RestfulModel` type, not the `Draft` type

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.