### PR TITLE
v5.5.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.5.1 / 2021-06-24
 * Fix tracking object not being added to a pre-existing `draft` object
 * Removed `request` dependency and related import statements
 * Fix `undefined` response when downloading file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description

New `nylas` v5.5.0 release bringing in the following fixes:
* Fix tracking object not being added to a pre-existing `draft` object (#241)
* Removed `request` dependency and related import statements (#240) 
* Fix `undefined` response when downloading file (#242)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.