### PR TITLE
[60372] Return better error details from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error
 * Replaced deprecated `request` library with `node-fetch`
+* Add custom error class `NylasApiError` to add more error details returned from the API
 
 ### 5.4.0 / 2020-05-21
 * Add `metadata` field in the Event model to support new Event metadata feature

--- a/src/models/NylasApiError.ts
+++ b/src/models/NylasApiError.ts
@@ -1,0 +1,22 @@
+export default class NylasApiError extends Error {
+    statusCode: number;
+    missingFields?: string[];
+    serverError?: string;
+
+    constructor(status_code: number, type: string, message: string) {
+        super(message);
+        this.statusCode = status_code;
+        this.name = type;
+    }
+
+    toString = () => {
+        return {
+            type: this.name,
+            message: this.message,
+            statusCode: this.statusCode,
+            missingFields: this.missingFields,
+            serverError: this.serverError,
+            stack: this.stack
+        }
+    }
+}

--- a/src/models/NylasApiError.ts
+++ b/src/models/NylasApiError.ts
@@ -45,16 +45,4 @@ export default class NylasApiError extends Error {
         this.name = this.errorMapping[statusCode];
         this.type = type;
     }
-
-    toString = () => {
-        return {
-            name: this.name,
-            message: this.message,
-            statusCode: this.statusCode,
-            type: this.type,
-            missingFields: this.missingFields,
-            serverError: this.serverError,
-            stack: this.stack
-        }
-    }
 }

--- a/src/models/NylasApiError.ts
+++ b/src/models/NylasApiError.ts
@@ -1,19 +1,57 @@
+/**
+ * Extended Error class for errors returned from the Nylas API
+ *
+ * Properties:
+ * name - The description of the HTTP status code
+ * message - The error message returned from the Nylas API payload
+ * statusCode - The status code returned from the API call
+ * type - The type of error returned from the Nylas API payload
+ * stack - The Error stacktrace
+ * missingFields (optional) - The fields that were missing in the call returned from the Nylas API payload
+ * serverError (optional) - The error returned by the provider returned from the Nylas API payload
+ */
 export default class NylasApiError extends Error {
     statusCode: number;
+    type: string;
     missingFields?: string[];
     serverError?: string;
 
-    constructor(status_code: number, type: string, message: string) {
+    /**
+     * Mapping of HTTP status codes to error descriptions
+     *
+     * For more details on what each status code means head to
+     * https://developer.nylas.com/docs/developer-tools/api/errors/
+     */
+    errorMapping: {[statusCode: number]: string} = {
+        400: "Bad Request",
+        401: "Unauthorized",
+        402: "Request Failed or Payment Required",
+        403: "Forbidden",
+        404: "Not Found",
+        405: "Method Not Allowed",
+        410: "Gone",
+        418: "I'm a Teapot",
+        422: "Sending Error",
+        429: "Too Many Requests",
+        500: "Server Error",
+        502: "Server Error",
+        503: "Server Error",
+        504: "Server Error"
+    }
+
+    constructor(statusCode: number, type: string, message: string) {
         super(message);
-        this.statusCode = status_code;
-        this.name = type;
+        this.statusCode = statusCode;
+        this.name = this.errorMapping[statusCode];
+        this.type = type;
     }
 
     toString = () => {
         return {
-            type: this.name,
+            name: this.name,
             message: this.message,
             statusCode: this.statusCode,
+            type: this.type,
             missingFields: this.missingFields,
             serverError: this.serverError,
             stack: this.stack

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -41,6 +41,14 @@ export type FormDataType = {
   options?: { [key: string]: any } | AppendOptions;
 }
 
+export type NylasApiError = {
+  status_code: number;
+  type: string;
+  message: string;
+  missing_fields?: string[];
+  server_error?: string;
+}
+
 export default class NylasConnection {
   accessToken: string | null | undefined;
   clientId: string | null | undefined;
@@ -187,14 +195,16 @@ export default class NylasConnection {
 
         if (response.status > 299) {
           return response.json().then(body => {
-            const error = new Error(body.message);
+            const error: NylasApiError = {
+              status_code: response.status,
+              type: body.type,
+              message: body.message
+            }
             if (body.missing_fields) {
-              error.message = `${body.message}: ${body.missing_fields}`;
+              error.missing_fields = body.missing_fields;
             }
             if (body.server_error) {
-              error.message = `${error.message} (Server Error:
-              ${body.server_error}
-            )`;
+              error.server_error = body.server_error;
             }
             return reject(error);
           });

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -19,6 +19,7 @@ import Resource from './models/resource';
 import Delta from './models/delta';
 import {Folder, Label} from './models/folder';
 import FormData, {AppendOptions} from "form-data";
+import NylasApiError from "./models/NylasApiError";
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -39,14 +40,6 @@ export type RequestOptions = {
 export type FormDataType = {
   value: any;
   options?: { [key: string]: any } | AppendOptions;
-}
-
-export type NylasApiError = {
-  status_code: number;
-  type: string;
-  message: string;
-  missing_fields?: string[];
-  server_error?: string;
 }
 
 export default class NylasConnection {
@@ -195,16 +188,12 @@ export default class NylasConnection {
 
         if (response.status > 299) {
           return response.json().then(body => {
-            const error: NylasApiError = {
-              status_code: response.status,
-              type: body.type,
-              message: body.message
-            }
+            const error = new NylasApiError(response.status, body.type, body.message);
             if (body.missing_fields) {
-              error.missing_fields = body.missing_fields;
+              error.missingFields = body.missing_fields;
             }
             if (body.server_error) {
-              error.server_error = body.server_error;
+              error.serverError = body.server_error;
             }
             return reject(error);
           });


### PR DESCRIPTION
# Description
Previously, we would only return generally the error message. Now we return a custom error object (that extends `Error`) that properly stores all of the error values we get back from the API and sets them in a way that is more native than just returning a string.

# Usage
The new `NylasApiError` class extends the `Error` class and both sets the build-in properties of Error and extends the error class to provide more values if needed. The following properties are made availalbe by the class:

- `name` (string): The name of the error, derived from the [API Errors page](https://developer.nylas.com/docs/developer-tools/api/errors/) (e.g. `Bad Request`)
- `message` (string): The error message returned from the API (e.g. `No recipients specified`)
- `statusCode` (number): The status code returned from the API call (e.g. `400`)
- `type` (string): The type of error returned from the API (e.g. `invalid_request_error`)
- `missingFields` (string[]): The array of fields that were missing in the call, if applicable (e.g. `["name", "email"]`)
- `serverError` (string): The error returned by the provider (e.g. `interaction_required`)
- `stack` (string): The stacktrace from JavaScript

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.