### PR TITLE
[63364] Add support for Calendar Availaiblity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed Jest test cases not respecting async methods
 * Fixed issue with parsing raw MIME emails
 * Added linting, enabled and set up eslint and prettier
+* Add support for `/calendars/availability` endpoint
 
 ### 5.5.1 / 2021-06-24
 * Fix tracking object not being added to a pre-existing `draft` object

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -61,7 +61,7 @@ describe('CalendarRestfulModelCollection', () => {
     );
   };
 
-  test('[FREE BUSY] should fetch results with snakecase params', () => {
+  test('[FREE BUSY] should fetch results with snakecase params', done => {
     const params = {
       start_time: '1590454800',
       end_time: '1590780800',
@@ -70,10 +70,13 @@ describe('CalendarRestfulModelCollection', () => {
 
     return testContext.connection.calendars
       .freeBusy(params)
-      .then(evaluateFreeBusy);
+      .then(() => {
+        evaluateFreeBusy();
+        done();
+      });
   });
 
-  test('[FREE BUSY] should fetch results with camelcase params', () => {
+  test('[FREE BUSY] should fetch results with camelcase params', done => {
     const params = {
       startTime: '1590454800',
       endTime: '1590780800',
@@ -82,10 +85,40 @@ describe('CalendarRestfulModelCollection', () => {
 
     return testContext.connection.calendars
       .freeBusy(params)
-      .then(evaluateFreeBusy);
+      .then(() => {
+        evaluateFreeBusy();
+        done();
+      });
   });
 
-  test('[AVAILABILITY] should fetch results with snakecase params', () => {
+  const evaluateAvailability = () => {
+    const options = testContext.connection.request.mock.calls[0][0];
+    expect(options.url.toString()).toEqual('https://api.nylas.com/calendars/availability');
+    expect(options.method).toEqual('POST');
+    expect(JSON.parse(options.body)).toEqual({
+      start_time: '1590454800',
+      end_time: '1590780800',
+      interval_minutes: 5,
+      duration_minutes: 30,
+      emails: [ 'jane@email.com' ],
+      free_busy: [],
+      open_hours: [{
+        emails: [
+          "swag@nylas.com"
+        ],
+        days: [
+          "0"
+        ],
+        timezone: "America/Chicago",
+        start: "10:00",
+        end: "14:00",
+        object_type: "open_hours"
+      }]
+    });
+    expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
+  }
+
+  test('[AVAILABILITY] should fetch results with snakecase params', done => {
     const params = {
       start_time: '1590454800',
       end_time: '1590780800',
@@ -106,36 +139,13 @@ describe('CalendarRestfulModelCollection', () => {
       }]
     };
 
-    fetch.Request = jest.fn((url, options) => {
-      expect(url.toString()).toEqual('https://api.nylas.com/calendars/availability');
-      expect(options.method).toEqual('POST');
-      expect(JSON.parse(options.body)).toEqual({
-        start_time: '1590454800',
-        end_time: '1590780800',
-        interval_minutes: 5,
-        duration_minutes: 30,
-        emails: [ 'jane@email.com' ],
-        free_busy: [],
-        open_hours: [{
-          emails: [
-            "swag@nylas.com"
-          ],
-          days: [
-            "0"
-          ],
-          timezone: "America/Chicago",
-          start: "10:00",
-          end: "14:00",
-          object_type: "open_hours"
-        }]
-      });
-      expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
+    return testContext.connection.calendars.availability(params).then(() => {
+      evaluateAvailability();
+      done();
     });
-
-    testContext.connection.calendars.availability(params);
   });
 
-  test('[AVAILABILITY] should fetch results with camelcase params', () => {
+  test('[AVAILABILITY] should fetch results with camelcase params', done => {
     const params = {
       startTime: '1590454800',
       endTime: '1590780800',
@@ -156,33 +166,10 @@ describe('CalendarRestfulModelCollection', () => {
       }]
     };
 
-    fetch.Request = jest.fn((url, options) => {
-      expect(url.toString()).toEqual('https://api.nylas.com/calendars/availability');
-      expect(options.method).toEqual('POST');
-      expect(JSON.parse(options.body)).toEqual({
-        start_time: '1590454800',
-        end_time: '1590780800',
-        interval_minutes: 5,
-        duration_minutes: 30,
-        emails: [ 'jane@email.com' ],
-        free_busy: [],
-        open_hours: [{
-          emails: [
-            "swag@nylas.com"
-          ],
-          days: [
-            "0"
-          ],
-          timezone: "America/Chicago",
-          start: "10:00",
-          end: "14:00",
-          object_type: "open_hours"
-        }]
-      });
-      expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
+    return testContext.connection.calendars.availability(params).then(() => {
+      evaluateAvailability();
+      done();
     });
-
-    testContext.connection.calendars.availability(params);
   });
 
   test('[DELETE] should use correct route, method and auth', done => {

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -85,6 +85,106 @@ describe('CalendarRestfulModelCollection', () => {
       .then(evaluateFreeBusy);
   });
 
+  test('[AVAILABILITY] should fetch results with snakecase params', () => {
+    const params = {
+      start_time: '1590454800',
+      end_time: '1590780800',
+      interval: 5,
+      duration: 30,
+      emails: ['jane@email.com'],
+      open_hours: [{
+        emails: [
+          "swag@nylas.com"
+        ],
+        days: [
+          "0"
+        ],
+        timezone: "America/Chicago",
+        start: "10:00",
+        end: "14:00",
+        object_type: "open_hours"
+      }]
+    };
+
+    fetch.Request = jest.fn((url, options) => {
+      expect(url.toString()).toEqual('https://api.nylas.com/calendars/availability');
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        start_time: '1590454800',
+        end_time: '1590780800',
+        interval_minutes: 5,
+        duration_minutes: 30,
+        emails: [ 'jane@email.com' ],
+        free_busy: [],
+        open_hours: [{
+          emails: [
+            "swag@nylas.com"
+          ],
+          days: [
+            "0"
+          ],
+          timezone: "America/Chicago",
+          start: "10:00",
+          end: "14:00",
+          object_type: "open_hours"
+        }]
+      });
+      expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
+    });
+
+    testContext.connection.calendars.availability(params);
+  });
+
+  test('[AVAILABILITY] should fetch results with camelcase params', () => {
+    const params = {
+      startTime: '1590454800',
+      endTime: '1590780800',
+      interval: 5,
+      duration: 30,
+      emails: ['jane@email.com'],
+      open_hours: [{
+        emails: [
+          "swag@nylas.com"
+        ],
+        days: [
+          "0"
+        ],
+        timezone: "America/Chicago",
+        start: "10:00",
+        end: "14:00",
+        object_type: "open_hours"
+      }]
+    };
+
+    fetch.Request = jest.fn((url, options) => {
+      expect(url.toString()).toEqual('https://api.nylas.com/calendars/availability');
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        start_time: '1590454800',
+        end_time: '1590780800',
+        interval_minutes: 5,
+        duration_minutes: 30,
+        emails: [ 'jane@email.com' ],
+        free_busy: [],
+        open_hours: [{
+          emails: [
+            "swag@nylas.com"
+          ],
+          days: [
+            "0"
+          ],
+          timezone: "America/Chicago",
+          start: "10:00",
+          end: "14:00",
+          object_type: "open_hours"
+        }]
+      });
+      expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
+    });
+
+    testContext.connection.calendars.availability(params);
+  });
+
   test('[DELETE] should use correct route, method and auth', done => {
     const calendarId = 'id123';
 

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -68,12 +68,10 @@ describe('CalendarRestfulModelCollection', () => {
       emails: ['jane@email.com'],
     };
 
-    return testContext.connection.calendars
-      .freeBusy(params)
-      .then(() => {
-        evaluateFreeBusy();
-        done();
-      });
+    return testContext.connection.calendars.freeBusy(params).then(() => {
+      evaluateFreeBusy();
+      done();
+    });
   });
 
   test('[FREE BUSY] should fetch results with camelcase params', done => {
@@ -83,40 +81,40 @@ describe('CalendarRestfulModelCollection', () => {
       emails: ['jane@email.com'],
     };
 
-    return testContext.connection.calendars
-      .freeBusy(params)
-      .then(() => {
-        evaluateFreeBusy();
-        done();
-      });
+    return testContext.connection.calendars.freeBusy(params).then(() => {
+      evaluateFreeBusy();
+      done();
+    });
   });
 
   const evaluateAvailability = () => {
     const options = testContext.connection.request.mock.calls[0][0];
-    expect(options.url.toString()).toEqual('https://api.nylas.com/calendars/availability');
+    expect(options.url.toString()).toEqual(
+      'https://api.nylas.com/calendars/availability'
+    );
     expect(options.method).toEqual('POST');
     expect(JSON.parse(options.body)).toEqual({
       start_time: '1590454800',
       end_time: '1590780800',
       interval_minutes: 5,
       duration_minutes: 30,
-      emails: [ 'jane@email.com' ],
+      emails: ['jane@email.com'],
       free_busy: [],
-      open_hours: [{
-        emails: [
-          "swag@nylas.com"
-        ],
-        days: [
-          "0"
-        ],
-        timezone: "America/Chicago",
-        start: "10:00",
-        end: "14:00",
-        object_type: "open_hours"
-      }]
+      open_hours: [
+        {
+          emails: ['swag@nylas.com'],
+          days: ['0'],
+          timezone: 'America/Chicago',
+          start: '10:00',
+          end: '14:00',
+          object_type: 'open_hours',
+        },
+      ],
     });
-    expect(options.headers['authorization']).toEqual(`Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`);
-  }
+    expect(options.headers['authorization']).toEqual(
+      `Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`
+    );
+  };
 
   test('[AVAILABILITY] should fetch results with snakecase params', done => {
     const params = {
@@ -125,18 +123,16 @@ describe('CalendarRestfulModelCollection', () => {
       interval: 5,
       duration: 30,
       emails: ['jane@email.com'],
-      open_hours: [{
-        emails: [
-          "swag@nylas.com"
-        ],
-        days: [
-          "0"
-        ],
-        timezone: "America/Chicago",
-        start: "10:00",
-        end: "14:00",
-        object_type: "open_hours"
-      }]
+      open_hours: [
+        {
+          emails: ['swag@nylas.com'],
+          days: ['0'],
+          timezone: 'America/Chicago',
+          start: '10:00',
+          end: '14:00',
+          object_type: 'open_hours',
+        },
+      ],
     };
 
     return testContext.connection.calendars.availability(params).then(() => {
@@ -152,18 +148,16 @@ describe('CalendarRestfulModelCollection', () => {
       interval: 5,
       duration: 30,
       emails: ['jane@email.com'],
-      open_hours: [{
-        emails: [
-          "swag@nylas.com"
-        ],
-        days: [
-          "0"
-        ],
-        timezone: "America/Chicago",
-        start: "10:00",
-        end: "14:00",
-        object_type: "open_hours"
-      }]
+      open_hours: [
+        {
+          emails: ['swag@nylas.com'],
+          days: ['0'],
+          timezone: 'America/Chicago',
+          start: '10:00',
+          end: '14:00',
+          object_type: 'open_hours',
+        },
+      ],
     };
 
     return testContext.connection.calendars.availability(params).then(() => {

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -47,4 +47,60 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
         return Promise.reject(err);
       });
   }
+
+  availability(options: {
+    emails: string[]
+    duration: number,
+    interval: number,
+    start_time: string,
+    startTime: string,
+    end_time: string,
+    endTime: string,
+    free_busy?: Array<{
+      emails: string,
+      object: string,
+      time_slots: Array<{
+        object: string,
+        status: string,
+        start_time: string,
+        end_time: string,
+      }>,
+    }>,
+    open_hours: Array<{
+      emails: string[],
+      days: string[],
+      timezone: string,
+      start: string,
+      end: string,
+      object_type: string
+    }>
+  }, callback?: (error: Error | null, data?: { [key: string]: any }) => void) {
+
+    return this.connection
+      .request({
+        method: 'POST',
+        path: `/calendars/availability`,
+        body: {
+          emails: options.emails,
+          duration_minutes: options.duration,
+          interval_minutes: options.interval,
+          start_time: options.startTime || options.start_time,
+          end_time: options.endTime || options.end_time,
+          free_busy: options.free_busy || [],
+          open_hours: options.open_hours
+        }
+      })
+      .then(json => {
+        if (callback) {
+          callback(null, json);
+        }
+        return Promise.resolve(json);
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      });
+  }
 }

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -48,34 +48,36 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       });
   }
 
-  availability(options: {
-    emails: string[]
-    duration: number,
-    interval: number,
-    start_time: string,
-    startTime: string,
-    end_time: string,
-    endTime: string,
-    free_busy?: Array<{
-      emails: string,
-      object: string,
-      time_slots: Array<{
-        object: string,
-        status: string,
-        start_time: string,
-        end_time: string,
-      }>,
-    }>,
-    open_hours: Array<{
-      emails: string[],
-      days: string[],
-      timezone: string,
-      start: string,
-      end: string,
-      object_type: string
-    }>
-  }, callback?: (error: Error | null, data?: { [key: string]: any }) => void) {
-
+  availability(
+    options: {
+      emails: string[];
+      duration: number;
+      interval: number;
+      start_time?: string;
+      startTime?: string;
+      end_time?: string;
+      endTime?: string;
+      free_busy?: Array<{
+        emails: string;
+        object: string;
+        time_slots: Array<{
+          object: string;
+          status: string;
+          start_time: string;
+          end_time: string;
+        }>;
+      }>;
+      open_hours: Array<{
+        emails: string[];
+        days: string[];
+        timezone: string;
+        start: string;
+        end: string;
+        object_type: string;
+      }>;
+    },
+    callback?: (error: Error | null, data?: { [key: string]: any }) => void
+  ) {
     return this.connection
       .request({
         method: 'POST',
@@ -87,8 +89,8 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
           start_time: options.startTime || options.start_time,
           end_time: options.endTime || options.end_time,
           free_busy: options.free_busy || [],
-          open_hours: options.open_hours
-        }
+          open_hours: options.open_hours,
+        },
       })
       .then(json => {
         if (callback) {


### PR DESCRIPTION
# Description
This functionality was added by @gianpaj (#248), this PR just adds some consistency fixes to match Node SDK. This change enables support for the `/calendar/availability` endpoint.

# Usage
```
const params = {
  startTime: '1590454800',
  endTime: '1590780800',
  interval: 5,
  duration: 30,
  emails: ['jane@email.com'],
  open_hours: [
    {
      emails: ['swag@nylas.com'],
      days: ['0'],
      timezone: 'America/Chicago',
      start: '10:00',
      end: '14:00',
      object_type: 'open_hours',
    },
  ],
};

const availability = await testContext.connection.calendars.availability(params);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.