### PR TITLE
[64365] Apply fixes to the Neural API Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix minor issues with Neural API implementation
+
 ### 5.6.0 / 2021-07-14
 * Fix Jest test cases not respecting async methods
 * Fix issue with parsing raw MIME emails

--- a/__tests__/neural-spec.js
+++ b/__tests__/neural-spec.js
@@ -326,7 +326,24 @@ describe('Neural', () => {
         });
     });
 
-    //TODO::Add test for recategorize
+    test('should properly call recategorize and return a new NeuralCategorize object', async done => {
+      const categorizeList = await testContext.connection.neural.categorize([
+        'abc123',
+      ]);
+      const newCategorize = await categorizeList[0].reCategorize('feed');
+      const options = testContext.connection.request.mock.calls[1][0];
+
+      expect(options.url.toString()).toEqual(
+        'https://api.nylas.com/neural/categorize/feedback'
+      );
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        message_id: 'abc123',
+        category: 'feed',
+      });
+      evaluateCategorize(newCategorize.categorizer);
+      done();
+    });
   });
 
   describe('OCR', () => {

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -23,7 +23,7 @@ Categorize.attributes = {
   category: Attributes.String({
     modelKey: 'category',
   }),
-  categorizedAt: Attributes.Date({
+  categorizedAt: Attributes.DateTime({
     modelKey: 'categorizedAt',
     jsonKey: 'categorized_at',
   }),
@@ -49,8 +49,11 @@ export default class NeuralCategorizer extends Message {
           'Content-Type': 'application/json',
         },
       })
-      .then(json => {
-        return this.connection.neural.categorize(json['message_id']);
+      .then(async json => {
+        const categorizeResponse = await this.connection.neural.categorize([
+          json['message_id'],
+        ]);
+        return categorizeResponse[0];
       });
   }
 }

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -119,7 +119,7 @@ NeuralSignatureContact.attributes = {
     modelKey: 'links',
     itemClass: Links,
   }),
-  phoneNumbers: Attributes.String({
+  phoneNumbers: Attributes.StringList({
     modelKey: 'phoneNumbers',
     jsonKey: 'phone_numbers',
   }),

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -16,23 +16,33 @@ export type NeuralMessageOptions = {
 
 export default class Neural extends RestfulModel {
   sentimentAnalysisMessage(
-    messageId: string
-  ): Promise<NeuralSentimentAnalysis> {
-    const body = { message_id: [messageId] };
-    return this._sentimentAnalysis(body);
+    messageIds: string[]
+  ): Promise<NeuralSentimentAnalysis[]> {
+    const body = { message_id: messageIds };
+    const path = 'sentiment';
+
+    return this._request(path, body).then((jsonArray: any) => {
+      return jsonArray.map((json: any) => {
+        return new NeuralSentimentAnalysis(this.connection, json);
+      });
+    });
   }
 
   sentimentAnalysisText(text: string): Promise<NeuralSentimentAnalysis> {
     const body = { text: text };
-    return this._sentimentAnalysis(body);
+    const path = 'sentiment';
+
+    return this._request(path, body).then(json => {
+      return new NeuralSentimentAnalysis(this.connection, json);
+    });
   }
 
   extractSignature(
-    messageId: string,
+    messageIds: string[],
     parseContact?: boolean,
     options?: NeuralMessageOptions
-  ): Promise<NeuralSignatureExtraction> {
-    let body: { [key: string]: any } = { message_id: [messageId] };
+  ): Promise<NeuralSignatureExtraction[]> {
+    let body: { [key: string]: any } = { message_id: messageIds };
     const path = 'signature';
 
     if (options) {
@@ -45,18 +55,17 @@ export default class Neural extends RestfulModel {
       body['parse_contact'] = parseContact;
     }
 
-    return this._request(path, body).then(json => {
-      if (Array.isArray(json)) {
-        json = json[0];
-      }
-      const signature = new NeuralSignatureExtraction(this.connection, json);
-      if (parseContact !== false) {
-        signature.contacts = new NeuralSignatureContact(
-          this.connection,
-          signature.contacts
-        );
-      }
-      return signature;
+    return this._request(path, body).then((jsonArray: any) => {
+      return jsonArray.map((json: any) => {
+        const signature = new NeuralSignatureExtraction(this.connection, json);
+        if (parseContact !== false) {
+          signature.contacts = new NeuralSignatureContact(
+            this.connection,
+            signature.contacts
+          );
+        }
+        return signature;
+      });
     });
   }
 
@@ -73,27 +82,27 @@ export default class Neural extends RestfulModel {
     });
   }
 
-  categorize(messageId: string): Promise<NeuralCategorizer> {
-    const body = { message_id: [messageId] };
+  categorize(messageIds: string[]): Promise<NeuralCategorizer[]> {
+    const body = { message_id: messageIds };
     const path = 'categorize';
-    return this._request(path, body).then(json => {
-      if (Array.isArray(json)) {
-        json = json[0];
-      }
-      const category = new NeuralCategorizer(this.connection, json);
-      category.categorizer = new Categorize(
-        this.connection,
-        category.categorizer
-      );
-      return category;
+
+    return this._request(path, body).then((jsonArray: any) => {
+      return jsonArray.map((json: any) => {
+        const category = new NeuralCategorizer(this.connection, json);
+        category.categorizer = new Categorize(
+          this.connection,
+          category.categorizer
+        );
+        return category;
+      });
     });
   }
 
   cleanConversation(
-    messageId: string,
+    messageIds: string[],
     options?: NeuralMessageOptions
-  ): Promise<NeuralCleanConversation> {
-    let body: { [key: string]: any } = { message_id: [messageId] };
+  ): Promise<NeuralCleanConversation[]> {
+    let body: { [key: string]: any } = { message_id: messageIds };
     const path = 'conversation';
 
     if (options) {
@@ -103,23 +112,10 @@ export default class Neural extends RestfulModel {
       };
     }
 
-    return this._request(path, body).then(json => {
-      // The Neural API will always return only one item
-      // but sometimes it returns it in the form of a 'singleton' array
-      if (Array.isArray(json)) {
-        json = json[0];
-      }
-      return new NeuralCleanConversation(this.connection, json);
-    });
-  }
-
-  _sentimentAnalysis(body: object): Promise<NeuralSentimentAnalysis> {
-    const path = 'sentiment';
-    return this._request(path, body).then(json => {
-      if (Array.isArray(json)) {
-        json = json[0];
-      }
-      return new NeuralSentimentAnalysis(this.connection, json);
+    return this._request(path, body).then((jsonArray: any) => {
+      return jsonArray.map((json: any) => {
+        return new NeuralCleanConversation(this.connection, json);
+      });
     });
   }
 


### PR DESCRIPTION
# Description
This PR brings a few minor fixes for the SDK's implementation of Neural API. The main 3 fixes are:
* Support for multiple `message_id`s in one request to the Neural APIs that support it
* In `NeuralSignatureContact`, `phoneNumbers` was incorrectly cast as a String instead of array of Strings
* In `NeuralCategorizer`, we now support epoch for the `categorized_at` field

Updated code samples can be found below.

# Usage
To use [Sentiment Analysis](https://developer.nylas.com/docs/intelligence/sentiment-analysis/):
```javascript
// To perform sentiment analysis on a message, pass in the message ID:
const messageAnalysis = await nylas.neural.sentimentAnalysisMessage([MESSAGE_ID]);

// To perform sentiment analysis on just text, pass in a string:
const textAnalysis = await nylas.neural.sentimentAnalysisText("Hi, thank you so much for reaching out! We can catch up tomorrow.");
```

To use [Signature Extraction](https://developer.nylas.com/docs/intelligence/signature-extraction/):
```javascript
const signature = await nylas.neural.extractSignature([MESSAGE_ID]);

// The method also accepts two optional parameters
// parseContact, a boolean for whether Nylas should parse the contact from the signature (API defaults to true)
// options, an object of options that can be enabled for the Neural endpoint, of type NeuralMessageOptions:
const options = {
    ignore_links: false,
    ignore_images: false,
    ignore_tables: false,
    remove_conclusion_phrases: false,
    images_as_markdowns: false
}

const signature = await nylas.neural.extractSignature([MESSAGE_ID], true, options);
```
and to parse the contact and convert it to the standard Nylas contact object:
```javascript
const contact = signature[0].contacts.toContactObject();
```

To use [Clean Conversations](https://developer.nylas.com/docs/intelligence/clean-conversations/):
```javascript
const convo = await nylas.neural.cleanConversation([MESSAGE_ID]);

// You can also pass in an object of options that can be enabled for the Neural endpoint, of type NeuralMessageOptions
const convo = await nylas.neural.cleanConversation([MESSAGE_ID], options);
```
and to extract images from the result:
```javascript
await convo[0].extractImages();
```

To use [Optical Character Recognition](https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/):
```javascript
const ocr = await nylas.neural.ocrRequest(FILE_ID);

// This endpoint also supports a second, optional parameter for an array specifying the pages that the user wants analyzed:
const ocr = await nylas.neural.ocrRequest(FILE_ID, [2,3]);
```


To use [Categorizer](https://developer.nylas.com/docs/intelligence/categorizer/)
```javascript
let cat = await nylas.neural.categorize([MESSAGE_ID]);

// You can also send a request to recategorize the message:
cat = await cat[0].reCategorize("conversation");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.