### PR TITLE
[63072] Fixed Jest test cases not respecting async methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Fixed Jest test cases not respecting async methods
+* Fixed issue with parsing raw MIME emails
+
 ### 5.5.1 / 2021-06-24
 * Fix tracking object not being added to a pre-existing `draft` object
 * Removed `request` dependency and related import statements

--- a/__tests__/account-spec.js
+++ b/__tests__/account-spec.js
@@ -1,6 +1,4 @@
-import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
-import Account from '../src/models/account';
 
 describe('account', () => {
   let testContext;
@@ -35,14 +33,14 @@ describe('account', () => {
   });
 
   test('account attributes should resolve', done => {
-    testContext.connection.account.get().then(function(account) {
+     testContext.connection.account.get().then(function(account) {
       expect(account.id).toBe('hecea680y4sborshkiraj17c');
       expect(account.emailAddress).toBe('jeremy@emmerge.com');
       expect(account.organizationUnit).toBe('folder');
       expect(account.provider).toBe('eas');
       expect(account.syncState).toBe('running');
       expect(account.linkedAt).toEqual(new Date(linkedAtNum * 1000));
+      done();
     });
-    done();
   });
 });

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -1,11 +1,25 @@
-import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import Calendar from '../src/models/calendar';
+import fetch from "node-fetch";
+import Nylas from "../src/nylas";
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
 
 describe('Calendar', () => {
   let testContext;
 
   beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
     const calendarJSON = {
@@ -20,97 +34,103 @@ describe('Calendar', () => {
       read_only: false,
       timezone: "America/Los_Angeles"
     };
-    testContext.connection.request = jest.fn(() => Promise.resolve(calendarJSON));
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => { return {
+      status: 200,
+      buffer: () => {
+        return Promise.resolve("body");
+      },
+      json: () => {
+        if(receivedBody === null) {
+          return Promise.resolve(calendarJSON);
+        }
+
+        const j = JSON.parse(receivedBody.toString());
+        if(!j.id) {
+          j.id = calendarJSON.id;
+        }
+        return Promise.resolve(j);
+      },
+      headers: new Map()
+    } };
+
+    fetch.mockImplementation(req =>
+        Promise.resolve(response(req.body))
+    );
     testContext.calendar = new Calendar(testContext.connection, calendarJSON);
   });
 
+  const sharedCalendarEvaluation = (calendar) => {
+    expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
+    expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
+    expect(calendar.isPrimary).toEqual(false);
+    expect(calendar.location).toEqual('Santa Monica, CA');
+    expect(calendar.name).toEqual('Holidays');
+    expect(calendar.object).toEqual('calendar');
+    expect(calendar.timezone).toEqual('America/Los_Angeles');
+    expect(calendar.readOnly).toEqual(false);
+    expect(calendar.jobStatusId).toEqual('48pp6ijzrxpw9jors9ylnsxnf');
+  }
+
   test('[SAVE] should do a POST request if the calendar has no id', done => {
-    expect.assertions(11);
+    expect.assertions(13);
     testContext.calendar.id = undefined;
     testContext.calendar.save().then((calendar) => {
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'POST',
-        body: {
-          name: 'Holidays',
-          description: 'All the holidays',
-          location: 'Santa Monica, CA',
-          timezone: 'America/Los_Angeles'
-        },
-        qs: {},
-        path: '/calendars',
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual('https://api.nylas.com/calendars');
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        name: 'Holidays',
+        description: 'All the holidays',
+        location: 'Santa Monica, CA',
+        timezone: 'America/Los_Angeles'
       });
-      expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
-      expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
+      sharedCalendarEvaluation(calendar);
       expect(calendar.description).toEqual('All the holidays');
-      expect(calendar.isPrimary).toEqual(false);
-      expect(calendar.location).toEqual('Santa Monica, CA');
-      expect(calendar.name).toEqual('Holidays');
-      expect(calendar.object).toEqual('calendar');
-      expect(calendar.timezone).toEqual('America/Los_Angeles');
-      expect(calendar.readOnly).toEqual(false);
-      expect(calendar.jobStatusId).toEqual('48pp6ijzrxpw9jors9ylnsxnf')
       done();
     });
   });
 
   test('[SAVE] should do a PUT request if the event has an id', done => {
-    expect.assertions(10);
+    expect.assertions(13);
     testContext.calendar.id = '8e570s302fdazx9zqwiuk9jqn';
     testContext.calendar.description = 'Updated description';
     testContext.calendar.save().then((calendar) => {
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'PUT',
-        body: {
-          name: 'Holidays',
-          description: 'Updated description',
-          location: 'Santa Monica, CA',
-          timezone: 'America/Los_Angeles'
-        },
-        qs: {},
-        path: '/calendars/8e570s302fdazx9zqwiuk9jqn',
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual('https://api.nylas.com/calendars/8e570s302fdazx9zqwiuk9jqn');
+      expect(options.method).toEqual('PUT');
+      expect(JSON.parse(options.body)).toEqual({
+        name: 'Holidays',
+        description: 'Updated description',
+        location: 'Santa Monica, CA',
+        timezone: 'America/Los_Angeles'
       });
-      expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
-      expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
-      expect(calendar.description).toEqual('All the holidays');
-      expect(calendar.isPrimary).toEqual(false);
-      expect(calendar.location).toEqual('Santa Monica, CA');
-      expect(calendar.name).toEqual('Holidays');
-      expect(calendar.object).toEqual('calendar');
-      expect(calendar.timezone).toEqual('America/Los_Angeles');
-      expect(calendar.readOnly).toEqual(false);
+      sharedCalendarEvaluation(calendar);
+      expect(calendar.description).toEqual('Updated description');
       done();
     });
   });
 
   test('[FIND] should use correct method and route', done => {
-    expect.assertions(10);
+    expect.assertions(12);
     testContext.connection.calendars.find('8e570s302fdazx9zqwiuk9jqn').then((calendar) => {
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'GET',
-        qs: {},
-        path: '/calendars/8e570s302fdazx9zqwiuk9jqn',
-      });
-      expect(calendar.id).toEqual('8e570s302fdazx9zqwiuk9jqn');
-      expect(calendar.accountId).toEqual('eof2wrhqkl7kdwhy9hylpv9o9');
-      expect(calendar.description).toEqual('All the holidays');
-      expect(calendar.isPrimary).toEqual(false);
-      expect(calendar.location).toEqual('Santa Monica, CA');
-      expect(calendar.name).toEqual('Holidays');
-      expect(calendar.object).toEqual('calendar');
-      expect(calendar.timezone).toEqual('America/Los_Angeles');
-      expect(calendar.readOnly).toEqual(false);
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual('https://api.nylas.com/calendars/8e570s302fdazx9zqwiuk9jqn');
+      expect(options.method).toEqual('GET');
+      expect(options.body).toBeUndefined();
+      sharedCalendarEvaluation(calendar);
       done();
     });
   });
 
   test('[GET job status] should use correct method and route', done => {
-    expect.assertions(1);
-    testContext.calendar.getJobStatus().then(calendar => {
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'GET',
-        qs: {},
-        path: '/job-statuses/48pp6ijzrxpw9jors9ylnsxnf',
-      });
+    expect.assertions(3);
+    testContext.calendar.getJobStatus().then(() => {
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual('https://api.nylas.com/job-statuses/48pp6ijzrxpw9jors9ylnsxnf');
+      expect(options.method).toEqual('GET');
+      expect(options.body).toBeUndefined();
       done();
     });
   });

