### PR TITLE
[65378] Dynamic conferencing link creation support

### DIFF
--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -419,7 +419,9 @@ describe('Event', () => {
         });
         conferenceEvent.save().then(() => {
           const options = testContext.connection.request.mock.calls[0][0];
-          expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/events'
+          );
           expect(options.method).toEqual('POST');
           expect(JSON.parse(options.body)).toEqual({
             calendar_id: undefined,
@@ -451,14 +453,16 @@ describe('Event', () => {
             provider: 'Zoom Meeting',
             autocreate: {
               settings: {
-                password: "1234"
-              }
+                password: '1234',
+              },
             },
           },
         });
         conferenceEvent.save().then(() => {
           const options = testContext.connection.request.mock.calls[0][0];
-          expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/events'
+          );
           expect(options.method).toEqual('POST');
           expect(JSON.parse(options.body)).toEqual({
             calendar_id: undefined,
@@ -474,8 +478,8 @@ describe('Event', () => {
               provider: 'Zoom Meeting',
               autocreate: {
                 settings: {
-                  password: "1234"
-                }
+                  password: '1234',
+                },
               },
             },
           });
@@ -495,17 +499,21 @@ describe('Event', () => {
             },
             autocreate: {
               settings: {
-                password: "1234"
-              }
+                password: '1234',
+              },
             },
           },
         });
         conferenceEvent.save().catch(e => {
-          expect(e).toEqual(new Error("Cannot set both 'details' and 'autocreate' in conferencing object."));
-        })
+          expect(e).toEqual(
+            new Error(
+              "Cannot set both 'details' and 'autocreate' in conferencing object."
+            )
+          );
+        });
         done();
       });
