### PR TITLE
[57257] [Issue #220] Fix Passing undefined fileids value to draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,27 @@
 # Changelog
 
-### Unreleased
-- Add `metadata` field in the Event model to support new event metadata
-- Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`
+### 5.4.0 / 2020-05-21
+* Add `metadata` field in the Event model to support new Event metadata feature
+* Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`
+* Updated dependencies `lodash`, `y18n`, and `pug` to the latest stable version
+
+### 5.3.3 / 2020-03-26
+* Pass error message from the API to the SDK user
+* Migrate `delta` streaming to `node-fetch`
+* Migrate `exchangeCodeForToken` to `node-fetch`
 
 ### 5.3.2 / 2020-01-11
-* Typing fixes to nylas.drafts and other RestfulModelCollections
+* Typing fixes to `nylas.drafts` and other `RestfulModelCollections`
 
 ### 5.3.1 / 2020-11-20
 * Drop async dependency for smaller package fingerprint. Async is replaced with promises.
-* Remove circular dependency in nylas-connection.ts
+* Remove circular dependency in `nylas-connection.ts`
 * Update readme with syntax highlighting
 
 ### 5.3.0 / 2020-09-23
-* Fix bug where setting event.start and event.end did not set event.when if event.when didn't exist
+* Fix bug where setting `event.start` and `event.end` did not set `event.when` if `event.when` didn't exist
 * Refactor parameter ordering in `find()` and `draft.send()` methods [backwards compatible]
-* Add JobStatus model and collection
+* Add `JobStatus` model and collection
 
 ### 5.2.0 / 2020-07-27
 * Implement support for GET /contacts/groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error
+
 ### 5.4.0 / 2020-05-21
 * Add `metadata` field in the Event model to support new Event metadata feature
 * Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -16,7 +16,7 @@ export default class Draft extends Message {
       throw Error('toJSON() cannot be called for raw MIME drafts');
     }
     const json = super.toJSON();
-    json.file_ids = this.fileIds();
+    json.file_ids = super.fileIds();
     json.object = 'draft';
 
     return json;

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -49,7 +49,7 @@ export default class Message extends RestfulModel {
   }
 
   fileIds() {
-    return (this.files || []).map(file => file.id);
+    return this.files ? this.files.map(file => file.id) : [];
   }
 
   getRaw() {


### PR DESCRIPTION
# Description
This PR fixes #220, where an error would be thrown when trying to save a new `drafts` object with an undefined `fieldsids` attribute set. This was caused because we were calling a parent function by `this.` instead of `super.`. We also found and fixed a subsequent issue where if the filesids are not set, the parent function might call `.map` on an undefined variable, throwing an error.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.