### PR TITLE
Pass error message

### DIFF
--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -159,9 +159,6 @@ module.exports = class NylasConnection {
           }
           if (response.statusCode) {
             error.statusCode = response.statusCode;
-            if(!('message' in error)){
-              error.message = response.message;
-            }
           }
           return reject(error);
         } else {

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -159,6 +159,9 @@ module.exports = class NylasConnection {
           }
           if (response.statusCode) {
             error.statusCode = response.statusCode;
+            if(!('message' in error)){
+              error.message = response.message;
+            }
           }
           return reject(error);
         } else {

--- a/src/nylas-connection.js
+++ b/src/nylas-connection.js
@@ -159,6 +159,9 @@ module.exports = class NylasConnection {
           }
           if (response.statusCode) {
             error.statusCode = response.statusCode;
+            if (!('message' in error)) {
+              error.message = response.message;
+            }
           }
           return reject(error);
         } else {


### PR DESCRIPTION
Just wanted to pass along the error message generically in our SDK if customers come upon them.
Looks like we only pass status code.

For context, a customer is using native auth and is only seeing a 401.
However, in our authentication example(which just uses a regular request/not the SDK), we're able to see the full stack trace.

```
Unhandled rejection Error: Could not connect to Nylas. Error: Could not fetch Nylas code: 401 - "Nylas_Error: You've entered invalid credentials.  Provider_Error: Wrong username or password for https://eas.outlook.com/EWS/Exchange.asmx"
    at /Users/terenceyang/nylas-nodejs/example/authentication/auth.js:38:9
    at tryCatcher (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues (/Users/terenceyang/nylas-nodejs/example/authentication/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (internal/timers.js:458:21)
```


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.