-    })
+    });
 
     describe('when the request succeeds', () => {
       beforeEach(() => {

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -404,32 +404,9 @@ describe('Event', () => {
       });
     });
 
-    test('should create an event with conferencing options', done => {
-      const conferenceEvent = testContext.connection.events.build({
-        conferencing: {
-          provider: 'Zoom Meeting',
-          details: {
-            url: 'https://us02web.zoom.us/j/****************',
-            meeting_code: '213',
-            password: 'xyz',
-            phone: ['+11234567890'],
-          },
-        },
-      });
-      conferenceEvent.save().then(() => {
-        const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
-        expect(options.method).toEqual('POST');
-        expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
-          busy: undefined,
-          title: undefined,
-          description: undefined,
-          location: undefined,
-          when: undefined,
-          _start: undefined,
-          _end: undefined,
-          participants: [],
+    describe('conferencing', () => {
+      test('should create an event with conferencing details', done => {
+        const conferenceEvent = testContext.connection.events.build({
           conferencing: {
             provider: 'Zoom Meeting',
             details: {
@@ -440,9 +417,95 @@ describe('Event', () => {
             },
           },
         });
+        conferenceEvent.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            calendar_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            location: undefined,
+            when: undefined,
+            _start: undefined,
+            _end: undefined,
+            participants: [],
+            conferencing: {
+              provider: 'Zoom Meeting',
+              details: {
+                url: 'https://us02web.zoom.us/j/****************',
+                meeting_code: '213',
+                password: 'xyz',
+                phone: ['+11234567890'],
+              },
+            },
+          });
+          done();
+        });
+      });
+
+      test('should create an event with conferencing autocreate set', done => {
+        const conferenceEvent = testContext.connection.events.build({
+          conferencing: {
+            provider: 'Zoom Meeting',
+            autocreate: {
+              settings: {
+                password: "1234"
+              }
+            },
+          },
+        });
+        conferenceEvent.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            calendar_id: undefined,
+            busy: undefined,
+            title: undefined,
+            description: undefined,
+            location: undefined,
+            when: undefined,
+            _start: undefined,
+            _end: undefined,
+            participants: [],
+            conferencing: {
+              provider: 'Zoom Meeting',
+              autocreate: {
+                settings: {
+                  password: "1234"
+                }
+              },
+            },
+          });
+          done();
+        });
+      });
+
+      test('should throw exception if both conferencing details and autocreate are set', done => {
+        const conferenceEvent = testContext.connection.events.build({
+          conferencing: {
+            provider: 'Zoom Meeting',
+            details: {
+              url: 'https://us02web.zoom.us/j/****************',
+              meeting_code: '213',
+              password: 'xyz',
+              phone: ['+11234567890'],
+            },
+            autocreate: {
+              settings: {
+                password: "1234"
+              }
+            },
+          },
+        });
+        conferenceEvent.save().catch(e => {
+          expect(e).toEqual(new Error("Cannot set both 'details' and 'autocreate' in conferencing object."));
+        })
         done();
       });
-    });
+    })
 
     describe('when the request succeeds', () => {
       beforeEach(() => {

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -41,11 +41,15 @@ EventConferencingDetails.attributes = {
 export class EventConferencing extends RestfulModel {
   details?: EventConferencingDetails;
   provider?: string;
+  autocreate?: {
+    settings?: object;
+  }
 
   toJSON(): any {
     return {
       details: this.details,
       provider: this.provider,
+      autocreate: this.autocreate,
     };
   }
 }
@@ -57,5 +61,8 @@ EventConferencing.attributes = {
   }),
   provider: Attributes.String({
     modelKey: 'provider',
+  }),
+  autocreate: Attributes.Object({
+    modelKey: 'autocreate',
   }),
 };

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -43,7 +43,7 @@ export class EventConferencing extends RestfulModel {
   provider?: string;
   autocreate?: {
     settings?: object;
-  }
+  };
 
   toJSON(): any {
     return {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -32,6 +32,7 @@ export default class Event extends RestfulModel {
   originalStartTime?: number;
   conferencing?: EventConferencing;
   metadata?: object;
+  jobStatusId?: string;
 
   get start() {
     const start =
@@ -204,5 +205,9 @@ Event.attributes = {
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',
+  }),
+  jobStatusId: Attributes.String({
+    modelKey: 'jobStatusId',
+    jsonKey: 'job_status_id',
   }),
 };

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -113,8 +113,16 @@ export default class Event extends RestfulModel {
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
-    if(this.conferencing && this.conferencing.details && this.conferencing.autocreate) {
-      return Promise.reject(new Error("Cannot set both 'details' and 'autocreate' in conferencing object."));
+    if (
+      this.conferencing &&
+      this.conferencing.details &&
+      this.conferencing.autocreate
+    ) {
+      return Promise.reject(
+        new Error(
+          "Cannot set both 'details' and 'autocreate' in conferencing object."
+        )
+      );
     }
     return this._save(params, callback);
   }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -113,6 +113,9 @@ export default class Event extends RestfulModel {
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+    if(this.conferencing && this.conferencing.details && this.conferencing.autocreate) {
+      return Promise.reject(new Error("Cannot set both 'details' and 'autocreate' in conferencing object."));
+    }
     return this._save(params, callback);
   }
 


### PR DESCRIPTION
# Description
The Event API, in addition to support for manually-added conference details, supports auto generating conference details. If you have an integration authorized and enabled for your Nylas account you can provide an `autocreate` object instead of a `details` object to have the Nylas API autofill the conferencing details.

# Usage
To have Nylas autocreate the conference field for you, pass the `autocreate` object to the new event:
```javascript
const zoomEvent = nylas.events.build({
    ...
    conferencing: {
        provider: "Zoom Meeting",
        autocreate: {
            settings: {},
        }
    },
});
```
A few notes and things to keep in mind:
* Only **one** of `details` or `autocreate` can be present, and we have implemented client-side checking to enforce this rule
* Autocreating conferencing data is an asynchronous operation on the server-side. The Event object returned will not have a conferencing field, but it should be available in a future get call once the conference is created on the backend. The initial Event object returned will have a `jobStatusId` value which can be used to check on the status of conference creation.
* The `settings` object within the `autocreate` object maps to the settings the Nylas API will send to the conference provider for the conference creation. For example with Zoom the settings object maps to Zoom's [Create a Meeting object](https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingcreate).

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.