### PR TITLE
[63848] Add missing fields for recurring events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix minor issues with Neural API implementation
+* Add missing fields for recurring events
 
 ### 5.6.0 / 2021-07-14
 * Fix Jest test cases not respecting async methods

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -413,6 +413,8 @@ describe('Event', () => {
             when: { time: 1409594400, object: 'time' },
             participants: [{ name: 'foo', email: 'bar', status: 'noreply' }],
             ical_uid: 'id-5678',
+            master_event_id: 'master-1234',
+            original_start_time: 1409592400,
           };
           return Promise.resolve(eventJSON);
         });
@@ -425,6 +427,8 @@ describe('Event', () => {
           expect(event.when.time).toEqual(1409594400);
           expect(event.when.object).toEqual('time');
           expect(event.iCalUID).toBe('id-5678');
+          expect(event.masterEventId).toBe('master-1234');
+          expect(event.originalStartTime.toString()).toBe(new Date(1409592400 * 1000).toString())
           const participant = event.participants[0];
           expect(participant.toJSON()).toEqual({
             name: 'foo',

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -428,7 +428,9 @@ describe('Event', () => {
           expect(event.when.object).toEqual('time');
           expect(event.iCalUID).toBe('id-5678');
           expect(event.masterEventId).toBe('master-1234');
-          expect(event.originalStartTime.toString()).toBe(new Date(1409592400 * 1000).toString())
+          expect(event.originalStartTime.toString()).toBe(
+            new Date(1409592400 * 1000).toString()
+          );
           const participant = event.participants[0];
           expect(participant.toJSON()).toEqual({
             name: 'foo',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -189,10 +189,12 @@ Event.attributes = {
   masterEventId: Attributes.String({
     modelKey: 'masterEventId',
     jsonKey: 'master_event_id',
+    readOnly: true
   }),
   originalStartTime: Attributes.DateTime({
     modelKey: 'originalStartTime',
     jsonKey: 'original_start_time',
+    readOnly: true
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -189,12 +189,12 @@ Event.attributes = {
   masterEventId: Attributes.String({
     modelKey: 'masterEventId',
     jsonKey: 'master_event_id',
-    readOnly: true
+    readOnly: true,
   }),
   originalStartTime: Attributes.DateTime({
     modelKey: 'originalStartTime',
     jsonKey: 'original_start_time',
-    readOnly: true
+    readOnly: true,
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -27,6 +27,8 @@ export default class Event extends RestfulModel {
     rrule: string[];
     timezone: string;
   };
+  masterEventId?: string;
+  originalStartTime?: number;
   metadata?: object;
 
   get start() {
@@ -183,6 +185,14 @@ Event.attributes = {
   }),
   recurrence: Attributes.Object({
     modelKey: 'recurrence',
+  }),
+  masterEventId: Attributes.String({
+    modelKey: 'masterEventId',
+    jsonKey: 'master_event_id',
+  }),
+  originalStartTime: Attributes.DateTime({
+    modelKey: 'originalStartTime',
+    jsonKey: 'original_start_time',
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',


### PR DESCRIPTION
# Description
The `Event` class was missing two fields that are present in recurring events, and are now added:
* `master_event_id` which represents the ID of the recurring event, and
* `original_start_time` which represents the start time of the recurring event

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.