### PR TITLE
[61828] Fix typing for classes that extend `RestfulModelCollection` or `RestfulModelInstance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error
 * Replaced deprecated `request` library with `node-fetch`
 * Add custom error class `NylasApiError` to add more error details returned from the API
+* Add support for read only fields
+* Enabled Nylas API v2.2 support
+* Fix typings for classes that extend `RestfulModelCollection` or `RestfulModelInstance`
 
 ### 5.4.0 / 2020-05-21
 * Add `metadata` field in the Event model to support new Event metadata feature

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -3,7 +3,7 @@ import NylasConnection from '../nylas-connection';
 import RestfulModel from './restful-model';
 import RestfulModelCollection from './restful-model-collection';
 
-export default class CalendarRestfulModelCollection<Calendar> extends RestfulModelCollection<RestfulModel> {
+export default class CalendarRestfulModelCollection extends RestfulModelCollection<Calendar> {
   connection: NylasConnection;
   modelClass: typeof Calendar;
 

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -3,7 +3,7 @@ import NylasConnection from '../nylas-connection';
 import RestfulModel from './restful-model';
 import RestfulModelCollection from './restful-model-collection';
 
-export default class ContactRestfulModelCollection<Contact> extends RestfulModelCollection<RestfulModel> {
+export default class ContactRestfulModelCollection extends RestfulModelCollection<Contact> {
   connection: NylasConnection;
   modelClass: typeof Contact;
 

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -1,7 +1,7 @@
 import NylasConnection from '../nylas-connection';
 import RestfulModel from './restful-model';
 
-export default class RestfulModelInstance {
+export default class RestfulModelInstance<T extends RestfulModel> {
   connection: NylasConnection;
   modelClass: typeof RestfulModel;
 
@@ -20,7 +20,7 @@ export default class RestfulModelInstance {
     return `/${this.modelClass.endpointName}`;
   }
 
-  get(params: { [key: string]: any } = {}) {
+  get(params: { [key: string]: any } = {}): Promise<T> {
     return this.connection
       .request({
         method: 'GET',
@@ -28,7 +28,7 @@ export default class RestfulModelInstance {
         qs: params,
       })
       .then(json => {
-        const model = new this.modelClass(this.connection, json);
+        const model = new this.modelClass(this.connection, json) as T;
         return Promise.resolve(model);
       });
   }

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -8,11 +8,9 @@ import ContactRestfulModelCollection from './models/contact-restful-model-collec
 import RestfulModelInstance from './models/restful-model-instance';
 import Account from './models/account';
 import Thread from './models/thread';
-import {Contact} from './models/contact';
 import Message from './models/message';
 import Draft from './models/draft';
 import File from './models/file';
-import Calendar from './models/calendar';
 import Event from './models/event';
 import JobStatus from './models/job-status';
 import Resource from './models/resource';
@@ -47,11 +45,11 @@ export default class NylasConnection {
   clientId: string | null | undefined;
 
   threads: RestfulModelCollection<Thread> = new RestfulModelCollection(Thread, this);
-  contacts: ContactRestfulModelCollection<Contact> = new ContactRestfulModelCollection(this);
+  contacts: ContactRestfulModelCollection = new ContactRestfulModelCollection(this);
   messages: RestfulModelCollection<Message> = new RestfulModelCollection(Message, this);
   drafts: RestfulModelCollection<Draft> = new RestfulModelCollection(Draft, this);
   files: RestfulModelCollection<File> = new RestfulModelCollection(File, this);
-  calendars: CalendarRestfulModelCollection<Calendar> = new CalendarRestfulModelCollection(this);
+  calendars: CalendarRestfulModelCollection = new CalendarRestfulModelCollection(this);
   jobStatuses: RestfulModelCollection<JobStatus> = new RestfulModelCollection(JobStatus, this);
   events: RestfulModelCollection<Event> = new RestfulModelCollection(Event, this);
   resources: RestfulModelCollection<Resource> = new RestfulModelCollection(Resource, this);

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -56,7 +56,7 @@ export default class NylasConnection {
   deltas = new Delta(this);
   labels: RestfulModelCollection<Label> = new RestfulModelCollection(Label, this);
   folders: RestfulModelCollection<Folder> = new RestfulModelCollection(Folder, this);
-  account = new RestfulModelInstance(Account, this);
+  account: RestfulModelInstance<Account> =  new RestfulModelInstance(Account, this);
 
   constructor(
     accessToken: string | null | undefined,


### PR DESCRIPTION
# Description
Some classes were returning a generic type, rendering some calls and functionality useless. This PR aims at fixing this by properly setting the type of objects that that extend `RestfulModelCollection` or `RestfulModelInstance` to provide the user access to type-specific properties and methods.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.