### PR TITLE
Migrate delta streaming to node-fetch

### DIFF
--- a/__tests__/delta-spec.js
+++ b/__tests__/delta-spec.js
@@ -1,6 +1,15 @@
+jest.mock('node-fetch', () => {
+  const { Request, Response, Headers } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  fetch.Headers = Headers;
+  return fetch;
+});
+
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
-
+import fetch, { Response } from 'node-fetch';
 import * as config from '../src/config.ts';
 import Delta from '../src/models/delta';
 import NylasConnection from '../src/nylas-connection';
@@ -16,18 +25,7 @@ describe('Delta', () => {
   });
 
   describe('startStream (delta streaming)', () => {
-    const createRequest = requestOpts => {
-      const request = new EventEmitter();
-      request.origOpts = requestOpts;
-      request.abort = jest.fn();
-      return request;
-    };
-
-    const createResponse = statusCode => {
-      const response = new PassThrough();
-      response.statusCode = statusCode;
-      return response;
-    };
+    config.setApiServer('http://nylas.com');
 
     // Listens to the 'delta' event on the stream and pushes them to the returned array.
     const observeDeltas = stream => {
@@ -36,62 +34,57 @@ describe('Delta', () => {
       return deltas;
     };
 
-    test('start and close stream', () => {
-      const stream = testContext.delta._startStream(
-        createRequest,
-        'deltacursor0'
+    test('start and close stream', async () => {
+      fetch.mockImplementation(() =>
+        Promise.resolve(new Response(new PassThrough(), { status: 200 }))
       );
-      const { request } = stream;
+      const stream = await testContext.delta.startStream('deltacursor0');
+      const { request, controller } = stream.requestInfo;
 
-      expect(request.origOpts.method).toBe('GET');
-      expect(request.origOpts.url).toBe(`${config.apiServer}/delta/streaming`);
-      expect(request.origOpts.qs).toEqual({ cursor: 'deltacursor0' });
+      expect(request.method).toBe('GET');
+      expect(request.url).toBe(
+        `${config.apiServer}/delta/streaming?cursor=deltacursor0`
+      );
 
-      const response = createResponse(200);
-      request.emit('response', response);
-
-      expect(request.abort.mock.calls.length).toEqual(0);
+      expect(controller.signal.aborted).toEqual(false);
       stream.close();
-      expect(request.abort.mock.calls.length).toEqual(1);
-      expect(stream.request).toEqual(undefined);
+      expect(controller.signal.aborted).toEqual(true);
+      expect(stream.requestInfo).toEqual(undefined);
 
       // Make sure the stream doesn't auto-restart if explicitly closed.
       jest.runTimersToTime(Delta.streamingTimeoutMs + 500);
-      expect(stream.request).toEqual(undefined);
+      expect(stream.requestInfo).toEqual(undefined);
     });
 
-    test('passes the correct params to the request', () => {
-      const stream = testContext.delta._startStream(
-        createRequest,
-        'deltacursor0',
-        {
-          expanded: true,
-          includeTypes: ['thread', 'message'],
-          excludeTypes: ['event'],
-        }
+    test('passes the correct params to the request', async () => {
+      fetch.mockImplementation(() =>
+        Promise.resolve(new Response(new PassThrough(), { status: 200 }))
       );
-      const { request } = stream;
-
-      expect(request.origOpts.method).toBe('GET');
-      expect(request.origOpts.url).toBe(`${config.apiServer}/delta/streaming`);
-      expect(request.origOpts.qs).toEqual({
-        cursor: 'deltacursor0',
-        view: 'expanded',
-        include_types: 'thread,message',
-        exclude_types: 'event',
+      const stream = await testContext.delta.startStream('deltacursor0', {
+        expanded: true,
+        includeTypes: ['thread', 'message'],
+        excludeTypes: ['event'],
       });
+      const { request } = stream.requestInfo;
+
+      expect(request.method).toBe('GET');
+      const search = [
+        'view=expanded',
+        'cursor=deltacursor0',
+        'exclude_types=event',
+        `include_types=thread%2Cmessage`,
+      ].join('&');
+      expect(request.url).toBe(`${config.apiServer}/delta/streaming?${search}`);
     });
 
-    test('stream response parsing', () => {
-      const stream = testContext.delta._startStream(
-        createRequest,
+    test('stream response parsing', async () => {
+      const response = new Response(new PassThrough(), { status: 200 });
+      fetch.mockImplementation(() => Promise.resolve(response));
+      const stream = await testContext.delta.startStream(
         'deltacursor0'
       );
-      const { request } = stream;
       const deltas = observeDeltas(stream);
 
-      const response = createResponse(200);
-      request.emit('response', response);
       expect(deltas).toEqual([]);
       expect(stream.cursor).toEqual('deltacursor0');
 
@@ -103,23 +96,21 @@ describe('Delta', () => {
         id: 'deltaid1',
       };
 
-      response.write(JSON.stringify(delta1));
+      response.body.write(JSON.stringify(delta1));
       expect(deltas).toEqual([delta1]);
       expect(stream.cursor).toEqual('deltacursor1');
 
       stream.close();
     });
 
-    test('stream response parsing, delta split across data packets', () => {
-      const stream = testContext.delta._startStream(
-        createRequest,
+    test('stream response parsing, delta split across data packets', async () => {
+      const response = new Response(new PassThrough(), { status: 200 });
+      fetch.mockImplementation(() => Promise.resolve(response));
+      const stream = await testContext.delta.startStream(
         'deltacursor0'
       );
-      const { request } = stream;
       const deltas = observeDeltas(stream);
 
-      const response = createResponse(200);
-      request.emit('response', response);
       expect(deltas).toEqual([]);
       expect(stream.cursor).toEqual('deltacursor0');
 
@@ -133,57 +124,53 @@ describe('Delta', () => {
       const deltaStr = JSON.stringify(delta1);
 
       // Partial data packet will not result in a delta yet...
-      response.write(deltaStr.substring(0, 20));
+      response.body.write(deltaStr.substring(0, 20));
       expect(deltas).toEqual([]);
       expect(stream.cursor).toEqual('deltacursor0');
 
       // ...now the rest of the delta comes in, and there should be a delta object.
-      response.write(deltaStr.substring(20));
+      response.body.write(deltaStr.substring(20));
       expect(deltas).toEqual([delta1]);
       expect(stream.cursor).toEqual('deltacursor1');
 
       stream.close();
     });
 
-    test('stream timeout and auto-restart', () => {
-      const stream = testContext.delta._startStream(
-        createRequest,
+    test('stream timeout and auto-restart', async () => {
+      const response = new Response(new PassThrough(), { status: 200 });
+      fetch.mockImplementation(() => Promise.resolve(response));
+      const stream = await testContext.delta.startStream(
         'deltacursor0'
       );
-      const { request } = stream;
+      const requestInfo = stream.requestInfo
+      const { request, controller } = requestInfo;
 
-      const response = createResponse(200);
-      request.emit('response', response);
       expect(stream.cursor).toEqual('deltacursor0');
 
-      const expectRequestNotAborted = request =>
-        expect(request.abort.calls.length).toEqual(0);
-
       // Server sends a heartbeat every 5 seconds.
-      response.write('\n');
+      response.body.write('\n');
       jest.runTimersToTime(5000);
-      expect(request.abort.mock.calls.length).toEqual(0);
-      response.write('\n');
-      expect(request.abort.mock.calls.length).toEqual(0);
+      expect(controller.signal.aborted).toEqual(false);
+      response.body.write('\n');
+      expect(controller.signal.aborted).toEqual(false);
 
       // Actual response packets also reset the timeout.
       jest.runTimersToTime(5000);
       const delta1 = { cursor: 'deltacursor1' };
-      response.write(JSON.stringify(delta1));
+      response.body.write(JSON.stringify(delta1));
       expect(stream.cursor).toEqual('deltacursor1');
       jest.runTimersToTime(5500);
-      expect(request.abort.mock.calls.length).toEqual(0);
+      expect(controller.signal.aborted).toEqual(false);
 
       // If the timeout has elapsed since the last data received, the stream is restarted.
       jest.runTimersToTime(Delta.streamingTimeoutMs);
       // The old request should have been aborted, and a new request created.
-      expect(request.abort.mock.calls.length).toEqual(1);
-      expect(stream.request).not.toBe(request);
+      expect(controller.signal.aborted).toEqual(true);
+      expect(stream.requestInfo).not.toBe(requestInfo);
       // The new request should be using the last delta cursor received prior to timeout.
-      expect(stream.request.origOpts.url).toBe(
-        `${config.apiServer}/delta/streaming`
+      expect(stream.requestInfo.request.url).toBe(
+        `${config.apiServer}/delta/streaming?cursor=deltacursor1`
       );
-      expect(stream.request.origOpts.qs).toEqual({ cursor: 'deltacursor1' });
 
       stream.close();
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1353,6 +1353,29 @@
       "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/request": {
       "version": "2.48.4",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
@@ -1536,6 +1559,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "6.3.0",
@@ -2688,6 +2719,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -5760,6 +5796,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   "license": "MIT",
   "dependencies": {
     "JSONStream": "^1.3.5",
+    "abort-controller": "^3.0.0",
     "backoff": "^2.5.0",
+    "node-fetch": "^2.6.1",
     "request": "^2.88.0"
   },
   "devDependencies": {
@@ -54,6 +56,7 @@
     "@babel/preset-env": "^7.3.1",
     "@types/backoff": "^2.5.1",
     "@types/jest": "^25.1.4",
+    "@types/node-fetch": "^2.5.8",
     "@types/request": "^2.48.4",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",


### PR DESCRIPTION
Ref https://github.com/nylas/nylas-nodejs/issues/174 https://github.com/nylas/nylas-nodejs/pull/214

Another migration example with node streams. Also added abort-controller polyfill and getRequest analog of requestOptions method in nylas connection

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.