### PR TITLE
[59911] Add support for querying event metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+- Add `metadata` field in the Event model to support new event metadata
+- Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`
+
 ### 5.3.2 / 2020-01-11
 * Typing fixes to nylas.drafts and other RestfulModelCollections
 

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -1,6 +1,3 @@
-import request from 'request';
-
-import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import Event from '../src/models/event';
 
@@ -415,6 +412,33 @@ describe('Event', () => {
             participants: [],
             read_only: undefined,
             status: undefined,
+          },
+          qs: {},
+          path: '/events',
+        });
+        done();
+      });
+    });
+
+    test('should create an event with a metadata object', done => {
+      testContext.event.metadata = {'hello': 'world'};
+      testContext.event.save().then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            id: undefined,
+            object: 'event',
+            account_id: undefined,
+            calendar_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            location: undefined,
+            when: undefined,
+            _start: undefined,
+            _end: undefined,
+            participants: [],
+            metadata: {'hello': 'world'}
           },
           qs: {},
           path: '/events',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -27,6 +27,7 @@ export default class Event extends RestfulModel {
     rrule: string[];
     timezone: string;
   };
+  metadata?: object;
 
   get start() {
     const start =
@@ -178,5 +179,8 @@ Event.attributes = {
   }),
   recurrence: Attributes.Object({
     modelKey: 'recurrence',
+  }),
+  metadata: Attributes.Object({
+    modelKey: 'metadata',
   })
 };

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -70,6 +70,7 @@ export default class NylasConnection {
       url: `${config.apiServer}${options.path}`,
       headers: options.headers || {},
       json: options.json == null ? true : options.json,
+      useQuerystring: true,
     };
 
     if (options.downloadRequest) {

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -93,6 +93,16 @@ export default class NylasConnection {
         }
         delete newOptions.qs.expanded;
       }
+
+      // The API understands a metadata_pair filter in the form of:
+      // <key>:<value>
+      if (newOptions.qs.metadata_pair != null) {
+        const new_metadata_pair = []
+        for (const item in newOptions.qs.metadata_pair) {
+          new_metadata_pair.push(`${item}:${newOptions.qs.metadata_pair[item]}`)
+        }
+        newOptions.qs.metadata_pair = new_metadata_pair;
+      }
     }
 
     const user =


### PR DESCRIPTION
# Description 
#227 added support for event metadata, this PR enhances this feature and allows for a user to query metadata using either the `metadata_key`, or `metadata_value`, or `metadata_pair` parameters.

# Usage
Adding a metadata object is simple. Add the object under the `metadata` key when creating an event:
```
const event = nylas.events.build({
  title: 'New Years Party!',
  calendarId: CALENDAR_ID,
  when: { start_time: 1546290000, end_time: 1546300800 },
  participants: [{ email: 'swag@nylas.com', name: 'My Nylas Friend' }],
  location: 'My House!',
  metadata: {
      'event_type': 'gathering'
  }
});
```

To query events based on metadata, you can filter on three different parameters:
- `metadata_key` (string or array) to filter based on the keys within the metadata object
- `metadata_value` (string or array) to filter based on the value within the metadata object
- `metadata_pair` (object) to filter based on the key-value pairs within the metadata object

These filters can be passed in as parameters:
`events = nylas.events.list({calendar_id: CALENDAR_ID, metadata_pair:{'event_type': 'gathering'}})`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.