### PR TITLE
Respect options.json a bit more to fix sending raw mime (fixes #246).

### DIFF
--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -122,7 +122,7 @@ export default class NylasConnection {
         }
       }
       options.body = fd;
-    } else if (options.body) {
+    } else if (options.body && options.json !== false) {
       options.body = JSON.stringify(options.body);
     }
 


### PR DESCRIPTION
Version 5.5 has a breaking change where it calls `JSON.stringify` on `options.body` regardless of `options.json`. This breaks the [send raw mime](https://developer.nylas.com/docs/developer-tools/sdk/javascript-sdk/#send-raw-mime) functionality. I document this in a bit more detail here: https://github.com/nylas/nylas-nodejs/issues/246

Checking to see if options.json is explicitly set to `false` seems pretty safe here (rather than make the condition `options.body && options.json` as that breaks some calendar unit tests even though it's probably a bit more semantically correct). It looks like this library use to do something similar: https://github.com/nylas/nylas-nodejs/commit/b995b4f4489c09e05f07c810772b7d816399fe4e#diff-2de4f9bb82a400d2734c75d30d64883eec745110373fcde2c3e46fea7d3eb325L229

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.