### PR TITLE
Migrate exchangeCodeForToken to node-fetch

### DIFF
--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -167,7 +167,7 @@ describe('Nylas', () => {
         Nylas.exchangeCodeForToken(
           'code-from-server',
           (returnedError, accessToken) => {
-            expect(returnedError).toBe(error);
+            expect(returnedError).toEqual(error);
             done();
           }
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1353,6 +1353,29 @@
       "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/request": {
       "version": "2.48.4",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
@@ -5760,6 +5783,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "JSONStream": "^1.3.5",
     "backoff": "^2.5.0",
+    "node-fetch": "^2.6.1",
     "request": "^2.88.0"
   },
   "devDependencies": {
@@ -54,6 +55,7 @@
     "@babel/preset-env": "^7.3.1",
     "@types/backoff": "^2.5.1",
     "@types/jest": "^25.1.4",
+    "@types/node-fetch": "^2.5.8",
     "@types/request": "^2.48.4",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -156,10 +156,11 @@ class Nylas {
           return body['access_token'];
         },
         error => {
+          const newError = new Error(error.message);
           if (callback) {
-            callback(error);
+            callback(newError);
           }
-          throw error;
+          throw newError;
         }
       );
   }


### PR DESCRIPTION
Ref https://github.com/nylas/nylas-nodejs/issues/174

Migrating whole library from "request" at once would be quite massive.
In this diff I migrated only exchangeCodeForToken to figure out how to
test and install dependencies.

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.