--- a/__tests__/contact-restful-model-collection-spec.js
+++ b/__tests__/contact-restful-model-collection-spec.js
@@ -5,6 +5,14 @@ import NylasConnection from '../src/nylas-connection';
 import RestfulModelCollection from '../src/models/restful-model-collection';
 import { Group } from '../src/models/contact';
 
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
+
 describe('RestfulModelCollection', () => {
   let testContext;
   const testAccessToken = 'test-access-token';
@@ -13,63 +21,75 @@ describe('RestfulModelCollection', () => {
     Nylas.config({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
     });
     testContext = {};
     testContext.connection = new NylasConnection(testAccessToken, {
       clientId: 'foo',
     });
-    testContext.apiResponse = [{
+    jest.spyOn(testContext.connection, 'request');
+
+    const contactJSON = [{
       account_id: 'account123',
       id: 'group123',
       object: 'contact_group',
       name: 'name123',
       path: 'path123'
-    }];
+    }]
+
+    const response = {
+      status: 200,
+      buffer: () => {
+        return Promise.resolve("body");
+      },
+      json: () => {
+        return Promise.resolve(contactJSON);
+      },
+      headers: new Map()
+    };
+
+    fetch.mockImplementation(() =>
+        Promise.resolve(response)
+    );
   });
 
   describe('groups', () => {
     test('should call API with correct authentication', done => {
       expect.assertions(3);
 
-      fetch.Request = jest.fn((url, options) => {
-        expect(url.toString()).toEqual('https://api.nylas.com/contacts/groups');
+      return testContext.connection.contacts.groups().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/contacts/groups');
         expect(options.method).toEqual('GET');
         expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
         done();
       });
-
-      testContext.connection.contacts.groups();
     });
+
+    const evaluateContactGroup = (data) => {
+      expect(data[0].accountId).toBe('account123');
+      expect(data[0].id).toBe('group123');
+      expect(data[0].object).toBe('contact_group');
+      expect(data[0].name).toBe('name123');
+      expect(data[0].path).toBe('path123');
+      expect(data[0] instanceof Group).toBe(true);
+    }
 
     test('should call callback', done => {
       expect.assertions(7);
-      testContext.connection.request = jest.fn(() => Promise.resolve(testContext.apiResponse));
-
       const testCallback = (err, data) => {
         expect(err).toBe(null);
-        expect(data[0].accountId).toBe('account123');
-        expect(data[0].id).toBe('group123');
-        expect(data[0].object).toBe('contact_group');
-        expect(data[0].name).toBe('name123');
-        expect(data[0].path).toBe('path123');
-        expect(data[0] instanceof Group).toBe(true);
+        evaluateContactGroup(data);
         done();
       };
 
-      testContext.connection.contacts.groups(testCallback);
+      return testContext.connection.contacts.groups(testCallback);
     });
 
     test('should resolve to group object', done => {
       expect.assertions(6);
-      testContext.connection.request = jest.fn(() => Promise.resolve(testContext.apiResponse));
-
-      testContext.connection.contacts.groups().then(data => {
-        expect(data[0].accountId).toBe('account123');
-        expect(data[0].id).toBe('group123');
-        expect(data[0].object).toBe('contact_group');
-        expect(data[0].name).toBe('name123');
-        expect(data[0].path).toBe('path123');
-        expect(data[0] instanceof Group).toBe(true);
+      return testContext.connection.contacts.groups().then(data => {
+        evaluateContactGroup(data);
         done();
       });
     });

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -1,80 +1,105 @@
-import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import { Contact } from '../src/models/contact';
+import Nylas from "../src/nylas";
+import fetch from "node-fetch";
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
 
 describe('Contact', () => {
   let testContext;
 
   beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-    testContext.connection.request = jest.fn(() => {
-      return Promise.resolve();
-    });
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        buffer: () => {
+          return Promise.resolve("body");
+        },
+        json: () => {
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map()
+      }
+    };
+
+    fetch.mockImplementation(req =>
+        Promise.resolve(response(req.body))
+    );
     testContext.contact = new Contact(testContext.connection);
   });
 
   describe('save', () => {
     test('should do a POST request if the contact has no id', done => {
       testContext.contact.id = undefined;
-      testContext.contact.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            given_name: undefined,
-            middle_name: undefined,
-            surname: undefined,
-            suffix: undefined,
-            nickname: undefined,
-            birthday: undefined,
-            job_title: undefined,
-            manager_name: undefined,
-            company_name: undefined,
-            office_location: undefined,
-            notes: undefined,
-            picture_url: undefined,
-            emails: [],
-            im_addresses: [],
-            physical_addresses: [],
-            phone_numbers: [],
-            web_pages: [],
-            groups:[],
-            source: undefined,
-          },
-          qs: {},
-          path: '/contacts',
+      return testContext.contact.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/contacts');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          given_name: undefined,
+          middle_name: undefined,
+          surname: undefined,
+          suffix: undefined,
+          nickname: undefined,
+          birthday: undefined,
+          job_title: undefined,
+          manager_name: undefined,
+          company_name: undefined,
+          office_location: undefined,
+          notes: undefined,
+          picture_url: undefined,
+          emails: [],
+          im_addresses: [],
+          physical_addresses: [],
+          phone_numbers: [],
+          web_pages: [],
+          groups:[],
+          source: undefined,
         });
         done();
       });
     });
-    test('should do a POST request if the contact has no id', done => {
+    test('should do a PUT request if the contact has id', done => {
       testContext.contact.id = '1257';
-      testContext.contact.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'PUT',
-          body: {
-            given_name: undefined,
-            middle_name: undefined,
-            surname: undefined,
-            suffix: undefined,
-            nickname: undefined,
-            birthday: undefined,
-            job_title: undefined,
-            manager_name: undefined,
-            company_name: undefined,
-            office_location: undefined,
-            notes: undefined,
-            picture_url: undefined,
-            emails: [],
-            im_addresses: [],
-            physical_addresses: [],
-            phone_numbers: [],
-            web_pages: [],
-            groups:[],
-            source: undefined,
-          },
-          qs: {},
-          path: '/contacts/1257',
+      return testContext.contact.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/contacts/1257');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          given_name: undefined,
+          middle_name: undefined,
+          surname: undefined,
+          suffix: undefined,
+          nickname: undefined,
+          birthday: undefined,
+          job_title: undefined,
+          manager_name: undefined,
+          company_name: undefined,
+          office_location: undefined,
+          notes: undefined,
+          picture_url: undefined,
+          emails: [],
+          im_addresses: [],
+          physical_addresses: [],
+          phone_numbers: [],
+          web_pages: [],
+          groups:[],
+          source: undefined,
         });
         done();
       });
@@ -82,20 +107,20 @@ describe('Contact', () => {
   });
 
   describe('picture url', () => {
-    test('should make GET request for the picture', () => {
+    test('should make GET request for the picture', done => {
       testContext.contact.id = 'a_pic_url';
-      testContext.contact.getPicture();
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'GET',
-        path: '/contacts/a_pic_url/picture',
-        qs: {},
+      return testContext.contact.getPicture().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/contacts/a_pic_url/picture');
+        expect(options.method).toEqual('GET');
+        expect(options.body).toBeUndefined();
+        done();
       });
     });
   });
 
   describe('when the request succeeds', () => {
     beforeEach(() => {
-      testContext.connection.request = jest.fn(() => {
         const contactJSON = {
           id: '1257',
           object: 'contact',
@@ -120,8 +145,7 @@ describe('Contact', () => {
           groups: [{id: '123', object: 'contact_group', account_id: '1234', name: 'Fam', path: 'Fam'}],
           source: 'inbox',
         };
-        return Promise.resolve(contactJSON);
-      });
+      testContext.contact = new Contact(testContext.connection, contactJSON);
     });
 
     test('should resolve with the contact object', done => {
@@ -153,8 +177,7 @@ describe('Contact', () => {
     });
 
     test('should call the callback with the contact object', done => {
-      testContext.contact.save((err, contact) => {
-        expect(err).toBe(null);
+      return testContext.contact.save().then(contact => {
         expect(contact.id).toBe('1257');
         expect(contact.givenName).toBe('John');
         expect(contact.middleName).toBe('Jacob');

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -28,8 +28,8 @@ describe('Draft', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        buffer: () => {
-          return Promise.resolve("body");
+        text: () => {
+          return Promise.resolve(receivedBody);
         },
         json: () => {
           return Promise.resolve(receivedBody);
@@ -306,7 +306,7 @@ Would you like to grab coffee @ 2pm this Thursday?`;
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/send');
         expect(options.method).toEqual('POST');
-        expect(JSON.parse(options.body)).toEqual(msg);
+        expect(options.body).toEqual(msg);
         expect(options.headers['Content-Type']).toEqual('message/rfc822');
         expect(options.json).toBe(false);
         done();

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -1,47 +1,78 @@
-import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import Draft from '../src/models/draft';
 import Message from '../src/models/message';
+import Nylas from "../src/nylas";
+import fetch from "node-fetch";
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
 
 describe('Draft', () => {
   let testContext;
 
   beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-    testContext.connection.request = jest.fn(() => Promise.resolve({}));
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        buffer: () => {
+          return Promise.resolve("body");
+        },
+        json: () => {
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map()
+      }
+    };
+
+    fetch.mockImplementation(req =>
+        Promise.resolve(response(req.body))
+    );
+
+    // testContext.connection.request = jest.fn(() => Promise.resolve({}));
     testContext.draft = new Draft(testContext.connection);
   });
 
   describe('save', () => {
     test('should do a POST request if the draft has no id', done => {
       testContext.draft.id = undefined;
-      testContext.draft.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            to: [],
-            cc: [],
-            bcc: [],
-            from: [],
-            date: null,
-            body: undefined,
-            events: [],
-            unread: undefined,
-            snippet: undefined,
-            thread_id: undefined,
-            subject: undefined,
-            version: undefined,
-            folder: undefined,
-            starred: undefined,
-            labels: [],
-            file_ids: [],
-            headers: undefined,
-            reply_to: [],
-            reply_to_message_id: undefined
-          },
-          qs: {},
-          path: '/drafts',
+      return testContext.draft.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/drafts');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          to: [],
+          cc: [],
+          bcc: [],
+          from: [],
+          date: null,
+          body: undefined,
+          events: [],
+          unread: undefined,
+          snippet: undefined,
+          thread_id: undefined,
+          subject: undefined,
+          version: undefined,
+          folder: undefined,
+          starred: undefined,
+          labels: [],
+          file_ids: [],
+          headers: undefined,
+          reply_to: [],
+          reply_to_message_id: undefined
         });
         done();
       });
@@ -49,32 +80,30 @@ describe('Draft', () => {
 
     test('should do a PUT request if the draft has an id', done => {
       testContext.draft.id = 'id-1234';
-      testContext.draft.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'PUT',
-          body: {
-            to: [],
-            cc: [],
-            bcc: [],
-            from: [],
-            date: null,
-            body: undefined,
-            events: [],
-            unread: undefined,
-            snippet: undefined,
-            thread_id: undefined,
-            subject: undefined,
-            version: undefined,
-            folder: undefined,
-            starred: undefined,
-            labels: [],
-            file_ids: [],
-            headers: undefined,
-            reply_to: [],
-            reply_to_message_id: undefined,
-          },
-          qs: {},
-          path: '/drafts/id-1234',
+      return testContext.draft.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/drafts/id-1234');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          to: [],
+          cc: [],
+          bcc: [],
+          from: [],
+          date: null,
+          body: undefined,
+          events: [],
+          unread: undefined,
+          snippet: undefined,
+          thread_id: undefined,
+          subject: undefined,
+          version: undefined,
+          folder: undefined,
+          starred: undefined,
+          labels: [],
+          file_ids: [],
+          headers: undefined,
+          reply_to: [],
+          reply_to_message_id: undefined
         });
         done();
       });
@@ -140,17 +169,15 @@ describe('Draft', () => {
     test('should send the draft_id and version if the draft has an id', done => {
       testContext.draft.id = 'id-1234';
       testContext.draft.version = 2;
-      testContext.draft.send().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            draft_id: 'id-1234',
-            version: 2,
-          },
-          path: '/send',
-          headers: {},
-          json: true,
+      return testContext.draft.send().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/send');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          draft_id: 'id-1234',
+          version: 2,
         });
+        expect(options.json).toBe(true);
         done();
       });
     });
@@ -158,18 +185,16 @@ describe('Draft', () => {
     test('should send the draft JSON with the tracking object if the draft has an id and has a tracking object passed in', done => {
       testContext.draft.id = 'id-1234';
       testContext.draft.version = 2;
-      testContext.draft.send({"opens": true}).then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            draft_id: 'id-1234',
-            version: 2,
-            tracking: {"opens": true}
-          },
-          path: '/send',
-          headers: {},
-          json: true,
+      return testContext.draft.send({"opens": true}).then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/send');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          draft_id: 'id-1234',
+          version: 2,
+          tracking: {"opens": true}
         });
+        expect(options.json).toBe(true);
         done();
       });
     });
@@ -177,34 +202,32 @@ describe('Draft', () => {
     test('should send the draft JSON if the draft has no id', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
-      testContext.draft.send().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            to: [],
-            cc: [],
-            bcc: [],
-            from: [],
-            date: null,
-            body: undefined,
-            events: [],
-            unread: undefined,
-            snippet: undefined,
-            thread_id: undefined,
-            subject: 'Test Subject',
-            version: undefined,
-            folder: undefined,
-            starred: undefined,
-            labels: [],
-            file_ids: [],
-            headers: undefined,
-            reply_to: [],
-            reply_to_message_id: undefined,
-          },
-          path: '/send',
-          headers: {},
-          json: true,
+      return testContext.draft.send().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/send');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          to: [],
+          cc: [],
+          bcc: [],
+          from: [],
+          date: null,
+          body: undefined,
+          events: [],
+          unread: undefined,
+          snippet: undefined,
+          thread_id: undefined,
+          subject: 'Test Subject',
+          version: undefined,
+          folder: undefined,
+          starred: undefined,
+          labels: [],
+          file_ids: [],
+          headers: undefined,
+          reply_to: [],
+          reply_to_message_id: undefined,
         });
+        expect(options.json).toBe(true);
         done();
       });
     });
@@ -212,35 +235,8 @@ describe('Draft', () => {
     test('should send the draft JSON with the tracking object if the draft has no id and has a tracking object passed in as the second parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
-      testContext.draft.send(null, {"opens": true}).then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            to: [],
-            cc: [],
-            bcc: [],
-            from: [],
-            date: null,
-            body: undefined,
-            events: [],
-            unread: undefined,
-            snippet: undefined,
-            thread_id: undefined,
-            subject: 'Test Subject',
-            version: undefined,
-            folder: undefined,
-            starred: undefined,
-            labels: [],
-            file_ids: [],
-            headers: undefined,
-            reply_to: [],
-            reply_to_message_id: undefined,
-            tracking: {"opens": true}
-          },
-          path: '/send',
-          headers: {},
-          json: true,
-        });
+      return testContext.draft.send(null, {"opens": true}).then(() => {
+        evaluateTracking();
         done();
       });
     });
@@ -248,35 +244,8 @@ describe('Draft', () => {
     test('should send the draft JSON with the tracking object if the draft has a tracking object as the only parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
-      testContext.draft.send({"opens": true}).then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            to: [],
-            cc: [],
-            bcc: [],
-            from: [],
-            date: null,
-            body: undefined,
-            events: [],
-            unread: undefined,
-            snippet: undefined,
-            thread_id: undefined,
-            subject: 'Test Subject',
-            version: undefined,
-            folder: undefined,
-            starred: undefined,
-            labels: [],
-            file_ids: [],
-            headers: undefined,
-            reply_to: [],
-            reply_to_message_id: undefined,
-            tracking: {"opens": true}
-          },
-          path: '/send',
-          headers: {},
-          json: true,
-        });
+      return testContext.draft.send({"opens": true}).then(() => {
+        evaluateTracking();
         done();
       });
     });
@@ -284,38 +253,40 @@ describe('Draft', () => {
     test('should send the draft JSON with the tracking object if the draft has no id and has a tracking object passed in as the first parameter', done => {
       testContext.draft.id = undefined;
       testContext.draft.subject = 'Test Subject';
-      testContext.draft.send({"opens": true}, (err, data) => {}).then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            to: [],
-            cc: [],
-            bcc: [],
-            from: [],
-            date: null,
-            body: undefined,
-            events: [],
-            unread: undefined,
-            snippet: undefined,
-            thread_id: undefined,
-            subject: 'Test Subject',
-            version: undefined,
-            folder: undefined,
-            starred: undefined,
-            labels: [],
-            file_ids: [],
-            headers: undefined,
-            reply_to: [],
-            reply_to_message_id: undefined,
-            tracking: {"opens": true}
-          },
-          path: '/send',
-          headers: {},
-          json: true,
-        });
+      return testContext.draft.send({"opens": true}, (err, data) => {}).then(() => {
+        evaluateTracking();
         done();
       });
     });
+
+    const evaluateTracking = () => {
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual('https://api.nylas.com/send');
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        to: [],
+        cc: [],
+        bcc: [],
+        from: [],
+        date: null,
+        body: undefined,
+        events: [],
+        unread: undefined,
+        snippet: undefined,
+        thread_id: undefined,
+        subject: 'Test Subject',
+        version: undefined,
+        folder: undefined,
+        starred: undefined,
+        labels: [],
+        file_ids: [],
+        headers: undefined,
+        reply_to: [],
+        reply_to_message_id: undefined,
+        tracking: {"opens": true}
+      });
+      expect(options.json).toBe(true);
+    }
 
     test('should send the draft as raw MIME if rawMime exists', done => {
       const msg = `MIME-Version: 1.0 \
@@ -332,15 +303,12 @@ Would you like to grab coffee @ 2pm this Thursday?`;
 
       const draft = testContext.connection.drafts.build({ rawMime: msg });
       draft.send().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          headers: {
-            'Content-Type': 'message/rfc822',
-          },
-          method: 'POST',
-          path: '/send',
-          body: msg,
-          json: false,
-        });
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/send');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual(msg);
+        expect(options.headers['Content-Type']).toEqual('message/rfc822');
+        expect(options.json).toBe(false);
         done();
       });
     });
@@ -417,8 +385,9 @@ Would you like to grab coffee @ 2pm this Thursday?`;
             expect(err).toBe(testContext.error);
             expect(message).toBe(undefined);
             done();
-          })
-          .catch(() => {});
+          }).catch(() => {
+            // do nothing
+        });
       });
     });
   });

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -1,33 +1,64 @@
 import NylasConnection from '../src/nylas-connection';
 import Event from '../src/models/event';
+import Nylas from "../src/nylas";
+import fetch from "node-fetch";
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
 
 describe('Event', () => {
   let testContext;
 
   beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-    testContext.connection.request = jest.fn(() => Promise.resolve());
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        buffer: () => {
+          return Promise.resolve("body");
+        },
+        json: () => {
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map()
+      }
+    };
+
+    fetch.mockImplementation(req =>
+        Promise.resolve(response(req.body))
+    );
+
     testContext.event = new Event(testContext.connection);
   });
 
   describe('save', () => {
     test('should do a POST request if the event has no id', done => {
       testContext.event.id = undefined;
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            location: undefined,
-            when: undefined,
-            participants: [],
-          },
-          qs: {},
-          path: '/events',
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: undefined,
+          participants: [],
         });
         done();
       });
@@ -35,42 +66,37 @@ describe('Event', () => {
 
     test('should do a PUT request if the event has an id', done => {
       testContext.event.id = 'id-1234';
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'PUT',
-          body: {
-            calendar_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            location: undefined,
-            when: undefined,
-            participants: [],
-          },
-          qs: {},
-          path: '/events/id-1234',
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events/id-1234');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: undefined,
+          participants: [],
         });
         done();
       });
     });
 
     test('should include params in the request if they were passed in', done => {
-      testContext.event.save({ notify_participants: true }).then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            location: undefined,
-            when: undefined,
-            participants: [],
-          },
-          qs: {
-            notify_participants: true,
-          },
-          path: '/events',
+      return testContext.event.save({ notify_participants: true }).then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.qs['notify_participants']).toEqual(true);
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events?notify_participants=true');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: undefined,
+          participants: [],
         });
         done();
       });
