### PR TITLE
[64663] Add Conferencing Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Fix minor issues with Neural API implementation
 * Add missing fields for recurring events
+* Add support for conferencing
 
 ### 5.6.0 / 2021-07-14
 * Fix Jest test cases not respecting async methods

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -404,6 +404,50 @@ describe('Event', () => {
       });
     });
 
+    test('should create an event with conferencing options', done => {
+      const conferenceEvent = testContext.connection.events.build({
+        conferencing: {
+          provider: "Zoom Meeting",
+          details: {
+            url: "https://us02web.zoom.us/j/****************",
+            meeting_code: "213",
+            password: "xyz",
+            phone: [
+              "+11234567890"
+            ]
+          }
+        },
+      });
+      conferenceEvent.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: undefined,
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: undefined,
+          _start: undefined,
+          _end: undefined,
+          participants: [],
+          conferencing: {
+            provider: "Zoom Meeting",
+            details: {
+              url: "https://us02web.zoom.us/j/****************",
+              meeting_code: "213",
+              password: "xyz",
+              phone: [
+                "+11234567890"
+              ]
+            },
+          },
+        });
+        done();
+      });
+    });
+
     describe('when the request succeeds', () => {
       beforeEach(() => {
         testContext.connection.request = jest.fn(() => {

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -407,15 +407,13 @@ describe('Event', () => {
     test('should create an event with conferencing options', done => {
       const conferenceEvent = testContext.connection.events.build({
         conferencing: {
-          provider: "Zoom Meeting",
+          provider: 'Zoom Meeting',
           details: {
-            url: "https://us02web.zoom.us/j/****************",
-            meeting_code: "213",
-            password: "xyz",
-            phone: [
-              "+11234567890"
-            ]
-          }
+            url: 'https://us02web.zoom.us/j/****************',
+            meeting_code: '213',
+            password: 'xyz',
+            phone: ['+11234567890'],
+          },
         },
       });
       conferenceEvent.save().then(() => {
@@ -433,14 +431,12 @@ describe('Event', () => {
           _end: undefined,
           participants: [],
           conferencing: {
-            provider: "Zoom Meeting",
+            provider: 'Zoom Meeting',
             details: {
-              url: "https://us02web.zoom.us/j/****************",
-              meeting_code: "213",
-              password: "xyz",
-              phone: [
-                "+11234567890"
-              ]
+              url: 'https://us02web.zoom.us/j/****************',
+              meeting_code: '213',
+              password: 'xyz',
+              phone: ['+11234567890'],
             },
           },
         });

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -49,6 +49,23 @@ class AttributeObject extends Attribute {
     super({ modelKey, jsonKey, readOnly });
     this.itemClass = itemClass;
   }
+
+  toJSON(val: any) {
+    if (!val) {
+      return val;
+    }
+    if (val.toJSON != null) {
+      return val.toJSON()
+    }
+    return val;
+  }
+
+  fromJSON(val: any, _parent: any) {
+    if(!val || !this.itemClass) {
+      return val;
+    }
+    return new this.itemClass(_parent.connection, val);
+  }
 }
 
 class AttributeNumber extends Attribute {

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -55,13 +55,13 @@ class AttributeObject extends Attribute {
       return val;
     }
     if (val.toJSON != null) {
-      return val.toJSON()
+      return val.toJSON();
     }
     return val;
   }
 
   fromJSON(val: any, _parent: any) {
-    if(!val || !this.itemClass) {
+    if (!val || !this.itemClass) {
       return val;
     }
     return new this.itemClass(_parent.connection, val);

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -40,7 +40,7 @@ EventConferencingDetails.attributes = {
 
 export class EventConferencing extends RestfulModel {
   details?: EventConferencingDetails;
-  provider?: string
+  provider?: string;
 
   toJSON(): any {
     return {
@@ -53,7 +53,7 @@ EventConferencing.collectionName = 'event_conferencing';
 EventConferencing.attributes = {
   details: Attributes.Object({
     modelKey: 'details',
-    itemClass: EventConferencingDetails
+    itemClass: EventConferencingDetails,
   }),
   provider: Attributes.String({
     modelKey: 'provider',

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -10,7 +10,7 @@ class EventConferencingDetails extends RestfulModel {
 
   toJSON() {
     return {
-      meetingCode: this.meetingCode,
+      meeting_code: this.meetingCode,
       phone: this.phone,
       password: this.password,
       pin: this.pin,

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -1,0 +1,61 @@
+import RestfulModel from './restful-model';
+import Attributes from './attributes';
+
+class EventConferencingDetails extends RestfulModel {
+  meetingCode?: string;
+  phone?: string[];
+  password?: string;
+  pin?: string;
+  url?: string;
+
+  toJSON() {
+    return {
+      meetingCode: this.meetingCode,
+      phone: this.phone,
+      password: this.password,
+      pin: this.pin,
+      url: this.url,
+    };
+  }
+}
+EventConferencingDetails.collectionName = 'event_conferencing_details';
+EventConferencingDetails.attributes = {
+  meetingCode: Attributes.String({
+    modelKey: 'meetingCode',
+    jsonKey: 'meeting_code',
+  }),
+  phone: Attributes.StringList({
+    modelKey: 'phone',
+  }),
+  password: Attributes.String({
+    modelKey: 'password',
+  }),
+  pin: Attributes.String({
+    modelKey: 'pin',
+  }),
+  url: Attributes.String({
+    modelKey: 'url',
+  }),
+};
+
+export class EventConferencing extends RestfulModel {
+  details?: EventConferencingDetails;
+  provider?: string
+
+  toJSON(): any {
+    return {
+      details: this.details,
+      provider: this.provider,
+    };
+  }
+}
+EventConferencing.collectionName = 'event_conferencing';
+EventConferencing.attributes = {
+  details: Attributes.Object({
+    modelKey: 'details',
+    itemClass: EventConferencingDetails
+  }),
+  provider: Attributes.String({
+    modelKey: 'provider',
+  }),
+};

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,6 +1,7 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 import EventParticipant from './event-participant';
+import { EventConferencing } from './event-conferencing';
 
 export default class Event extends RestfulModel {
   calendarId?: string;
@@ -29,6 +30,7 @@ export default class Event extends RestfulModel {
   };
   masterEventId?: string;
   originalStartTime?: number;
+  conferencing?: EventConferencing;
   metadata?: object;
 
   get start() {
@@ -195,6 +197,10 @@ Event.attributes = {
     modelKey: 'originalStartTime',
     jsonKey: 'original_start_time',
     readOnly: true,
+  }),
+  conferencing: Attributes.Object({
+    modelKey: 'conferencing',
+    itemClass: EventConferencing,
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -57,14 +57,7 @@ export default class Neural extends RestfulModel {
 
     return this._request(path, body).then((jsonArray: any) => {
       return jsonArray.map((json: any) => {
-        const signature = new NeuralSignatureExtraction(this.connection, json);
-        if (parseContact !== false) {
-          signature.contacts = new NeuralSignatureContact(
-            this.connection,
-            signature.contacts
-          );
-        }
-        return signature;
+        return new NeuralSignatureExtraction(this.connection, json);
       });
     });
   }
@@ -88,12 +81,7 @@ export default class Neural extends RestfulModel {
 
     return this._request(path, body).then((jsonArray: any) => {
       return jsonArray.map((json: any) => {
-        const category = new NeuralCategorizer(this.connection, json);
-        category.categorizer = new Categorize(
-          this.connection,
-          category.categorizer
-        );
-        return category;
+        return new NeuralCategorizer(this.connection, json);
       });
     });
   }

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -2,9 +2,8 @@ import RestfulModel from './restful-model';
 import NeuralSentimentAnalysis from './neural-sentiment-analysis';
 import NeuralSignatureExtraction from './neural-signature-extraction';
 import NeuralOcr from './neural-ocr';
-import NeuralCategorizer, { Categorize } from './neural-categorizer';
+import NeuralCategorizer from './neural-categorizer';
 import NeuralCleanConversation from './neural-clean-conversation';
-import NeuralSignatureContact from './neural-signature-contact';
 
 export type NeuralMessageOptions = {
   ignore_links?: boolean;


### PR DESCRIPTION
# Description
This PR enables support for the new Nylas [Conference Sync (Beta)](https://developer.nylas.com/docs/connectivity/calendar/conference-sync-beta) feature.

# Usage
`Event.conference` is now a field that will contain conference details for Events that contain them, and it can be populated when new events through the SDK.

You can read the values like so:
```javascript
const event = await nylas.events.find("id");
const conferencingProvider = event.conferencing.provider;
const conferenceURL = event.conferencing.details.url;
const conferencePassword = event.conferencing.details.password;
const conferenceMeetingCode = event.conferencing.details.meetingCode;
const conferencePhoneNumbers = event.conferencing.details.phone;
const conferencePin = event.conferencing.details.pin;
```
You can also build a new event that includes conferencing details with the SDK:
```javascript
const zoomEvent = nylas.events.build({
    ...
    conferencing: {
        provider: "Zoom Meeting",
        details: {
            url: "https://us02web.zoom.us/j/****************",
            meeting_code: "213",
            password: "xyz",
            phone: [
                "+11234567890"
            ]
        }
    },
});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.