### PR TITLE
[62896] `undefined` returned when trying to download file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Fix tracking object not being added to a pre-existing `draft` object
 * Removed `request` dependency and related import statements
+* Fix `undefined` response when downloading file
 
 ### 5.5.0 / 2021-06-09
 * Fix bug where saving a `draft` object with an undefined `filesIds` would throw an error

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -75,16 +75,7 @@ export default class File extends RestfulModel {
         path: `/files/${this.id}/download`,
         downloadRequest: true,
       })
-      .then(response => {
-        let filename;
-        const file = { ...response.headers, body: response.body };
-        if ('content-disposition' in file) {
-          filename =
-            /filename=([^;]*)/.exec(file['content-disposition'])![1] ||
-            'filename';
-        } else {
-          filename = 'filename';
-        }
+      .then(file => {
         if (callback) {
           callback(null, file);
         }

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -94,7 +94,6 @@ export default class NylasConnection {
     }
     options.url = url;
 
-    // const headers: HeadersInit = new Headers(options.headers);
     const headers = {...options.headers}
     const user =
         options.path.substr(0, 3) === '/a/'
@@ -109,7 +108,6 @@ export default class NylasConnection {
     headers['Nylas-API-Version'] = SUPPORTED_API_VERSION;
     headers['Nylas-SDK-API-Version'] = SUPPORTED_API_VERSION;
     if (this.clientId != null) {
-      // headers.set('X-Nylas-Client-Id', this.clientId);
       headers['X-Nylas-Client-Id'] = this.clientId;
     }
     options.headers = headers;

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -197,7 +197,17 @@ export default class NylasConnection {
           });
         } else {
           if (options.downloadRequest) {
-            return resolve(response.body);
+            response.buffer().then(buffer => {
+              // Return an object with the headers and the body as a buffer
+              const fileDetails: { [key: string]: any } = {};
+              response.headers.forEach((v, k) => {
+                fileDetails[k] = v;
+              });
+              fileDetails['body'] = buffer;
+              return resolve(fileDetails);
+            }).catch(e => {
+              return reject(e);
+            })
           } else {
             return resolve(response.json());
           }


### PR DESCRIPTION
# Description
When downloading a file, the body returns `undefined`. This was due to a previous change when we cut over from the old `requests` library and moved to the `node-fetch` library. Test suite has also been updated to ensure that we have coverage for this in the future.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.