@@ -84,21 +110,19 @@ describe('Event', () => {
         "timezone": "America/New_York"
       }
       testContext.event.recurrence = recurrence;
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            location: undefined,
-            when: undefined,
-            participants: [],
-            recurrence: recurrence
-          },
-          qs: {},
-          path: '/events',
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: undefined,
+          participants: [],
+          recurrence: recurrence
         });
         done();
       });
@@ -108,26 +132,24 @@ describe('Event', () => {
       testContext.event.when = {};
       testContext.event.start = 1408875644;
       testContext.event.end = 1408875644;
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              time: 1408875644,
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            time: 1408875644,
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         done();
       });
@@ -137,27 +159,25 @@ describe('Event', () => {
       testContext.event.when = {};
       testContext.event.start = 1409594400
       testContext.event.end = 1409598000
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              start_time: 1409594400,
-              end_time: 1409598000,
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            start_time: 1409594400,
+            end_time: 1409598000,
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         done();
       });
@@ -167,26 +187,24 @@ describe('Event', () => {
       testContext.event.when = {};
       testContext.event.start = '1912-06-23';
       testContext.event.end = '1912-06-23';
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              date: '1912-06-23',
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            date: '1912-06-23',
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         done();
       });
@@ -196,27 +214,24 @@ describe('Event', () => {
       testContext.event.when = {};
       testContext.event.start = '1815-12-10';
       testContext.event.end = '1852-11-27';
-      testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              start_date: '1815-12-10',
-              end_date: '1852-11-27',
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            start_date: '1815-12-10',
+            end_date: '1852-11-27',
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
         });
         done();
       });
