### PR TITLE
[62051] Draft tracking object not being added to a pre-existing `draft` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix tracking object not being added to a pre-existing `draft` object
+* Removed `request` dependency and related import statements
 
 ### 5.5.0 / 2021-06-09
 * Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Unreleased
-* Fix tracking object not being added to an pre-existing `draft` object
+* Fix tracking object not being added to a pre-existing `draft` object
 
 ### 5.5.0 / 2021-06-09
 * Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-### 5.5.0 / 2021-06-09]
+### Unreleased
+* Fix tracking object not being added to an pre-existing `draft` object
+
+### 5.5.0 / 2021-06-09
 * Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error
 * Replaced deprecated `request` library with `node-fetch`
 * Add custom error class `NylasApiError` to add more error details returned from the API

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -157,6 +157,25 @@ describe('Draft', () => {
       });
     });
 
+    test('should send the draft JSON with the tracking object if the draft has an id and has a tracking object passed in', done => {
+      testContext.draft.id = 'id-1234';
+      testContext.draft.version = 2;
+      testContext.draft.send({"opens": true}).then(() => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'POST',
+          body: {
+            draft_id: 'id-1234',
+            version: 2,
+            tracking: {"opens": true}
+          },
+          path: '/send',
+          headers: {},
+          json: true,
+        });
+        done();
+      });
+    });
+
     test('should send the draft JSON if the draft has no id', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
@@ -192,7 +211,7 @@ describe('Draft', () => {
       });
     });
 
-    test('should send the draft JSON if the draft has no id and has a tracking object passed in as the second parameter', done => {
+    test('should send the draft JSON with the tracking object if the draft has no id and has a tracking object passed in as the second parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
       testContext.draft.send(null, {"opens": true}).then(() => {
@@ -228,7 +247,7 @@ describe('Draft', () => {
       });
     });
 
-    test('should send the draft JSON if the draft has a tracking object as the only parameter', done => {
+    test('should send the draft JSON with the tracking object if the draft has a tracking object as the only parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
       testContext.draft.send({"opens": true}).then(() => {
@@ -264,7 +283,7 @@ describe('Draft', () => {
       });
     });
 
-    test('should send the draft JSON if the draft has no id and has a tracking object passed in as the first parameter', done => {
+    test('should send the draft JSON with the tracking object if the draft has no id and has a tracking object passed in as the first parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
       testContext.draft.send({"opens": true}, (err, data) => {}).then(() => {

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -87,9 +87,9 @@ export default class Draft extends Message {
         };
       } else {
         body = this.saveRequestBody();
-        if (tracking) {
-          body['tracking'] = tracking;
-        }
+      }
+      if (tracking) {
+        body['tracking'] = tracking;
       }
     }
 


### PR DESCRIPTION
# Description
The Node SDK only added a tracking object to the payload if the draft was never "created" before (created in the Nylas API, as in the object was not `.save()` yet and does not have a draft ID), which is allowed according to the [Message Tracking documentation](https://developer.nylas.com/docs/developer-tools/webhooks/message-tracking/#enabling-tracking). However if the user has already created a `draft` object in the Nylas and tries to send it with a tracking object, it never gets added. This PR allows for a tracking object to be included in either case. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.