### PR TITLE
[63892] v5.6.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.6.0 / 2021-07-14
 * Fix Jest test cases not respecting async methods
 * Fix issue with parsing raw MIME emails
 * Add linting, enabled and set up eslint and prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "5.5.1",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description

New `nylas` v5.6.0 release bringing in the following fixes:
* Fix Jest test cases not respecting async methods (#249)
* Fix issue with parsing raw MIME emails (#247)
* Add linting, enabled and set up eslint and prettier (#252)
* Add support for `/calendars/availability` endpoint (#248, #254)
* Add support for the Neural API (#253) 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.