### PR TITLE
[66948] Fix JSON.stringify omitting read only values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue where JSON.stringify would omit read-only values
+
 ### 5.7.0 / 2021-08-18
 * Fix minor issues with Neural API implementation
 * Fix not rejecting uncaught errors during requests

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -56,7 +56,7 @@ export default class RestfulModel {
     const json: any = {};
     const attributes = this.attributes();
     for (const attrName in attributes) {
-      if (!enforceReadOnly || !attributes[attrName].readOnly) {
+      if (!attributes[attrName].readOnly || enforceReadOnly !== true) {
         const attr = attributes[attrName];
         json[attr.jsonKey] = attr.toJSON((this as any)[attrName]);
       }


### PR DESCRIPTION
# Describe
The conditional logic in the RestfulModel `toJSON` method was not explicit enough on the value of `enforceReadOnly`, leading to JSON.stringify unintentionally ignoring read only values.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.