@@ -224,26 +239,24 @@ describe('Event', () => {
 
     test('should create event with time when event param `when` is updated with time', done => {
       testContext.event.when = { time: 1408875644 };
-      testContext.event.save().then(event => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              time: 1408875644,
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(event => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            time: 1408875644,
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         expect(event.start).toBe(1408875644);
         expect(event.end).toBe(1408875644);
@@ -253,27 +266,25 @@ describe('Event', () => {
 
     test('should create event with start_time and end_time when event param `when` is updated with start_time and end_time', done => {
       testContext.event.when = { start_time: 1409594400, end_time: 1409598000 };
-      testContext.event.save().then(event => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              start_time: 1409594400,
-              end_time: 1409598000,
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(event => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            start_time: 1409594400,
+            end_time: 1409598000,
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         expect(event.start).toBe(1409594400);
         expect(event.end).toBe(1409598000);
@@ -283,26 +294,24 @@ describe('Event', () => {
 
     test('should create event with date when the event param `when` is updated with date', done => {
       testContext.event.when = { date: '1912-06-23' };
-      testContext.event.save().then(event => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              date: '1912-06-23',
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(event => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            date: '1912-06-23',
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         expect(event.start).toBe('1912-06-23');
         expect(event.end).toBe('1912-06-23');
@@ -312,27 +321,25 @@ describe('Event', () => {
 
     test('should create event with start_date and end_date when the event param `when` is updated with start_date and end_date', done => {
       testContext.event.when = { start_date: '1815-12-10', end_date: '1852-11-27' };
-      testContext.event.save().then(event => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              start_date: '1815-12-10',
-              end_date: '1852-11-27',
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(event => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            start_date: '1815-12-10',
+            end_date: '1852-11-27',
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         expect(event.start).toBe('1815-12-10');
         expect(event.end).toBe('1852-11-27');
@@ -348,27 +355,25 @@ describe('Event', () => {
         start_date: '1815-12-10',
         end_date: '1852-11-27',
       });
-      testContext.event.save().then(event => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            message_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            owner: undefined,
-            location: undefined,
-            when: {
-              start_date: '1815-12-10',
-              end_date: '1852-11-27',
-            },
-            participants: [],
-            read_only: undefined,
-            status: undefined,
+      return testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          message_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          owner: undefined,
+          location: undefined,
+          when: {
+            start_date: '1815-12-10',
+            end_date: '1852-11-27',
           },
-          qs: {},
-          path: '/events',
+          participants: [],
+          read_only: undefined,
+          status: undefined,
         });
         done();
       });
@@ -377,22 +382,20 @@ describe('Event', () => {
     test('should create an event with a metadata object', done => {
       testContext.event.metadata = {'hello': 'world'};
       testContext.event.save().then(() => {
-        expect(testContext.connection.request).toHaveBeenCalledWith({
-          method: 'POST',
-          body: {
-            calendar_id: undefined,
-            busy: undefined,
-            title: undefined,
-            description: undefined,
-            location: undefined,
-            when: undefined,
-            _start: undefined,
-            _end: undefined,
-            participants: [],
-            metadata: {'hello': 'world'}
-          },
-          qs: {},
-          path: '/events',
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: undefined,
+          _start: undefined,
+          _end: undefined,
+          participants: [],
+          metadata: {'hello': 'world'}
         });
         done();
       });
@@ -415,13 +418,13 @@ describe('Event', () => {
       });
 
       test('should resolve with the event object', done => {
-        testContext.event.save().then(event => {
+        return testContext.event.save().then(event => {
           expect(event.id).toBe('id-1234');
           expect(event.title).toBe('test event');
           expect(event.when.time).toEqual(1409594400);
           expect(event.when.object).toEqual('time');
           expect(event.iCalUID).toBe('id-5678');
-          let participant = event.participants[0];
+          const participant = event.participants[0];
           expect(participant.toJSON()).toEqual(
             {'name': 'foo', 'email': 'bar', 'status': 'noreply'});
           done();
@@ -429,7 +432,7 @@ describe('Event', () => {
       });
 
       test('should call the callback with the event object', done => {
-        testContext.event.save((err, event) => {
+        return testContext.event.save((err, event) => {
           expect(err).toBe(null);
           expect(event.id).toBe('id-1234');
           expect(event.title).toBe('test event');
@@ -460,23 +463,26 @@ describe('Event', () => {
             expect(event).toBe(undefined);
             done();
           })
-          .catch(() => {});
+          .catch(() => {
+            // do nothing
+          });
       });
     });
   });
 
   describe('rsvp', () => {
-    test('should do a POST request to the RSVP endpoint', () => {
+    test('should do a POST request to the RSVP endpoint', done => {
       testContext.event.id = 'public_id';
-      testContext.event.rsvp('yes', 'I will come.');
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'POST',
-        body: {
+      return testContext.event.rsvp('yes', 'I will come.').then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/send-rsvp');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
           event_id: 'public_id',
           status: 'yes',
           comment: 'I will come.',
-        },
-        path: '/send-rsvp',
+        });
+        done();
       });
     });
   });

--- a/__tests__/label-spec.js
+++ b/__tests__/label-spec.js
@@ -1,49 +1,73 @@
-import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
-import Message from '../src/models/message';
 import { Label } from '../src/models/folder';
+import fetch from "node-fetch";
+import Nylas from "../src/nylas";
 
-const testUntil = fn => {
-  let finished = false;
-  runs(() => fn(callback => (finished = true)));
-  waitsFor(() => finished);
-};
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
 
 describe('Label', () => {
   let testContext;
 
   beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-    testContext.connection.request = jest.fn(() => Promise.resolve());
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        buffer: () => {
+          return Promise.resolve("body");
+        },
+        json: () => {
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map()
+      }
+    };
+
+    fetch.mockImplementation(req =>
+        Promise.resolve(response(req.body))
+    );
     testContext.label = new Label(testContext.connection);
     testContext.label.displayName = 'Label name';
     testContext.label.name = 'Longer label name';
   });
 
   describe('save', () => {
-    test('should do a POST request if id is undefined', () => {
-      testContext.label.save();
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'POST',
-        body: {
+    test('should do a POST request if id is undefined', done => {
+      return testContext.label.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/labels');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
           display_name: 'Label name',
-        },
-        qs: {},
-        path: '/labels',
+        });
+        done();
       });
     });
 
-    test('should do a PUT if id is defined', () => {
+    test('should do a PUT if id is defined', done => {
       testContext.label.id = 'label_id';
-      testContext.label.save();
-      expect(testContext.connection.request).toHaveBeenCalledWith({
-        method: 'PUT',
-        body: {
+      return testContext.label.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/labels/label_id');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
           display_name: 'Label name',
-        },
-        qs: {},
-        path: '/labels/label_id',
+        })
+        done();
       });
     });
   });

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -4,13 +4,50 @@ import File from '../src/models/file';
 import Message from '../src/models/message';
 import { Label } from '../src/models/folder';
 import RestfulModelCollection from '../src/models/restful-model-collection'
+import fetch from "node-fetch";
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
 
 describe('Message', () => {
   let testContext;
 
   beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        buffer: () => {
+          return Promise.resolve("body");
+        },
+        json: () => {
+          // For the raw/MIME flow
+          if(receivedBody === null) {
+            return Promise.resolve("MIME");
+          }
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map()
+      }
+    };
+
+    fetch.mockImplementation(req =>
+        Promise.resolve(response(req.body))
+    );
+
     testContext.message = new Message(testContext.connection);
     testContext.message.id = '4333';
     testContext.message.subject = 'foo';
@@ -18,67 +55,51 @@ describe('Message', () => {
     testContext.message.starred = true;
     testContext.message.unread = false;
     testContext.message.to = [{"email": "foo", "name": "bar"}];
-    testContext.connection.request = jest.fn(() => Promise.resolve(testContext.message.toJSON()));
-    testContext.collection = new RestfulModelCollection(
-      Message,
-      testContext.connection
-    );
-    testContext.collection._getModelCollection = jest.fn(() => {
-      return Promise.resolve([testContext.message]);
-    });
   });
 
   describe('save', () => {
-    test('should do a PUT request with labels if labels is defined. Additional arguments should be ignored.', () => {
+    test('should do a PUT request with labels if labels is defined. Additional arguments should be ignored.', done => {
       const label = new Label(testContext.connection);
       label.id = 'label_id';
       testContext.message.labels = [label];
       testContext.message.randomArgument = true;
-      testContext.message
-        .save()
-        .then(() => {
-          expect(testContext.connection.request).toHaveBeenCalledWith({
-            method: 'PUT',
-            body: {
-              label_ids: ['label_id'],
-              starred: true,
-              unread: false,
-            },
-            qs: {},
-            path: '/messages/4333',
-          });
-        })
-        .catch(() => {});
+      return testContext.message.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/messages/4333');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          label_ids: ['label_id'],
+          starred: true,
+          unread: false,
+        });
+        done();
+      });
     });
 
-    test('should do a PUT with folder if folder is defined', () => {
+    test('should do a PUT with folder if folder is defined', done => {
       const label = new Label(testContext.connection);
       label.id = 'label_id';
       testContext.message.folder = label;
-      testContext.message
-        .save()
-        .then(() => {
-          expect(testContext.connection.request).toHaveBeenCalledWith({
-            method: 'PUT',
-            body: {
-              folder_id: 'label_id',
-              starred: true,
-              unread: false,
-            },
-            qs: {},
-            path: '/messages/4333',
-          });
-        })
-        .catch(() => {});
+      return testContext.message.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/messages/4333');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          folder_id: 'label_id',
+          starred: true,
+          unread: false,
+        });
+        done();
+      });
     });
 
     test('should resolve with the message object', done => {
-      testContext.message.save().then(message => {
+      return testContext.message.save().then(message => {
         expect(message.id).toBe('4333');
         expect(message.body).toBe('bar');
         expect(message.subject).toBe('foo');
-        let toParticipant = message.to[0];
-        expect(toParticipant.toJSON()).toEqual(
+        const toParticipant = message.to[0];
+        expect(toParticipant).toEqual(
           {'email': 'foo', 'name': 'bar'});
         done();
       });
@@ -86,25 +107,28 @@ describe('Message', () => {
   });
 
   describe('getRaw', () => {
-    test('should support getting raw messages', () => {
-      testContext.connection.request = jest.fn(() => Promise.resolve('MIME'));
-      testContext.message
-        .getRaw()
-        .then(rawMessage => {
-          expect(testContext.connection.request).toHaveBeenCalledWith({
-            headers: {
-              Accept: 'message/rfc822',
-            },
-            method: 'GET',
-            path: '/messages/4333',
-          });
-          expect(rawMessage).toBe('MIME');
-        })
-        .catch(() => {});
+    test('should support getting raw messages', done => {
+      return testContext.message.getRaw().then(rawMessage => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/messages/4333');
+        expect(options.method).toEqual('GET');
+        expect(options.headers['message/rfc822']).toEqual();
+        expect(rawMessage).toBe('MIME');
+        done();
+      });
     });
   });
 
   describe('first', () => {
+    beforeEach(() => {
+      testContext.collection = new RestfulModelCollection(
+          Message,
+          testContext.connection
+      );
+      testContext.collection._getModelCollection = jest.fn(() => {
+        return Promise.resolve([testContext.message]);
+      });
+    })
     test('should resolve with the first item', done => {
       const fileObj = {
         account_id: 'foo',
@@ -119,10 +143,10 @@ describe('Message', () => {
       }
       const file = new File(testContext.connection, fileObj);
       testContext.message.files = [file];
-      testContext.collection.first().then(message => {
+      return testContext.collection.first().then(message => {
         expect(message instanceof Message).toBe(true);
         expect(message).toBe(testContext.message);
-        let file = message.files[0];
+        const file = message.files[0];
         expect(file.toJSON()).toEqual(fileObj);
         expect(file.contentDisposition).toEqual(fileObj.content_disposition);
         done();

--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -17,6 +17,10 @@ describe('Nylas', () => {
     Nylas.clientId = undefined;
     Nylas.clientSecret = undefined;
     Nylas.apiServer = 'https://api.nylas.com';
+
+    fetch.mockImplementation(() =>
+        Promise.resolve(new Response('{"access_token":"12345"}'))
+    );
   });
 
   describe('config', () => {
@@ -91,17 +95,11 @@ describe('Nylas', () => {
     });
 
     test('should return a promise', () => {
-      fetch.mockImplementation(() =>
-        Promise.resolve(new Response('{"access_token":"12345"}'))
-      );
       const p = Nylas.exchangeCodeForToken('code-from-server');
       expect(p).toBeInstanceOf(Promise);
     });
 
     test('should make a request to /oauth/token with the correct grant_type and client params', async () => {
-      fetch.mockImplementation(() =>
-        Promise.resolve(new Response('{"access_token":"12345"}'))
-      );
       await Nylas.exchangeCodeForToken('code-from-server');
       const search =
         'client_id=newId&client_secret=newSecret&grant_type=authorization_code&code=code-from-server';
@@ -110,9 +108,6 @@ describe('Nylas', () => {
     });
 
     test('should resolve with the returned access_token', async () => {
-      fetch.mockImplementation(() =>
-        Promise.resolve(new Response('{"access_token":"12345"}'))
-      );
       const accessToken = await Nylas.exchangeCodeForToken('code-from-server');
       expect(accessToken).toEqual('12345');
     });
@@ -170,7 +165,9 @@ describe('Nylas', () => {
             expect(returnedError).toEqual(error);
             done();
           }
-        );
+        ).catch(() => {
+          // do nothing
+        });
       });
     });
   });

--- a/__tests__/webhook-spec.js
+++ b/__tests__/webhook-spec.js
@@ -24,7 +24,7 @@ describe('Webhook', () => {
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve([webhookJSON])
       );
-      Nylas.webhooks
+      return Nylas.webhooks
         .list({}, (err, webhooks) => {
           expect(webhooks.length).toEqual(1);
           expect(webhooks[0].id).toEqual(WEBHOOK_ID);
@@ -44,7 +44,7 @@ describe('Webhook', () => {
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
       );
-      Nylas.webhooks.find(WEBHOOK_ID).then(webhookResp => {
+      return Nylas.webhooks.find(WEBHOOK_ID).then(webhookResp => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'GET',
@@ -69,7 +69,7 @@ describe('Webhook', () => {
         triggers: ['message.opened', 'message.link_clicked'],
         version: '2.0'
       });
-      webhook.save().then(webhookResp => {
+      return webhook.save().then(webhookResp => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'POST',
@@ -100,7 +100,7 @@ describe('Webhook', () => {
         triggers: ['message.opened', 'message.link_clicked'],
         version: '2.0'
       });
-      webhook.save().then(webhookResp => {
+      return webhook.save().then(webhookResp => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'PUT',
@@ -127,7 +127,7 @@ describe('Webhook', () => {
         triggers: ['message.opened', 'message.link_clicked'],
         version: '2.0'
       });
-      Nylas.webhooks.delete(webhook).then(webhookResp => {
+      return Nylas.webhooks.delete(webhook).then(webhookResp => {
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'DELETE',
           path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
@@ -143,7 +143,7 @@ describe('Webhook', () => {
       Nylas.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(null)
       );
-      Nylas.webhooks.delete(WEBHOOK_ID).then(webhookResp => {
+      return Nylas.webhooks.delete(WEBHOOK_ID).then(webhookResp => {
         expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'DELETE',
           path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -111,7 +111,7 @@ export default class Event extends RestfulModel {
     return this._save(params, callback);
   }
 
-  rsvp(status: string, comment: string, callback: (error: Error | null, data?: Event) => void) {
+  rsvp(status: string, comment: string, callback?: (error: Error | null, data?: Event) => void) {
     return this.connection
       .request({
         method: 'POST',

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -35,7 +35,7 @@ export default class File extends RestfulModel {
       .request({
         method: 'POST',
         path: `/${File.collectionName}`,
-        json: false,
+        json: true,
         formData: {
           file: {
             value: this.data,

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -207,7 +207,12 @@ export default class NylasConnection {
               return reject(e);
             })
           } else {
-            return resolve(response.json());
+            response.json().then(json => {
+              if(options.json === false) {
+                return resolve(JSON.parse(json));
+              }
+              return resolve(json);
+            })
           }
         }
       })

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -206,13 +206,10 @@ export default class NylasConnection {
             }).catch(e => {
               return reject(e);
             })
+          } else if(response.headers.get('message/rfc822')) {
+            return resolve(response.text());
           } else {
-            response.json().then(json => {
-              if(options.json === false) {
-                return resolve(JSON.parse(json));
-              }
-              return resolve(json);
-            })
+            return resolve(response.json());
           }
         }
       })


### PR DESCRIPTION
# Description
Lots of tests were returning a pass before being properly evaluated as a result of the Jest test cases being written without it properly being told to wait for the async calls to resolve before evaluating. This PR also found a few minor issues that were fixed:
* `Event.rsvp()` `callback` parameter should be optional.
* Uploading a `File` should expect a JSON as the API returns metadata
* Converting raw MIME emails to JSON before we can access fields

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.