### PR TITLE
[58040] Added support for event metadata

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -27,6 +27,7 @@ export default class Event extends RestfulModel {
     rrule: string[];
     timezone: string;
   };
+  metadata?: object;
 
   get start() {
     const start =
@@ -178,5 +179,8 @@ Event.attributes = {
   }),
   recurrence: Attributes.Object({
     modelKey: 'recurrence',
+  }),
+  metadata: Attributes.Object({
+    modelKey: 'metadata',
   })
 };


### PR DESCRIPTION
The Nylas Calendar API has a new beta feature of adding a new [metadata field to calendar events](https://www.nylas.com/blog/event-metadata). This PR makes the feature available via the Nylas Node.js SDK. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.