### PR TITLE
[66696] Improve deserialization and object creation

### DIFF
--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -53,16 +53,20 @@ describe('CalendarRestfulModelCollection', () => {
       },
       json: () => {
         return Promise.resolve(
-          JSON.stringify([{
-            object: "free_busy",
-            email: "jane@email.com",
-            time_slots: [{
-              object: "time_slot",
-              status: "busy",
-              start_time: 1590454800,
-              end_time: 1590780800
-            }]
-          }])
+          JSON.stringify([
+            {
+              object: 'free_busy',
+              email: 'jane@email.com',
+              time_slots: [
+                {
+                  object: 'time_slot',
+                  status: 'busy',
+                  start_time: 1590454800,
+                  end_time: 1590780800,
+                },
+              ],
+            },
+          ])
         );
       },
       headers: new Map(),
@@ -91,12 +95,12 @@ describe('CalendarRestfulModelCollection', () => {
       );
       expect(freeBusy.length).toEqual(1);
       freeBusy = freeBusy[0];
-      expect(freeBusy.object).toEqual("free_busy");
-      expect(freeBusy.email).toEqual("jane@email.com");
+      expect(freeBusy.object).toEqual('free_busy');
+      expect(freeBusy.email).toEqual('jane@email.com');
       expect(freeBusy.timeSlots.length).toEqual(1);
       const timeSlots = freeBusy.timeSlots[0];
-      expect(timeSlots.object).toEqual("time_slot");
-      expect(timeSlots.status).toEqual("busy");
+      expect(timeSlots.object).toEqual('time_slot');
+      expect(timeSlots.status).toEqual('busy');
       expect(timeSlots.startTime).toEqual(1590454800);
       expect(timeSlots.endTime).toEqual(1590780800);
       done();

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -45,44 +45,60 @@ describe('CalendarRestfulModelCollection', () => {
     fetch.mockImplementation(() => Promise.resolve(response));
   });
 
-  const evaluateFreeBusy = () => {
-    const options = testContext.connection.request.mock.calls[0][0];
-    expect(options.url.toString()).toEqual(
-      'https://api.nylas.com/calendars/free-busy'
-    );
-    expect(options.method).toEqual('POST');
-    expect(JSON.parse(options.body)).toEqual({
-      start_time: '1590454800',
-      end_time: '1590780800',
-      emails: ['jane@email.com'],
-    });
-    expect(options.headers['authorization']).toEqual(
-      `Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`
-    );
-  };
-
-  test('[FREE BUSY] should fetch results with snakecase params', done => {
-    const params = {
-      start_time: '1590454800',
-      end_time: '1590780800',
-      emails: ['jane@email.com'],
-    };
-
-    return testContext.connection.calendars.freeBusy(params).then(() => {
-      evaluateFreeBusy();
-      done();
-    });
-  });
-
   test('[FREE BUSY] should fetch results with camelcase params', done => {
+    const response = {
+      status: 200,
+      buffer: () => {
+        return Promise.resolve('body');
+      },
+      json: () => {
+        return Promise.resolve(
+          JSON.stringify([{
+            object: "free_busy",
+            email: "jane@email.com",
+            time_slots: [{
+              object: "time_slot",
+              status: "busy",
+              start_time: 1590454800,
+              end_time: 1590780800
+            }]
+          }])
+        );
+      },
+      headers: new Map(),
+    };
+    fetch.mockImplementation(() => Promise.resolve(response));
+
     const params = {
-      startTime: '1590454800',
-      endTime: '1590780800',
+      startTime: 1590454800,
+      endTime: 1590780800,
       emails: ['jane@email.com'],
     };
 
-    return testContext.connection.calendars.freeBusy(params).then(() => {
-      evaluateFreeBusy();
+    return testContext.connection.calendars.freeBusy(params).then(freeBusy => {
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual(
+        'https://api.nylas.com/calendars/free-busy'
+      );
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        start_time: '1590454800',
+        end_time: '1590780800',
+        emails: ['jane@email.com'],
+      });
+      expect(options.headers['authorization']).toEqual(
+        `Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`
+      );
+      expect(freeBusy.length).toEqual(1);
+      freeBusy = freeBusy[0];
+      expect(freeBusy.object).toEqual("free_busy");
+      expect(freeBusy.email).toEqual("jane@email.com");
+      expect(freeBusy.timeSlots.length).toEqual(1);
+      const timeSlots = freeBusy.timeSlots[0];
+      expect(timeSlots.object).toEqual("time_slot");
+      expect(timeSlots.status).toEqual("busy");
+      expect(timeSlots.startTime).toEqual(1590454800);
+      expect(timeSlots.endTime).toEqual(1590780800);
       done();
     });
   });

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -58,7 +58,8 @@ describe('Calendar', () => {
     };
 
     fetch.mockImplementation(req => Promise.resolve(response(req.body)));
-    testContext.calendar = new Calendar(testContext.connection, calendarJSON);
+    testContext.calendar = new Calendar(testContext.connection);
+    testContext.calendar.fromJSON(calendarJSON);
   });
 
   const sharedCalendarEvaluation = calendar => {

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -125,39 +125,49 @@ describe('Contact', () => {
 
   describe('when the request succeeds', () => {
     beforeEach(() => {
-      const contactJSON = {
+      const contactProps = {
         id: '1257',
         object: 'contact',
-        account_id: '1234',
-        given_name: 'John',
-        middle_name: 'Jacob',
+        accountId: '1234',
+        givenName: 'John',
+        middleName: 'Jacob',
         surname: 'Jingleheimer Schmidt',
         suffix: 'II',
         nickname: 'John',
         birthday: '2019-07-01',
-        company_name: 'Life',
-        job_title: 'artist',
-        manager_name: 'April',
-        office_location: 'SF, CA, USA',
+        companyName: 'Life',
+        jobTitle: 'artist',
+        managerName: 'April',
+        officeLocation: 'SF, CA, USA',
         notes: 'lalala',
-        picture_url: 'example.com',
-        emails: [{ type: 'work', email: 'john@test.com' }],
-        im_addresses: [{ type: 'yahoo', im_address: 'jjj' }],
-        physical_addresses: [{ type: 'home', city: 'Boston' }],
-        phone_numbers: [{ type: 'mobile', number: '555-444-3333' }],
-        web_pages: [{ type: 'blog', url: 'johnblogs.com' }],
+        pictureUrl: 'example.com',
+        emailAddresses: [{ type: 'work', email: 'john@test.com' }],
+        imAddresses: [{ type: 'yahoo', imAddress: 'jjj' }],
+        physicalAddresses: [
+          {
+            format: "structured",
+            type: 'home',
+            streetAddress: "102 Test Dr",
+            city: 'Boston',
+            postalCode: "90210",
+            state: "MA",
+            country: "USA"
+          }
+        ],
+        phoneNumbers: [{ type: 'mobile', number: '555-444-3333' }],
+        webPages: [{ type: 'blog', url: 'johnblogs.com' }],
         groups: [
           {
             id: '123',
             object: 'contact_group',
-            account_id: '1234',
+            accountId: '1234',
             name: 'Fam',
             path: 'Fam',
           },
         ],
         source: 'inbox',
       };
-      testContext.contact = new Contact(testContext.connection, contactJSON);
+      testContext.contact = new Contact(testContext.connection, contactProps);
     });
 
     test('should resolve with the contact object', done => {
@@ -188,6 +198,11 @@ describe('Contact', () => {
         expect(contact.physicalAddresses[0].toJSON()).toEqual({
           type: 'home',
           city: 'Boston',
+          country: "USA",
+          format: "structured",
+          postal_code: "90210",
+          state: "MA",
+          street_address: "102 Test Dr",
         });
         expect(contact.phoneNumbers[0].toJSON()).toEqual({
           type: 'mobile',

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -145,14 +145,14 @@ describe('Contact', () => {
         imAddresses: [{ type: 'yahoo', imAddress: 'jjj' }],
         physicalAddresses: [
           {
-            format: "structured",
+            format: 'structured',
             type: 'home',
-            streetAddress: "102 Test Dr",
+            streetAddress: '102 Test Dr',
             city: 'Boston',
-            postalCode: "90210",
-            state: "MA",
-            country: "USA"
-          }
+            postalCode: '90210',
+            state: 'MA',
+            country: 'USA',
+          },
         ],
         phoneNumbers: [{ type: 'mobile', number: '555-444-3333' }],
         webPages: [{ type: 'blog', url: 'johnblogs.com' }],
@@ -198,11 +198,11 @@ describe('Contact', () => {
         expect(contact.physicalAddresses[0].toJSON()).toEqual({
           type: 'home',
           city: 'Boston',
-          country: "USA",
-          format: "structured",
-          postal_code: "90210",
-          state: "MA",
-          street_address: "102 Test Dr",
+          country: 'USA',
+          format: 'structured',
+          postal_code: '90210',
+          state: 'MA',
+          street_address: '102 Test Dr',
         });
         expect(contact.phoneNumbers[0].toJSON()).toEqual({
           type: 'mobile',

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -40,7 +40,6 @@ describe('Draft', () => {
 
     fetch.mockImplementation(req => Promise.resolve(response(req.body)));
 
-    // testContext.connection.request = jest.fn(() => Promise.resolve({}));
     testContext.draft = new Draft(testContext.connection);
   });
 
@@ -303,7 +302,10 @@ Hey Ben, \
 \
 Would you like to grab coffee @ 2pm this Thursday?`;
 
-      const draft = testContext.connection.drafts.build({ rawMime: msg });
+      const draft = new Draft(testContext.connection, {
+        to: [{ email: 'foo', name: 'bar' }],
+        rawMime: msg
+      });
       draft.send().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/send');

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -304,7 +304,7 @@ Would you like to grab coffee @ 2pm this Thursday?`;
 
       const draft = new Draft(testContext.connection, {
         to: [{ email: 'foo', name: 'bar' }],
-        rawMime: msg
+        rawMime: msg,
       });
       draft.send().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -1,7 +1,9 @@
 import NylasConnection from '../src/nylas-connection';
 import Event from '../src/models/event';
+import { EventConferencing } from '../src/models/event-conferencing';
 import Nylas from '../src/nylas';
 import fetch from 'node-fetch';
+import When from '../src/models/when';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -50,12 +52,12 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           busy: undefined,
           title: undefined,
           description: undefined,
           location: undefined,
-          when: undefined,
+          when: {},
           participants: [],
         });
         done();
@@ -71,12 +73,12 @@ describe('Event', () => {
         );
         expect(options.method).toEqual('PUT');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           busy: undefined,
           title: undefined,
           description: undefined,
           location: undefined,
-          when: undefined,
+          when: {},
           participants: [],
         });
         done();
@@ -92,12 +94,12 @@ describe('Event', () => {
         );
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           busy: undefined,
           title: undefined,
           description: undefined,
           location: undefined,
-          when: undefined,
+          when: {},
           participants: [],
         });
         done();
@@ -115,12 +117,12 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           busy: undefined,
           title: undefined,
           description: undefined,
           location: undefined,
-          when: undefined,
+          when: {},
           participants: [],
           recurrence: recurrence,
         });
@@ -129,7 +131,7 @@ describe('Event', () => {
     });
 
     test('should create event with time when start and end are the same UNIX timestamp', done => {
-      testContext.event.when = {};
+      testContext.event.when = new When();
       testContext.event.start = 1408875644;
       testContext.event.end = 1408875644;
       return testContext.event.save().then(() => {
@@ -137,7 +139,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -156,7 +158,6 @@ describe('Event', () => {
     });
 
     test('should create event with start_time and end_time when start and end are different UNIX timestamps', done => {
-      testContext.event.when = {};
       testContext.event.start = 1409594400;
       testContext.event.end = 1409598000;
       return testContext.event.save().then(() => {
@@ -164,7 +165,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -184,7 +185,6 @@ describe('Event', () => {
     });
 
     test('should create event with date when start and end are same ISO date', done => {
-      testContext.event.when = {};
       testContext.event.start = '1912-06-23';
       testContext.event.end = '1912-06-23';
       return testContext.event.save().then(() => {
@@ -192,7 +192,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -211,7 +211,6 @@ describe('Event', () => {
     });
 
     test('should create event with start_date and end_date when start and end are different ISO date', done => {
-      testContext.event.when = {};
       testContext.event.start = '1815-12-10';
       testContext.event.end = '1852-11-27';
       return testContext.event.save().then(() => {
@@ -219,7 +218,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -244,7 +243,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -265,13 +264,16 @@ describe('Event', () => {
     });
 
     test('should create event with start_time and end_time when event param `when` is updated with start_time and end_time', done => {
-      testContext.event.when = { start_time: 1409594400, end_time: 1409598000 };
+      testContext.event.when = new When({
+        startTime: 1409594400,
+        endTime: 1409598000,
+      });
       return testContext.event.save().then(event => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -293,13 +295,14 @@ describe('Event', () => {
     });
 
     test('should create event with date when the event param `when` is updated with date', done => {
-      testContext.event.when = { date: '1912-06-23' };
+      testContext.event.when = new When();
+      testContext.event.when.date = '1912-06-23';
       return testContext.event.save().then(event => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -320,16 +323,16 @@ describe('Event', () => {
     });
 
     test('should create event with start_date and end_date when the event param `when` is updated with start_date and end_date', done => {
-      testContext.event.when = {
-        start_date: '1815-12-10',
-        end_date: '1852-11-27',
-      };
+      testContext.event.when = new When({
+        startDate: '1815-12-10',
+        endDate: '1852-11-27',
+      });
       return testContext.event.save().then(event => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -354,7 +357,7 @@ describe('Event', () => {
       delete testContext.event.when;
       testContext.event.start = '1815-12-10';
       testContext.event.end = '1852-11-27';
-      expect(testContext.event.when).toEqual({
+      expect(testContext.event.when.toJSON()).toEqual({
         start_date: '1815-12-10',
         end_date: '1852-11-27',
       });
@@ -363,7 +366,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -389,14 +392,12 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: undefined,
+          calendar_id: "",
           busy: undefined,
           title: undefined,
           description: undefined,
           location: undefined,
-          when: undefined,
-          _start: undefined,
-          _end: undefined,
+          when: {},
           participants: [],
           metadata: { hello: 'world' },
         });
@@ -406,30 +407,28 @@ describe('Event', () => {
 
     describe('conferencing', () => {
       test('should create an event with conferencing details', done => {
-        const conferenceEvent = testContext.connection.events.build({
-          conferencing: {
-            provider: 'Zoom Meeting',
-            details: {
-              url: 'https://us02web.zoom.us/j/****************',
-              meeting_code: '213',
-              password: 'xyz',
-              phone: ['+11234567890'],
-            },
-          },
+        testContext.event.conferencing = new EventConferencing({
+          provider: 'Zoom Meeting',
+          details: {
+            url: 'https://us02web.zoom.us/j/****************',
+            meetingCode: '213',
+            password: 'xyz',
+            phone: ['+11234567890'],
+          }
         });
-        conferenceEvent.save().then(() => {
+        testContext.event.save().then(() => {
           const options = testContext.connection.request.mock.calls[0][0];
           expect(options.url.toString()).toEqual(
             'https://api.nylas.com/events'
           );
           expect(options.method).toEqual('POST');
           expect(JSON.parse(options.body)).toEqual({
-            calendar_id: undefined,
+            calendar_id: "",
             busy: undefined,
             title: undefined,
             description: undefined,
             location: undefined,
-            when: undefined,
+            when: {},
             _start: undefined,
             _end: undefined,
             participants: [],
@@ -448,31 +447,27 @@ describe('Event', () => {
       });
 
       test('should create an event with conferencing autocreate set', done => {
-        const conferenceEvent = testContext.connection.events.build({
-          conferencing: {
-            provider: 'Zoom Meeting',
-            autocreate: {
-              settings: {
-                password: '1234',
-              },
+        testContext.event.conferencing = new EventConferencing({
+          provider: 'Zoom Meeting',
+          autocreate: {
+            settings: {
+              password: '1234',
             },
           },
         });
-        conferenceEvent.save().then(() => {
+        testContext.event.save().then(() => {
           const options = testContext.connection.request.mock.calls[0][0];
           expect(options.url.toString()).toEqual(
             'https://api.nylas.com/events'
           );
           expect(options.method).toEqual('POST');
           expect(JSON.parse(options.body)).toEqual({
-            calendar_id: undefined,
+            calendar_id: "",
             busy: undefined,
             title: undefined,
             description: undefined,
             location: undefined,
-            when: undefined,
-            _start: undefined,
-            _end: undefined,
+            when: {},
             participants: [],
             conferencing: {
               provider: 'Zoom Meeting',
@@ -488,23 +483,21 @@ describe('Event', () => {
       });
 
       test('should throw exception if both conferencing details and autocreate are set', done => {
-        const conferenceEvent = testContext.connection.events.build({
-          conferencing: {
-            provider: 'Zoom Meeting',
-            details: {
-              url: 'https://us02web.zoom.us/j/****************',
-              meeting_code: '213',
-              password: 'xyz',
-              phone: ['+11234567890'],
-            },
-            autocreate: {
-              settings: {
-                password: '1234',
-              },
+        testContext.event.conferencing = new EventConferencing({
+          provider: 'Zoom Meeting',
+          details: {
+            url: 'https://us02web.zoom.us/j/****************',
+            meeting_code: '213',
+            password: 'xyz',
+            phone: ['+11234567890'],
+          },
+          autocreate: {
+            settings: {
+              password: '1234',
             },
           },
         });
-        conferenceEvent.save().catch(e => {
+        testContext.event.save().catch(e => {
           expect(e).toEqual(
             new Error(
               "Cannot set both 'details' and 'autocreate' in conferencing object."

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -52,7 +52,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           busy: undefined,
           title: undefined,
           description: undefined,
@@ -73,7 +73,7 @@ describe('Event', () => {
         );
         expect(options.method).toEqual('PUT');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           busy: undefined,
           title: undefined,
           description: undefined,
@@ -94,7 +94,7 @@ describe('Event', () => {
         );
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           busy: undefined,
           title: undefined,
           description: undefined,
@@ -117,7 +117,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           busy: undefined,
           title: undefined,
           description: undefined,
@@ -139,7 +139,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -165,7 +165,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -192,7 +192,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -218,7 +218,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -243,7 +243,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -273,7 +273,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -302,7 +302,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -332,7 +332,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -366,7 +366,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           message_id: undefined,
           busy: undefined,
           title: undefined,
@@ -392,7 +392,7 @@ describe('Event', () => {
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          calendar_id: "",
+          calendar_id: '',
           busy: undefined,
           title: undefined,
           description: undefined,
@@ -414,7 +414,7 @@ describe('Event', () => {
             meetingCode: '213',
             password: 'xyz',
             phone: ['+11234567890'],
-          }
+          },
         });
         testContext.event.save().then(() => {
           const options = testContext.connection.request.mock.calls[0][0];
@@ -423,7 +423,7 @@ describe('Event', () => {
           );
           expect(options.method).toEqual('POST');
           expect(JSON.parse(options.body)).toEqual({
-            calendar_id: "",
+            calendar_id: '',
             busy: undefined,
             title: undefined,
             description: undefined,
@@ -462,7 +462,7 @@ describe('Event', () => {
           );
           expect(options.method).toEqual('POST');
           expect(JSON.parse(options.body)).toEqual({
-            calendar_id: "",
+            calendar_id: '',
             busy: undefined,
             title: undefined,
             description: undefined,

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -53,7 +53,9 @@ describe('Message', () => {
     testContext.message.body = 'bar';
     testContext.message.starred = true;
     testContext.message.unread = false;
-    testContext.message.to = [ new EmailParticipant({ email: 'foo', name: 'bar' }) ];
+    testContext.message.to = [
+      new EmailParticipant({ email: 'foo', name: 'bar' }),
+    ];
   });
 
   describe('save', () => {

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -5,6 +5,7 @@ import Message from '../src/models/message';
 import { Label } from '../src/models/folder';
 import RestfulModelCollection from '../src/models/restful-model-collection';
 import fetch from 'node-fetch';
+import EmailParticipant from '../src/models/email-participant';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -52,7 +53,7 @@ describe('Message', () => {
     testContext.message.body = 'bar';
     testContext.message.starred = true;
     testContext.message.unread = false;
-    testContext.message.to = [{ email: 'foo', name: 'bar' }];
+    testContext.message.to = [ new EmailParticipant({ email: 'foo', name: 'bar' }) ];
   });
 
   describe('save', () => {
@@ -144,7 +145,8 @@ describe('Message', () => {
         message_ids: [],
         size: 123,
       };
-      const file = new File(testContext.connection, fileObj);
+      const file = new File(testContext.connection);
+      file.fromJSON(fileObj);
       testContext.message.files = [file];
       return testContext.collection.first().then(message => {
         expect(message instanceof Message).toBe(true);

--- a/__tests__/neural-spec.js
+++ b/__tests__/neural-spec.js
@@ -235,7 +235,9 @@ describe('Neural', () => {
       return testContext.connection.neural
         .extractSignature(['abc123'])
         .then(sigList => {
-          const contact = sigList[0].contacts.toContactObject();
+          const contact = sigList[0].contacts.toContactObject(
+            testContext.connection
+          );
 
           expect(contact.givenName).toEqual('Nylas');
           expect(contact.surname).toEqual('Swag');

--- a/__tests__/nylas-connection-spec.js
+++ b/__tests__/nylas-connection-spec.js
@@ -39,18 +39,12 @@ describe('NylasConnection', () => {
       );
       expect(noWarning).toEqual('');
 
-      const warnSdk = testContext.connection.getWarningForVersion(
-        '1.0',
-        '2.0'
-      );
+      const warnSdk = testContext.connection.getWarningForVersion('1.0', '2.0');
       expect(warnSdk).toEqual(
         `WARNING: SDK version may not support your Nylas API version. SDK supports version 1.0 of the API and your application is currently running on version 2.0 of the API. Please update the sdk to ensure it works properly.`
       );
 
-      const warnApi = testContext.connection.getWarningForVersion(
-        '2.0',
-        '1.0'
-      );
+      const warnApi = testContext.connection.getWarningForVersion('2.0', '1.0');
       expect(warnApi).toEqual(
         `WARNING: SDK version may not support your Nylas API version. SDK supports version 2.0 of the API and your application is currently running on version 1.0 of the API. Please update the version of the API that your application is using through the developer dashboard.`
       );

--- a/__tests__/restful-model-collection-spec.js
+++ b/__tests__/restful-model-collection-spec.js
@@ -619,6 +619,7 @@ describe('RestfulModelCollection', () => {
       );
       testContext.item = new Draft(testContext.connection, {
         id: '123',
+        to: [{ email: 'foo', name: 'bar' }],
         version: 0,
       });
     });

--- a/__tests__/restful-model-collection-spec.js
+++ b/__tests__/restful-model-collection-spec.js
@@ -695,24 +695,6 @@ describe('RestfulModelCollection', () => {
     });
   });
 
-  describe('build', () => {
-    test('should return a new instance of the model class', () => {
-      expect(testContext.collection.build() instanceof Thread).toBe(true);
-    });
-
-    test('should initialize the new instance with the connection', () => {
-      expect(testContext.collection.build().connection).toBe(
-        testContext.connection
-      );
-    });
-
-    test('should set other attributes provided to the build method', () => {
-      expect(testContext.collection.build({ subject: '123' }).subject).toEqual(
-        '123'
-      );
-    });
-  });
-
   describe('path', () => {
     test("should return the modelClass' collectionName with no prefix", () => {
       expect(testContext.collection.path).toEqual('/threads');

--- a/__tests__/restful-model-collection-spec.js
+++ b/__tests__/restful-model-collection-spec.js
@@ -714,7 +714,7 @@ describe('RestfulModelCollection', () => {
 
   describe('path', () => {
     test("should return the modelClass' collectionName with no prefix", () => {
-      expect(testContext.collection.path()).toEqual('/threads');
+      expect(testContext.collection.path).toEqual('/threads');
     });
   });
 

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -13,24 +13,17 @@ export interface AccountProperties {
 }
 
 export default class Account extends RestfulModel implements AccountProperties {
-  name!: string;
-  emailAddress!: string;
-  provider!: string;
-  organizationUnit!: string;
-  syncState!: string;
-  linkedAt!: Date;
+  name = '';
+  emailAddress = '';
+  provider = '';
+  organizationUnit = '';
+  syncState = '';
+  linkedAt = new Date();
   billingState?: string;
 
   constructor(connection: NylasConnection, props?: AccountProperties) {
     super(connection, props);
-    if (!props) {
-      this.name = '';
-      this.emailAddress = '';
-      this.provider = '';
-      this.organizationUnit = '';
-      this.syncState = '';
-      this.linkedAt = new Date();
-    }
+    this.initAttributes(props);
   }
 }
 Account.collectionName = 'accounts';

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -23,7 +23,7 @@ export default class Account extends RestfulModel implements AccountProperties {
 
   constructor(connection: NylasConnection, props?: AccountProperties) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.name = '';
       this.emailAddress = '';
       this.provider = '';

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -13,16 +13,24 @@ export interface AccountProperties {
 }
 
 export default class Account extends RestfulModel implements AccountProperties {
-  name = '';
-  emailAddress = '';
-  provider = '';
-  organizationUnit = '';
-  syncState = '';
-  linkedAt = new Date();
+  name!: string;
+  emailAddress!: string;
+  provider!: string;
+  organizationUnit!: string;
+  syncState!: string;
+  linkedAt!: Date;
   billingState?: string;
 
   constructor(connection: NylasConnection, props?: AccountProperties) {
     super(connection, props);
+    if(!props) {
+      this.name = '';
+      this.emailAddress = '';
+      this.provider = '';
+      this.organizationUnit = '';
+      this.syncState = '';
+      this.linkedAt = new Date();
+    }
   }
 }
 Account.collectionName = 'accounts';

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,14 +1,29 @@
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
 
-export default class Account extends RestfulModel {
-  name?: string;
-  emailAddress?: string;
-  provider?: string;
-  organizationUnit?: string;
-  syncState?: string;
+export interface AccountProperties {
+  name: string;
+  emailAddress: string;
+  provider: string;
+  organizationUnit: string;
+  syncState: string;
+  linkedAt: Date;
   billingState?: string;
-  linkedAt?: Date;
+}
+
+export default class Account extends RestfulModel implements AccountProperties {
+  name = '';
+  emailAddress = '';
+  provider = '';
+  organizationUnit = '';
+  syncState = '';
+  linkedAt = new Date();
+  billingState?: string;
+
+  constructor(connection: NylasConnection, props?: AccountProperties) {
+    super(connection, props);
+  }
 }
 Account.collectionName = 'accounts';
 Account.endpointName = 'account';

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -55,12 +55,6 @@ class AttributeObject extends Attribute {
     if (!val) {
       return val;
     }
-    if (this.itemClass) {
-      if (this.itemClass.prototype instanceof RestfulModel) {
-        val = new this.itemClass(_parent.connection, val);
-      }
-      val = new this.itemClass(val);
-    }
     if (val.toJSON != null) {
       return val.toJSON();
     }
@@ -189,13 +183,7 @@ class AttributeCollection extends Attribute {
       return [];
     }
     const json = [];
-    for (let val of vals) {
-      if (this.itemClass) {
-        if (this.itemClass.prototype instanceof RestfulModel) {
-          val = new this.itemClass(_parent.connection, val);
-        }
-        val = new this.itemClass(val);
-      }
+    for (const val of vals) {
       if (val.toJSON != null) {
         json.push(val.toJSON());
       } else {

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -25,7 +25,7 @@ export class Attribute {
     this.readOnly = readOnly || false;
   }
 
-  toJSON(val: any) {
+  toJSON(val: any, _parent?: any) {
     return val;
   }
   fromJSON(val: any, _parent: any) {
@@ -51,9 +51,15 @@ class AttributeObject extends Attribute {
     this.itemClass = itemClass;
   }
 
-  toJSON(val: any) {
+  toJSON(val: any, _parent: any) {
     if (!val) {
       return val;
+    }
+    if (this.itemClass) {
+      if (this.itemClass.prototype instanceof RestfulModel) {
+        val = new this.itemClass(_parent.connection, val);
+      }
+      val = new this.itemClass(val);
     }
     if (val.toJSON != null) {
       return val.toJSON();
@@ -160,6 +166,7 @@ class AttributeDateTime extends Attribute {
 }
 
 class AttributeCollection extends Attribute {
+  //TODO::Do we still do this? or jsut typeof model?
   itemClass: typeof Model | typeof RestfulModel;
 
   constructor({
@@ -177,12 +184,18 @@ class AttributeCollection extends Attribute {
     this.itemClass = itemClass;
   }
 
-  toJSON(vals: any) {
+  toJSON(vals: any, _parent: any) {
     if (!vals) {
       return [];
     }
     const json = [];
-    for (const val of vals) {
+    for (let val of vals) {
+      if (this.itemClass) {
+        if (this.itemClass.prototype instanceof RestfulModel) {
+          val = new this.itemClass(_parent.connection, val);
+        }
+        val = new this.itemClass(val);
+      }
       if (val.toJSON != null) {
         json.push(val.toJSON());
       } else {

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -1,3 +1,4 @@
+import Model from './model';
 import RestfulModel from './restful-model';
 
 // The Attribute class represents a single model attribute, like 'namespace_id'
@@ -33,7 +34,7 @@ export class Attribute {
 }
 
 class AttributeObject extends Attribute {
-  itemClass?: typeof RestfulModel;
+  itemClass?: typeof Model | typeof RestfulModel;
 
   constructor({
     modelKey,
@@ -43,7 +44,7 @@ class AttributeObject extends Attribute {
   }: {
     modelKey: string;
     jsonKey?: string;
-    itemClass?: typeof RestfulModel;
+    itemClass?: typeof Model | typeof RestfulModel;
     readOnly?: boolean;
   }) {
     super({ modelKey, jsonKey, readOnly });
@@ -64,7 +65,11 @@ class AttributeObject extends Attribute {
     if (!val || !this.itemClass) {
       return val;
     }
-    return new this.itemClass(_parent.connection, val);
+
+    if (this.itemClass.prototype instanceof RestfulModel) {
+      return new this.itemClass(_parent.connection, val);
+    }
+    return new this.itemClass(val);
   }
 }
 
@@ -155,7 +160,7 @@ class AttributeDateTime extends Attribute {
 }
 
 class AttributeCollection extends Attribute {
-  itemClass: typeof RestfulModel;
+  itemClass: typeof Model | typeof RestfulModel;
 
   constructor({
     modelKey,
@@ -165,7 +170,7 @@ class AttributeCollection extends Attribute {
   }: {
     modelKey: string;
     jsonKey?: string;
-    itemClass: typeof RestfulModel;
+    itemClass: typeof Model | typeof RestfulModel;
     readOnly?: boolean;
   }) {
     super({ modelKey, jsonKey, readOnly });
@@ -193,7 +198,12 @@ class AttributeCollection extends Attribute {
     }
     const objs = [];
     for (const objJSON of json) {
-      const obj = new this.itemClass(_parent.connection, objJSON);
+      let obj;
+      if (this.itemClass.prototype instanceof RestfulModel) {
+        obj = new this.itemClass(_parent.connection, objJSON);
+      } else {
+        obj = new this.itemClass(objJSON);
+      }
       objs.push(obj);
     }
     return objs;

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -67,9 +67,9 @@ class AttributeObject extends Attribute {
     }
 
     if (this.itemClass.prototype instanceof RestfulModel) {
-      return new this.itemClass(_parent.connection, val);
+      return new this.itemClass(_parent.connection).fromJSON(val);
     }
-    return new this.itemClass(val);
+    return new this.itemClass(val).fromJSON(val);
   }
 }
 
@@ -201,9 +201,9 @@ class AttributeCollection extends Attribute {
     for (const objJSON of json) {
       let obj;
       if (this.itemClass.prototype instanceof RestfulModel) {
-        obj = new this.itemClass(_parent.connection, objJSON);
+        obj = new this.itemClass(_parent.connection).fromJSON(objJSON);
       } else {
-        obj = new this.itemClass(objJSON);
+        obj = new this.itemClass(objJSON).fromJSON(objJSON);
       }
       objs.push(obj);
     }

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -1,6 +1,7 @@
 import Calendar from './calendar';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
+import FreeBusy from './free-busy';
 
 export default class CalendarRestfulModelCollection extends RestfulModelCollection<
   Calendar
@@ -16,21 +17,19 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
 
   freeBusy(
     options: {
-      start_time?: string;
-      startTime?: string;
-      end_time?: string;
-      endTime?: string;
+      startTime: number;
+      endTime: number;
       emails: string[];
     },
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
-  ) {
+  ): Promise<FreeBusy[]> {
     return this.connection
       .request({
         method: 'POST',
         path: `/calendars/free-busy`,
         body: {
-          start_time: options.startTime || options.start_time,
-          end_time: options.endTime || options.end_time,
+          start_time: options.startTime.toString(),
+          end_time: options.endTime.toString(),
           emails: options.emails,
         },
       })
@@ -38,7 +37,11 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
         if (callback) {
           callback(null, json);
         }
-        return Promise.resolve(json);
+        const freeBusy = [];
+        for (const fb of JSON.parse(json)) {
+          freeBusy.push(new FreeBusy().fromJSON(fb));
+        }
+        return Promise.resolve(freeBusy);
       })
       .catch(err => {
         if (callback) {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -1,15 +1,31 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import { GetCallback } from './restful-model-collection';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
 
-export default class Calendar extends RestfulModel {
-  name?: string;
-  description?: string;
+export interface CalendarProperties {
+  name: string;
+  description: string;
+  location: string;
+  timezone: string;
   readOnly?: boolean;
-  location?: string;
-  timezone?: string;
   isPrimary?: boolean;
   jobStatusId?: string;
+}
+
+export default class Calendar extends RestfulModel
+  implements CalendarProperties {
+  name = '';
+  description = '';
+  location = '';
+  timezone = '';
+  readOnly?: boolean;
+  isPrimary?: boolean;
+  jobStatusId?: string;
+
+  constructor(connection: NylasConnection, props?: CalendarProperties) {
+    super(connection, props);
+  }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
     return this._save(params, callback);

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -15,16 +15,22 @@ export interface CalendarProperties {
 
 export default class Calendar extends RestfulModel
   implements CalendarProperties {
-  name = '';
-  description = '';
-  location = '';
-  timezone = '';
+  name!: string;
+  description!: string;
+  location!: string;
+  timezone!: string;
   readOnly?: boolean;
   isPrimary?: boolean;
   jobStatusId?: string;
 
   constructor(connection: NylasConnection, props?: CalendarProperties) {
     super(connection, props);
+    if(!props) {
+      this.name = "";
+      this.description = "";
+      this.location = "";
+      this.timezone = "";
+    }
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -15,22 +15,17 @@ export interface CalendarProperties {
 
 export default class Calendar extends RestfulModel
   implements CalendarProperties {
-  name!: string;
-  description!: string;
-  location!: string;
-  timezone!: string;
+  name = '';
+  description = '';
+  location = '';
+  timezone = '';
   readOnly?: boolean;
   isPrimary?: boolean;
   jobStatusId?: string;
 
   constructor(connection: NylasConnection, props?: CalendarProperties) {
     super(connection, props);
-    if (!props) {
-      this.name = '';
-      this.description = '';
-      this.location = '';
-      this.timezone = '';
-    }
+    this.initAttributes(props);
   }
 
   protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -25,11 +25,11 @@ export default class Calendar extends RestfulModel
 
   constructor(connection: NylasConnection, props?: CalendarProperties) {
     super(connection, props);
-    if(!props) {
-      this.name = "";
-      this.description = "";
-      this.location = "";
-      this.timezone = "";
+    if (!props) {
+      this.name = '';
+      this.description = '';
+      this.location = '';
+      this.timezone = '';
     }
   }
 

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -1,7 +1,6 @@
 import { Contact, Group } from './contact';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
-import { GroupProperties } from './contact';
 
 export default class ContactRestfulModelCollection extends RestfulModelCollection<
   Contact
@@ -25,8 +24,7 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
       })
       .then(json => {
         const groups = json.map((group: { [key: string]: any }) => {
-          const props = Group.propsFromJSON(group, this) as GroupProperties;
-          return new Group(props);
+          return new Group().fromJSON(group);
         });
         if (callback) {
           callback(null, groups);

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -1,6 +1,7 @@
 import { Contact, Group } from './contact';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
+import { GroupProperties } from './contact';
 
 export default class ContactRestfulModelCollection extends RestfulModelCollection<
   Contact
@@ -24,7 +25,8 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
       })
       .then(json => {
         const groups = json.map((group: { [key: string]: any }) => {
-          return new Group(group);
+          const props = Group.propsFromJSON(group, this) as GroupProperties;
+          return new Group(props);
         });
         if (callback) {
           callback(null, groups);

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -24,7 +24,7 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
       })
       .then(json => {
         const groups = json.map((group: { [key: string]: any }) => {
-          return new Group(this.connection, group);
+          return new Group(group);
         });
         if (callback) {
           callback(null, groups);

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,11 +1,22 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 import Model from './model';
+import NylasConnection from '../nylas-connection';
 
-export class EmailAddress extends Model {
-  type?: string;
-  email?: string;
+export interface EmailAddressProperties {
+  type: string;
+  email: string;
+}
 
+export class EmailAddress extends Model implements EmailAddressProperties {
+  type = '';
+  email = '';
+
+  constructor(props?: EmailAddressProperties) {
+    super(props);
+  }
+
+  // TODO::Can probably remove toJSONs in classes that extend Model
   toJSON() {
     return {
       type: this.type,
@@ -15,7 +26,6 @@ export class EmailAddress extends Model {
 }
 
 EmailAddress.attributes = {
-  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -24,9 +34,18 @@ EmailAddress.attributes = {
   }),
 };
 
-class IMAddress extends Model {
-  type?: string;
-  imAddress?: string;
+export interface IMAddressProperties {
+  type: string;
+  imAddress: string;
+}
+
+class IMAddress extends Model implements IMAddressProperties {
+  type = '';
+  imAddress = '';
+
+  constructor(props?: IMAddressProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {
@@ -37,7 +56,6 @@ class IMAddress extends Model {
 }
 
 IMAddress.attributes = {
-  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -47,15 +65,31 @@ IMAddress.attributes = {
   }),
 };
 
-class PhysicalAddress extends Model {
-  type?: string;
-  format?: string;
+// TODO::Check if "address" is deprecated
+export interface PhysicalAddressProperties {
+  type: string;
+  format: string;
+  streetAddress: string;
+  city: string;
+  postalCode: string;
+  state: string;
+  country: string;
   address?: string;
-  streetAddress?: string;
-  city?: string;
-  postalCode?: string;
-  state?: string;
-  country?: string;
+}
+
+class PhysicalAddress extends Model implements PhysicalAddressProperties {
+  type = '';
+  format = '';
+  streetAddress = '';
+  city = '';
+  postalCode = '';
+  state = '';
+  country = '';
+  address?: string;
+
+  constructor(props?: PhysicalAddressProperties) {
+    super(props);
+  }
 
   toJSON() {
     const json: { [key: string]: any } = {
@@ -76,7 +110,6 @@ class PhysicalAddress extends Model {
 }
 
 PhysicalAddress.attributes = {
-  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -105,9 +138,18 @@ PhysicalAddress.attributes = {
   }),
 };
 
-export class PhoneNumber extends Model {
-  type?: string;
-  number?: string;
+export interface PhoneNumberProperties {
+  type: string;
+  number: string;
+}
+
+export class PhoneNumber extends Model implements PhoneNumberProperties {
+  type = '';
+  number = '';
+
+  constructor(props?: PhoneNumberProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {
@@ -118,7 +160,6 @@ export class PhoneNumber extends Model {
 }
 
 PhoneNumber.attributes = {
-  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -127,9 +168,18 @@ PhoneNumber.attributes = {
   }),
 };
 
-export class WebPage extends Model {
-  type?: string;
-  url?: string;
+export interface WebPageProperties {
+  type: string;
+  url: string;
+}
+
+export class WebPage extends Model implements WebPageProperties {
+  type = '';
+  url = '';
+
+  constructor(props?: WebPageProperties) {
+    super(props);
+  }
 
   toJSON() {
     const json = {
@@ -141,7 +191,6 @@ export class WebPage extends Model {
 }
 
 WebPage.attributes = {
-  ...RestfulModel.attributes,
   type: Attributes.String({
     modelKey: 'type',
   }),
@@ -150,13 +199,21 @@ WebPage.attributes = {
   }),
 };
 
-export class Group extends Model {
-  type?: string;
-  path?: string;
+export interface GroupProperties {
+  type: string;
+  path: string;
+}
+
+export class Group extends Model implements GroupProperties {
+  type = '';
+  path = '';
+
+  constructor(props?: GroupProperties) {
+    super(props);
+  }
 }
 
 Group.attributes = {
-  ...RestfulModel.attributes,
   name: Attributes.String({
     modelKey: 'name',
   }),
@@ -165,7 +222,28 @@ Group.attributes = {
   }),
 };
 
-export class Contact extends RestfulModel {
+export interface ContactProperties {
+  givenName?: string;
+  middleName?: string;
+  surname?: string;
+  suffix?: string;
+  nickname?: string;
+  birthday?: string;
+  companyName?: string;
+  jobTitle?: string;
+  officeLocation?: string;
+  notes?: string;
+  pictureUrl?: string;
+  emailAddresses?: EmailAddressProperties[];
+  imAddresses?: IMAddress[];
+  physicalAddresses?: PhysicalAddressProperties[];
+  phoneNumbers?: PhoneNumberProperties[];
+  webPages?: WebPageProperties[];
+  groups?: GroupProperties[];
+  source?: string;
+}
+
+export class Contact extends RestfulModel implements ContactProperties {
   givenName?: string;
   middleName?: string;
   surname?: string;
@@ -184,6 +262,10 @@ export class Contact extends RestfulModel {
   webPages?: WebPage[];
   groups?: Group[];
   source?: string;
+
+  constructor(connection: NylasConnection, props?: ContactProperties) {
+    super(connection, props);
+  }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
     return this._save(params, callback);

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -9,11 +9,15 @@ export interface EmailAddressProperties {
 }
 
 export class EmailAddress extends Model implements EmailAddressProperties {
-  type = '';
-  email = '';
+  type!: string;
+  email!: string;
 
   constructor(props?: EmailAddressProperties) {
     super(props);
+    if(!props) {
+      this.type = '';
+      this.email = '';
+    }
   }
 
   // TODO::Can probably remove toJSONs in classes that extend Model
@@ -34,17 +38,22 @@ EmailAddress.attributes = {
   }),
 };
 
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface IMAddressProperties {
   type: string;
   imAddress: string;
 }
 
 class IMAddress extends Model implements IMAddressProperties {
-  type = '';
-  imAddress = '';
+  type!: string;
+  imAddress!: string;
 
   constructor(props?: IMAddressProperties) {
     super(props);
+    if(!props) {
+      this.type = '';
+      this.imAddress = '';
+    }
   }
 
   toJSON() {
@@ -78,17 +87,26 @@ export interface PhysicalAddressProperties {
 }
 
 class PhysicalAddress extends Model implements PhysicalAddressProperties {
-  type = '';
-  format = '';
-  streetAddress = '';
-  city = '';
-  postalCode = '';
-  state = '';
-  country = '';
+  type!: string;
+  format!: string;
+  streetAddress!: string;
+  city!: string;
+  postalCode!: string;
+  state!: string;
+  country!: string;
   address?: string;
 
   constructor(props?: PhysicalAddressProperties) {
     super(props);
+    if(!props) {
+      this.type = '';
+      this.format = '';
+      this.streetAddress = '';
+      this.city = '';
+      this.postalCode = '';
+      this.state = '';
+      this.country = '';
+    }
   }
 
   toJSON() {
@@ -144,11 +162,15 @@ export interface PhoneNumberProperties {
 }
 
 export class PhoneNumber extends Model implements PhoneNumberProperties {
-  type = '';
-  number = '';
+  type!: string;
+  number!: string;
 
   constructor(props?: PhoneNumberProperties) {
     super(props);
+    if(!props) {
+      this.type = '';
+      this.number = '';
+    }
   }
 
   toJSON() {
@@ -174,11 +196,15 @@ export interface WebPageProperties {
 }
 
 export class WebPage extends Model implements WebPageProperties {
-  type = '';
-  url = '';
+  type!: string;
+  url!: string;
 
   constructor(props?: WebPageProperties) {
     super(props);
+    if(!props) {
+      this.type = '';
+      this.url = '';
+    }
   }
 
   toJSON() {
@@ -200,16 +226,26 @@ WebPage.attributes = {
 };
 
 export interface GroupProperties {
-  type: string;
+  name: string;
   path: string;
+  id?: string;
+  accountId?: string;
+  object?: string;
 }
 
 export class Group extends Model implements GroupProperties {
-  type = '';
-  path = '';
+  name!: string;
+  path!: string;
+  id?: string;
+  accountId?: string;
+  object?: string;
 
   constructor(props?: GroupProperties) {
     super(props);
+    if(!props) {
+      this.name = '';
+      this.path = '';
+    }
   }
 }
 
@@ -219,6 +255,19 @@ Group.attributes = {
   }),
   path: Attributes.String({
     modelKey: 'path',
+  }),
+  id: Attributes.String({
+    modelKey: 'id',
+    readOnly: true,
+  }),
+  object: Attributes.String({
+    modelKey: 'object',
+    readOnly: true,
+  }),
+  accountId: Attributes.String({
+    modelKey: 'accountId',
+    jsonKey: 'account_id',
+    readOnly: true,
   }),
 };
 
@@ -235,7 +284,7 @@ export interface ContactProperties {
   notes?: string;
   pictureUrl?: string;
   emailAddresses?: EmailAddressProperties[];
-  imAddresses?: IMAddress[];
+  imAddresses?: IMAddressProperties[];
   physicalAddresses?: PhysicalAddressProperties[];
   phoneNumbers?: PhoneNumberProperties[];
   webPages?: WebPageProperties[];

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -14,7 +14,7 @@ export class EmailAddress extends Model implements EmailAddressProperties {
 
   constructor(props?: EmailAddressProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.type = '';
       this.email = '';
     }
@@ -50,7 +50,7 @@ class IMAddress extends Model implements IMAddressProperties {
 
   constructor(props?: IMAddressProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.type = '';
       this.imAddress = '';
     }
@@ -98,7 +98,7 @@ class PhysicalAddress extends Model implements PhysicalAddressProperties {
 
   constructor(props?: PhysicalAddressProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.type = '';
       this.format = '';
       this.streetAddress = '';
@@ -167,7 +167,7 @@ export class PhoneNumber extends Model implements PhoneNumberProperties {
 
   constructor(props?: PhoneNumberProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.type = '';
       this.number = '';
     }
@@ -201,7 +201,7 @@ export class WebPage extends Model implements WebPageProperties {
 
   constructor(props?: WebPageProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.type = '';
       this.url = '';
     }
@@ -242,7 +242,7 @@ export class Group extends Model implements GroupProperties {
 
   constructor(props?: GroupProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.name = '';
       this.path = '';
     }

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -9,15 +9,12 @@ export interface EmailAddressProperties {
 }
 
 export class EmailAddress extends Model implements EmailAddressProperties {
-  type!: string;
-  email!: string;
+  type = '';
+  email = '';
 
   constructor(props?: EmailAddressProperties) {
-    super(props);
-    if (!props) {
-      this.type = '';
-      this.email = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   // TODO::Can probably remove toJSONs in classes that extend Model
@@ -44,16 +41,13 @@ export interface IMAddressProperties {
   imAddress: string;
 }
 
-class IMAddress extends Model implements IMAddressProperties {
-  type!: string;
-  imAddress!: string;
+export class IMAddress extends Model implements IMAddressProperties {
+  type = '';
+  imAddress = '';
 
   constructor(props?: IMAddressProperties) {
-    super(props);
-    if (!props) {
-      this.type = '';
-      this.imAddress = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -87,26 +81,18 @@ export interface PhysicalAddressProperties {
 }
 
 class PhysicalAddress extends Model implements PhysicalAddressProperties {
-  type!: string;
-  format!: string;
-  streetAddress!: string;
-  city!: string;
-  postalCode!: string;
-  state!: string;
-  country!: string;
-  address?: string;
+  type = '';
+  format = '';
+  streetAddress = '';
+  city = '';
+  postalCode = '';
+  state = '';
+  country = '';
+  address = '';
 
   constructor(props?: PhysicalAddressProperties) {
-    super(props);
-    if (!props) {
-      this.type = '';
-      this.format = '';
-      this.streetAddress = '';
-      this.city = '';
-      this.postalCode = '';
-      this.state = '';
-      this.country = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -162,15 +148,12 @@ export interface PhoneNumberProperties {
 }
 
 export class PhoneNumber extends Model implements PhoneNumberProperties {
-  type!: string;
-  number!: string;
+  type = '';
+  number = '';
 
   constructor(props?: PhoneNumberProperties) {
-    super(props);
-    if (!props) {
-      this.type = '';
-      this.number = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -196,15 +179,12 @@ export interface WebPageProperties {
 }
 
 export class WebPage extends Model implements WebPageProperties {
-  type!: string;
-  url!: string;
+  type = '';
+  url = '';
 
   constructor(props?: WebPageProperties) {
-    super(props);
-    if (!props) {
-      this.type = '';
-      this.url = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -234,18 +214,15 @@ export interface GroupProperties {
 }
 
 export class Group extends Model implements GroupProperties {
-  name!: string;
-  path!: string;
+  name = '';
+  path = '';
   id?: string;
   accountId?: string;
   object?: string;
 
   constructor(props?: GroupProperties) {
-    super(props);
-    if (!props) {
-      this.name = '';
-      this.path = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 }
 
@@ -313,7 +290,8 @@ export class Contact extends RestfulModel implements ContactProperties {
   source?: string;
 
   constructor(connection: NylasConnection, props?: ContactProperties) {
-    super(connection, props);
+    super(connection);
+    this.initAttributes(props);
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,7 +1,8 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
+import Model from './model';
 
-export class EmailAddress extends RestfulModel {
+export class EmailAddress extends Model {
   type?: string;
   email?: string;
 
@@ -13,7 +14,6 @@ export class EmailAddress extends RestfulModel {
   }
 }
 
-EmailAddress.collectionName = 'email_addresses';
 EmailAddress.attributes = {
   ...RestfulModel.attributes,
   type: Attributes.String({
@@ -24,7 +24,7 @@ EmailAddress.attributes = {
   }),
 };
 
-class IMAddress extends RestfulModel {
+class IMAddress extends Model {
   type?: string;
   imAddress?: string;
 
@@ -36,7 +36,6 @@ class IMAddress extends RestfulModel {
   }
 }
 
-IMAddress.collectionName = 'im_addresses';
 IMAddress.attributes = {
   ...RestfulModel.attributes,
   type: Attributes.String({
@@ -48,7 +47,7 @@ IMAddress.attributes = {
   }),
 };
 
-class PhysicalAddress extends RestfulModel {
+class PhysicalAddress extends Model {
   type?: string;
   format?: string;
   address?: string;
@@ -76,7 +75,6 @@ class PhysicalAddress extends RestfulModel {
   }
 }
 
-PhysicalAddress.collectionName = 'physical_addresses';
 PhysicalAddress.attributes = {
   ...RestfulModel.attributes,
   type: Attributes.String({
@@ -107,7 +105,7 @@ PhysicalAddress.attributes = {
   }),
 };
 
-export class PhoneNumber extends RestfulModel {
+export class PhoneNumber extends Model {
   type?: string;
   number?: string;
 
@@ -119,7 +117,6 @@ export class PhoneNumber extends RestfulModel {
   }
 }
 
-PhoneNumber.collectionName = 'phone_numbers';
 PhoneNumber.attributes = {
   ...RestfulModel.attributes,
   type: Attributes.String({
@@ -130,7 +127,7 @@ PhoneNumber.attributes = {
   }),
 };
 
-export class WebPage extends RestfulModel {
+export class WebPage extends Model {
   type?: string;
   url?: string;
 
@@ -143,7 +140,6 @@ export class WebPage extends RestfulModel {
   }
 }
 
-WebPage.collectionName = 'web_pages';
 WebPage.attributes = {
   ...RestfulModel.attributes,
   type: Attributes.String({
@@ -154,12 +150,11 @@ WebPage.attributes = {
   }),
 };
 
-export class Group extends RestfulModel {
+export class Group extends Model {
   type?: string;
   path?: string;
 }
 
-Group.collectionName = 'groups';
 Group.attributes = {
   ...RestfulModel.attributes,
   name: Attributes.String({

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -113,7 +113,7 @@ export default class Draft extends Message implements DraftProperties {
         json,
       })
       .then(json => {
-        const message = new Message(this.connection, json);
+        const message = new Message(this.connection).fromJSON(json);
 
         // We may get failures for a partial send
         if (json.failures) {

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -21,6 +21,7 @@ export default class Draft extends Message implements DraftProperties {
 
   constructor(connection: NylasConnection, props?: DraftProperties) {
     super(connection, props);
+    this.initAttributes(props);
   }
 
   toJSON(enforceReadOnly?: boolean) {

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -1,4 +1,4 @@
-import Message from './message';
+import Message, { MessageProperties } from './message';
 import Attributes from './attributes';
 import { SaveCallback } from './restful-model';
 
@@ -7,7 +7,13 @@ export type SendCallback = (
   json?: { [key: string]: any }
 ) => void;
 
-export default class Draft extends Message {
+export interface DraftProperties extends MessageProperties {
+  rawMime?: string;
+  replyToMessageId?: string;
+  version?: number;
+}
+
+export default class Draft extends Message implements DraftProperties {
   rawMime?: string;
   replyToMessageId?: string;
   version?: number;

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -145,6 +145,6 @@ Draft.attributes = {
   }),
   rawMime: Attributes.String({
     modelKey: 'rawMime',
-    readOnly: true
+    readOnly: true,
   }),
 };

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -1,6 +1,7 @@
 import Message, { MessageProperties } from './message';
 import Attributes from './attributes';
 import { SaveCallback } from './restful-model';
+import NylasConnection from '../nylas-connection';
 
 export type SendCallback = (
   err: Error | null,
@@ -17,6 +18,10 @@ export default class Draft extends Message implements DraftProperties {
   rawMime?: string;
   replyToMessageId?: string;
   version?: number;
+
+  constructor(connection: NylasConnection, props?: DraftProperties) {
+    super(connection, props);
+  }
 
   toJSON(enforceReadOnly?: boolean) {
     if (this.rawMime) {
@@ -137,5 +142,9 @@ Draft.attributes = {
   replyToMessageId: Attributes.String({
     modelKey: 'replyToMessageId',
     jsonKey: 'reply_to_message_id',
+  }),
+  rawMime: Attributes.String({
+    modelKey: 'rawMime',
+    readOnly: true
   }),
 };

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -13,8 +13,8 @@ export default class EmailParticipant extends Model
 
   constructor(props?: EmailParticipantProperties) {
     super(props);
-    if(!props) {
-      this.email = "";
+    if (!props) {
+      this.email = '';
     }
   }
 

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -8,11 +8,14 @@ export interface EmailParticipantProperties {
 
 export default class EmailParticipant extends Model
   implements EmailParticipantProperties {
-  email = '';
+  email!: string;
   name?: string;
 
-  constructor(props: EmailParticipantProperties) {
+  constructor(props?: EmailParticipantProperties) {
     super(props);
+    if(!props) {
+      this.email = "";
+    }
   }
 
   toJSON(): EmailParticipantProperties {

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -8,14 +8,12 @@ export interface EmailParticipantProperties {
 
 export default class EmailParticipant extends Model
   implements EmailParticipantProperties {
-  email!: string;
+  email = '';
   name?: string;
 
   constructor(props?: EmailParticipantProperties) {
-    super(props);
-    if (!props) {
-      this.email = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON(): EmailParticipantProperties {

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -1,19 +1,28 @@
-import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import Model from './model';
 
-export default class EmailParticipant extends RestfulModel {
+export interface EmailParticipantProperties {
+  email: string;
   name?: string;
-  email?: string;
+}
 
-  toJSON(enforceReadOnly?: boolean) {
-    const json = super.toJSON(enforceReadOnly);
+export default class EmailParticipant extends Model
+  implements EmailParticipantProperties {
+  email = '';
+  name?: string;
+
+  constructor(props: EmailParticipantProperties) {
+    super(props);
+  }
+
+  toJSON(): EmailParticipantProperties {
+    const json = super.toJSON();
     if (!json['name']) {
       json['name'] = json['email'];
     }
     return json;
   }
 }
-EmailParticipant.collectionName = 'email-participants';
 EmailParticipant.attributes = {
   name: Attributes.String({
     modelKey: 'name',

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -69,8 +69,8 @@ export class EventConferencing extends Model
 
   constructor(props?: EventConferencingProperties) {
     super(props);
-    if(!props) {
-      this.provider = "";
+    if (!props) {
+      this.provider = '';
     }
   }
 

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -1,7 +1,7 @@
-import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import Model from './model';
 
-class EventConferencingDetails extends RestfulModel {
+class EventConferencingDetails extends Model {
   meetingCode?: string;
   phone?: string[];
   password?: string;
@@ -18,7 +18,7 @@ class EventConferencingDetails extends RestfulModel {
     };
   }
 }
-EventConferencingDetails.collectionName = 'event_conferencing_details';
+
 EventConferencingDetails.attributes = {
   meetingCode: Attributes.String({
     modelKey: 'meetingCode',
@@ -38,7 +38,7 @@ EventConferencingDetails.attributes = {
   }),
 };
 
-export class EventConferencing extends RestfulModel {
+export class EventConferencing extends Model {
   details?: EventConferencingDetails;
   provider?: string;
   autocreate?: {
@@ -53,7 +53,7 @@ export class EventConferencing extends RestfulModel {
     };
   }
 }
-EventConferencing.collectionName = 'event_conferencing';
+
 EventConferencing.attributes = {
   details: Attributes.Object({
     modelKey: 'details',

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -18,7 +18,8 @@ class EventConferencingDetails extends Model
   url?: string;
 
   constructor(props?: EventConferencingProperties) {
-    super(props);
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -61,17 +62,15 @@ export interface EventConferencingProperties {
 
 export class EventConferencing extends Model
   implements EventConferencingProperties {
-  provider!: string;
+  provider = '';
   details?: EventConferencingDetails;
   autocreate?: {
     settings?: { [key: string]: string };
   };
 
   constructor(props?: EventConferencingProperties) {
-    super(props);
-    if (!props) {
-      this.provider = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON(): any {

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -1,12 +1,25 @@
 import Attributes from './attributes';
 import Model from './model';
 
-class EventConferencingDetails extends Model {
+export interface EventConferencingDetailsProperties {
   meetingCode?: string;
   phone?: string[];
   password?: string;
   pin?: string;
   url?: string;
+}
+
+class EventConferencingDetails extends Model
+  implements EventConferencingDetailsProperties {
+  meetingCode?: string;
+  phone?: string[];
+  password?: string;
+  pin?: string;
+  url?: string;
+
+  constructor(props?: EventConferencingProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {
@@ -38,12 +51,25 @@ EventConferencingDetails.attributes = {
   }),
 };
 
-export class EventConferencing extends Model {
+export interface EventConferencingProperties {
+  provider: string;
   details?: EventConferencingDetails;
-  provider?: string;
   autocreate?: {
     settings?: object;
   };
+}
+
+export class EventConferencing extends Model
+  implements EventConferencingProperties {
+  provider = '';
+  details?: EventConferencingDetails;
+  autocreate?: {
+    settings?: object;
+  };
+
+  constructor(props?: EventConferencingProperties) {
+    super(props);
+  }
 
   toJSON(): any {
     return {

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -53,7 +53,7 @@ EventConferencingDetails.attributes = {
 
 export interface EventConferencingProperties {
   provider: string;
-  details?: EventConferencingDetails;
+  details?: EventConferencingDetailsProperties;
   autocreate?: {
     settings?: object;
   };
@@ -61,14 +61,17 @@ export interface EventConferencingProperties {
 
 export class EventConferencing extends Model
   implements EventConferencingProperties {
-  provider = '';
+  provider!: string;
   details?: EventConferencingDetails;
   autocreate?: {
-    settings?: object;
+    settings?: { [key: string]: string };
   };
 
   constructor(props?: EventConferencingProperties) {
     super(props);
+    if(!props) {
+      this.provider = "";
+    }
   }
 
   toJSON(): any {

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -15,8 +15,8 @@ export default class EventParticipant extends Model
 
   constructor(props?: EventParticipantProperties) {
     super(props);
-    if(!props) {
-      this.email = "";
+    if (!props) {
+      this.email = '';
     }
   }
 

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -9,15 +9,13 @@ export interface EventParticipantProperties {
 
 export default class EventParticipant extends Model
   implements EventParticipantProperties {
-  email!: string;
+  email = '';
   name?: string;
   status?: string;
 
   constructor(props?: EventParticipantProperties) {
-    super(props);
-    if (!props) {
-      this.email = '';
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON(enforceReadOnly?: boolean) {

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -9,9 +9,16 @@ export interface EventParticipantProperties {
 
 export default class EventParticipant extends Model
   implements EventParticipantProperties {
-  email = '';
+  email!: string;
   name?: string;
   status?: string;
+
+  constructor(props?: EventParticipantProperties) {
+    super(props);
+    if(!props) {
+      this.email = "";
+    }
+  }
 
   toJSON(enforceReadOnly?: boolean) {
     const json = super.toJSON(enforceReadOnly);

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -1,9 +1,16 @@
 import Attributes from './attributes';
 import Model from './model';
 
-export default class EventParticipant extends Model {
+export interface EventParticipantProperties {
+  email: string;
   name?: string;
-  email?: string;
+  status?: string;
+}
+
+export default class EventParticipant extends Model
+  implements EventParticipantProperties {
+  email = '';
+  name?: string;
   status?: string;
 
   toJSON(enforceReadOnly?: boolean) {

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -1,7 +1,7 @@
-import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import Model from './model';
 
-export default class EventParticipant extends RestfulModel {
+export default class EventParticipant extends Model {
   name?: string;
   email?: string;
   status?: string;
@@ -14,7 +14,7 @@ export default class EventParticipant extends RestfulModel {
     return json;
   }
 }
-EventParticipant.collectionName = 'event-participants';
+
 EventParticipant.attributes = {
   name: Attributes.String({
     modelKey: 'name',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,11 +1,42 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
-import EventParticipant from './event-participant';
-import { EventConferencing } from './event-conferencing';
+import EventParticipant, {
+  EventParticipantProperties,
+} from './event-participant';
+import {
+  EventConferencing,
+  EventConferencingProperties,
+} from './event-conferencing';
 import When from './when';
+import NylasConnection from '../nylas-connection';
+
+export interface EventProperties {
+  calendarId: string;
+  when: When;
+  iCalUID?: string;
+  messageId?: string;
+  title?: string;
+  description?: string;
+  owner?: string;
+  participants?: EventParticipantProperties[];
+  readOnly?: boolean;
+  location?: string;
+  busy?: boolean;
+  status?: string;
+  recurrence?: {
+    rrule: string[];
+    timezone: string;
+  };
+  masterEventId?: string;
+  originalStartTime?: number;
+  conferencing?: EventConferencingProperties;
+  metadata?: object;
+  jobStatusId?: string;
+}
 
 export default class Event extends RestfulModel {
-  calendarId?: string;
+  calendarId = '';
+  when = new When();
   iCalUID?: string;
   messageId?: string;
   title?: string;
@@ -14,7 +45,6 @@ export default class Event extends RestfulModel {
   participants?: EventParticipant[];
   readOnly?: boolean;
   location?: string;
-  when?: When;
   busy?: boolean;
   status?: string;
   recurrence?: {
@@ -27,11 +57,17 @@ export default class Event extends RestfulModel {
   metadata?: object;
   jobStatusId?: string;
 
+  constructor(connection: NylasConnection, props?: EventProperties) {
+    super(connection, props);
+  }
+
   get start(): string | number | undefined {
-    return this.when?.startTime ||
+    return (
+      this.when?.startTime ||
       this.when?.startDate ||
       this.when?.time ||
-      this.when?.date;
+      this.when?.date
+    );
   }
 
   set start(val: string | number | undefined) {
@@ -63,10 +99,12 @@ export default class Event extends RestfulModel {
   }
 
   get end(): string | number | undefined {
-    return this.when?.endTime ||
+    return (
+      this.when?.endTime ||
       this.when?.endDate ||
       this.when?.time ||
-      this.when?.date;
+      this.when?.date
+    );
   }
 
   set end(val: string | number | undefined) {
@@ -183,7 +221,7 @@ Event.attributes = {
   }),
   when: Attributes.Object({
     modelKey: 'when',
-    itemClass: When
+    itemClass: When,
   }),
   busy: Attributes.Boolean({
     modelKey: 'busy',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -35,8 +35,8 @@ export interface EventProperties {
 }
 
 export default class Event extends RestfulModel {
-  calendarId = '';
-  when = new When();
+  calendarId!: string;
+  when!: When;
   iCalUID?: string;
   messageId?: string;
   title?: string;
@@ -59,6 +59,10 @@ export default class Event extends RestfulModel {
 
   constructor(connection: NylasConnection, props?: EventProperties) {
     super(connection, props);
+    if(!props) {
+      this.calendarId = '';
+      this.when = new When();
+    }
   }
 
   get start(): string | number | undefined {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -35,8 +35,8 @@ export interface EventProperties {
 }
 
 export default class Event extends RestfulModel {
-  calendarId!: string;
-  when!: When;
+  calendarId = '';
+  when = new When();
   iCalUID?: string;
   messageId?: string;
   title?: string;
@@ -59,10 +59,7 @@ export default class Event extends RestfulModel {
 
   constructor(connection: NylasConnection, props?: EventProperties) {
     super(connection, props);
-    if (!props) {
-      this.calendarId = '';
-      this.when = new When();
-    }
+    this.initAttributes(props);
   }
 
   get start(): string | number | undefined {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -2,6 +2,7 @@ import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 import EventParticipant from './event-participant';
 import { EventConferencing } from './event-conferencing';
+import When from './when';
 
 export default class Event extends RestfulModel {
   calendarId?: string;
@@ -13,15 +14,7 @@ export default class Event extends RestfulModel {
   participants?: EventParticipant[];
   readOnly?: boolean;
   location?: string;
-  when?: {
-    start_time?: number;
-    end_time?: number;
-    time?: number;
-    start_date?: string;
-    end_date?: string;
-    date?: string;
-    object?: string;
-  };
+  when?: When;
   busy?: boolean;
   status?: string;
   recurrence?: {
@@ -34,72 +27,72 @@ export default class Event extends RestfulModel {
   metadata?: object;
   jobStatusId?: string;
 
-  get start() {
-    const start =
-      this.when?.start_time ||
-      this.when?.start_date ||
+  get start(): string | number | undefined {
+    return this.when?.startTime ||
+      this.when?.startDate ||
       this.when?.time ||
       this.when?.date;
-    return start;
   }
 
   set start(val: string | number | undefined) {
     if (!this.when) {
-      this.when = {};
+      this.when = new When();
     }
     if (typeof val === 'number') {
-      if (val === this.when.end_time) {
-        this.when = { time: val };
+      if (val === this.when.endTime) {
+        this.when.time = val;
+        this.when.endTime = undefined;
       } else {
-        delete this.when.time;
-        delete this.when.start_date;
-        delete this.when.date;
-        this.when.start_time = val;
+        this.when.time = undefined;
+        this.when.startDate = undefined;
+        this.when.date = undefined;
+        this.when.startTime = val;
       }
     }
     if (typeof val === 'string') {
-      if (val === this.when.end_date) {
-        this.when = { date: val };
+      if (val === this.when.endDate) {
+        this.when.date = val;
+        this.when.endDate = undefined;
       } else {
-        delete this.when.date;
-        delete this.when.start_time;
-        delete this.when.time;
-        this.when.start_date = val;
+        this.when.time = undefined;
+        this.when.startTime = undefined;
+        this.when.date = undefined;
+        this.when.startDate = val;
       }
     }
   }
 
-  get end() {
-    const end =
-      this.when?.end_time ||
-      this.when?.end_date ||
+  get end(): string | number | undefined {
+    return this.when?.endTime ||
+      this.when?.endDate ||
       this.when?.time ||
       this.when?.date;
-    return end;
   }
 
   set end(val: string | number | undefined) {
     if (!this.when) {
-      this.when = {};
+      this.when = new When();
     }
     if (typeof val === 'number') {
-      if (val === this.when.start_time) {
-        this.when = { time: val };
+      if (val === this.when.startTime) {
+        this.when.time = val;
+        this.when.startTime = undefined;
       } else {
-        delete this.when.time;
-        delete this.when.end_date;
-        delete this.when.date;
-        this.when.end_time = val;
+        this.when.time = undefined;
+        this.when.endDate = undefined;
+        this.when.date = undefined;
+        this.when.endTime = val;
       }
     }
     if (typeof val === 'string') {
-      if (val === this.when.start_date) {
-        this.when = { date: val };
+      if (val === this.when.startDate) {
+        this.when.date = val;
+        this.when.startDate = undefined;
       } else {
-        delete this.when.date;
-        delete this.when.time;
-        delete this.when.end_time;
-        this.when.end_date = val;
+        this.when.time = undefined;
+        this.when.endTime = undefined;
+        this.when.date = undefined;
+        this.when.endDate = val;
       }
     }
   }
@@ -190,6 +183,7 @@ Event.attributes = {
   }),
   when: Attributes.Object({
     modelKey: 'when',
+    itemClass: When
   }),
   busy: Attributes.Boolean({
     modelKey: 'busy',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -7,12 +7,12 @@ import {
   EventConferencing,
   EventConferencingProperties,
 } from './event-conferencing';
-import When from './when';
+import When, { WhenProperties } from './when';
 import NylasConnection from '../nylas-connection';
 
 export interface EventProperties {
   calendarId: string;
-  when: When;
+  when: WhenProperties;
   iCalUID?: string;
   messageId?: string;
   title?: string;

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -59,7 +59,7 @@ export default class Event extends RestfulModel {
 
   constructor(connection: NylasConnection, props?: EventProperties) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.calendarId = '';
       this.when = new When();
     }

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -1,5 +1,6 @@
 import Attributes from './attributes';
 import RestfulModel from './restful-model';
+import NylasConnection from '../nylas-connection';
 
 export interface FileProperties {
   contentType?: string;
@@ -19,6 +20,11 @@ export default class File extends RestfulModel implements FileProperties {
   contentId?: string;
   contentDisposition?: string;
   data?: any;
+
+  constructor(connection: NylasConnection, props?: FileProperties) {
+    super(connection, props);
+    this.initAttributes(props);
+  }
 
   upload(callback?: (error: Error | null, model?: File) => void) {
     if (!this.filename) {

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -1,7 +1,17 @@
 import Attributes from './attributes';
 import RestfulModel from './restful-model';
 
-export default class File extends RestfulModel {
+export interface FileProperties {
+  contentType?: string;
+  size?: number;
+  filename?: string;
+  messageIds?: string[];
+  contentId?: string;
+  contentDisposition?: string;
+  data?: any;
+}
+
+export default class File extends RestfulModel implements FileProperties {
   contentType?: string;
   size?: number;
   filename?: string;

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -13,6 +13,7 @@ export class Folder extends RestfulModel implements FolderProperties {
 
   constructor(connection: NylasConnection, props?: FolderProperties) {
     super(connection, props);
+    this.initAttributes(props);
   }
 
   saveRequestBody() {
@@ -39,7 +40,7 @@ Folder.attributes = {
   }),
 };
 
-export class Label extends Folder implements FolderProperties {
+export class Label extends Folder {
   constructor(connection: NylasConnection, props?: FolderProperties) {
     super(connection, props);
   }

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -1,9 +1,19 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
 
-export class Folder extends RestfulModel {
+export interface FolderProperties {
   displayName?: string;
   name?: string;
+}
+
+export class Folder extends RestfulModel implements FolderProperties {
+  displayName?: string;
+  name?: string;
+
+  constructor(connection: NylasConnection, props?: FolderProperties) {
+    super(connection, props);
+  }
 
   saveRequestBody() {
     const json: { [key: string]: any } = {};
@@ -29,7 +39,11 @@ Folder.attributes = {
   }),
 };
 
-export class Label extends Folder {
+export class Label extends Folder implements FolderProperties {
+  constructor(connection: NylasConnection, props?: FolderProperties) {
+    super(connection, props);
+  }
+
   saveRequestBody() {
     return { display_name: this.displayName };
   }

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -1,0 +1,67 @@
+import Model from './model';
+import Attributes from './attributes';
+
+interface TimeSlotProperties {
+  object: string;
+  status: string;
+  startTime: number;
+  endTime: number;
+}
+
+class TimeSlot extends Model implements TimeSlotProperties {
+  object = 'time_slot';
+  status = '';
+  startTime = 0;
+  endTime = 0;
+
+  constructor(props?: TimeSlotProperties) {
+    super();
+    this.initAttributes(props);
+  }
+}
+TimeSlot.attributes = {
+  object: Attributes.String({
+    modelKey: 'object',
+  }),
+  status: Attributes.String({
+    modelKey: 'status',
+  }),
+  startTime: Attributes.Number({
+    modelKey: 'startTime',
+    jsonKey: 'start_time',
+  }),
+  endTime: Attributes.Number({
+    modelKey: 'endTime',
+    jsonKey: 'end_time',
+  }),
+}
+
+interface FreeBusyProperties {
+  object: string;
+  email: string;
+  timeSlots: TimeSlotProperties[];
+}
+
+export default class FreeBusy extends Model implements FreeBusyProperties {
+  object = 'free_busy';
+  email = '';
+  timeSlots = [];
+
+  constructor(props?: FreeBusyProperties) {
+    super();
+    this.initAttributes(props);
+  }
+}
+FreeBusy.attributes = {
+  object: Attributes.String({
+    modelKey: 'object',
+  }),
+  email: Attributes.String({
+    modelKey: 'email',
+  }),
+  timeSlots: Attributes.Collection({
+    modelKey: 'timeSlots',
+    jsonKey: 'time_slots',
+    itemClass: TimeSlot,
+  })
+}

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -34,7 +34,7 @@ TimeSlot.attributes = {
     modelKey: 'endTime',
     jsonKey: 'end_time',
   }),
-}
+};
 
 interface FreeBusyProperties {
   object: string;
@@ -63,5 +63,5 @@ FreeBusy.attributes = {
     modelKey: 'timeSlots',
     jsonKey: 'time_slots',
     itemClass: TimeSlot,
-  })
-}
+  }),
+};

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -9,7 +9,8 @@ export interface JobStatusProperties {
   status?: string;
 }
 
-export default class JobStatus extends RestfulModel implements JobStatusProperties {
+export default class JobStatus extends RestfulModel
+  implements JobStatusProperties {
   action?: string;
   createdAt?: Date;
   jobStatusId?: string;

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -1,11 +1,24 @@
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
 
-export default class JobStatus extends RestfulModel {
+export interface JobStatusProperties {
   action?: string;
   createdAt?: Date;
   jobStatusId?: string;
   status?: string;
+}
+
+export default class JobStatus extends RestfulModel implements JobStatusProperties {
+  action?: string;
+  createdAt?: Date;
+  jobStatusId?: string;
+  status?: string;
+
+  constructor(connection: NylasConnection, props?: JobStatusProperties) {
+    super(connection, props);
+    this.initAttributes(props);
+  }
 }
 
 JobStatus.collectionName = 'job-statuses';

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -13,11 +13,11 @@ export interface ManagementAccountProperties {
 
 export default class ManagementAccount extends ManagementModel
   implements ManagementAccountProperties {
-  billingState = "";
-  emailAddress = "";
-  namespaceId = "";
-  provider = "";
-  syncState = "";
+  billingState = '';
+  emailAddress = '';
+  namespaceId = '';
+  provider = '';
+  syncState = '';
   trial = false;
 
   constructor(

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -1,13 +1,32 @@
 import ManagementModel from './management-model';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
 
-export default class ManagementAccount extends ManagementModel {
-  billingState?: string;
-  emailAddress?: string;
-  namespaceId?: string;
-  provider?: string;
-  syncState?: string;
-  trial?: boolean;
+export interface ManagementAccountProperties {
+  billingState: string;
+  emailAddress: string;
+  namespaceId: string;
+  provider: string;
+  syncState: string;
+  trial: boolean;
+}
+
+export default class ManagementAccount extends ManagementModel
+  implements ManagementAccountProperties {
+  billingState = '';
+  emailAddress = '';
+  namespaceId = '';
+  provider = '';
+  syncState = '';
+  trial = false;
+
+  constructor(
+    connection: NylasConnection,
+    clientId: string,
+    props: ManagementAccountProperties
+  ) {
+    super(connection, clientId, props);
+  }
 
   upgrade() {
     return this.connection

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -13,12 +13,12 @@ export interface ManagementAccountProperties {
 
 export default class ManagementAccount extends ManagementModel
   implements ManagementAccountProperties {
-  billingState = '';
-  emailAddress = '';
-  namespaceId = '';
-  provider = '';
-  syncState = '';
-  trial = false;
+  billingState: string;
+  emailAddress: string;
+  namespaceId: string;
+  provider: string;
+  syncState: string;
+  trial: boolean;
 
   constructor(
     connection: NylasConnection,
@@ -26,6 +26,12 @@ export default class ManagementAccount extends ManagementModel
     props: ManagementAccountProperties
   ) {
     super(connection, clientId, props);
+    this.billingState = props.billingState;
+    this.emailAddress = props.emailAddress;
+    this.namespaceId = props.namespaceId;
+    this.provider = props.provider;
+    this.syncState = props.syncState;
+    this.trial = props.trial;
   }
 
   upgrade() {

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -13,12 +13,12 @@ export interface ManagementAccountProperties {
 
 export default class ManagementAccount extends ManagementModel
   implements ManagementAccountProperties {
-  billingState: string;
-  emailAddress: string;
-  namespaceId: string;
-  provider: string;
-  syncState: string;
-  trial: boolean;
+  billingState = "";
+  emailAddress = "";
+  namespaceId = "";
+  provider = "";
+  syncState = "";
+  trial = false;
 
   constructor(
     connection: NylasConnection,
@@ -26,12 +26,7 @@ export default class ManagementAccount extends ManagementModel
     props: ManagementAccountProperties
   ) {
     super(connection, clientId, props);
-    this.billingState = props.billingState;
-    this.emailAddress = props.emailAddress;
-    this.namespaceId = props.namespaceId;
-    this.provider = props.provider;
-    this.syncState = props.syncState;
-    this.trial = props.trial;
+    this.initAttributes(props);
   }
 
   upgrade() {

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -6,6 +6,7 @@ export default class ManagementModelCollection<
   T extends ManagementModel
 > extends RestfulModelCollection<T> {
   clientId: string;
+  path: string;
 
   constructor(
     modelClass: typeof ManagementModel,
@@ -14,10 +15,7 @@ export default class ManagementModelCollection<
   ) {
     super(modelClass as any, connection);
     this.clientId = clientId;
-  }
-
-  get path(): string {
-    return `/a/${this.clientId}/${this.modelClass.collectionName}`;
+    this.path = `/a/${this.clientId}/${this.modelClass.collectionName}`;
   }
 
   _createModel(json: { [key: string]: any }) {

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -19,6 +19,7 @@ export default class ManagementModelCollection<
   }
 
   _createModel(json: { [key: string]: any }) {
-    return new (this.modelClass as any)(this.connection, this.clientId, json);
+    const props = this.modelClass.propsFromJSON(json, this);
+    return new (this.modelClass as any)(this.connection, this.clientId, props);
   }
 }

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -18,6 +18,10 @@ export default class ManagementModelCollection<
     this.path = `/a/${this.clientId}/${this.modelClass.collectionName}`;
   }
 
+  build(args: { [key: string]: any }): T {
+    return super._build(args);
+  }
+
   _createModel(json: { [key: string]: any }) {
     const props = this.modelClass.propsFromJSON(json, this);
     return new (this.modelClass as any)(this.connection, this.clientId, props);

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -16,7 +16,7 @@ export default class ManagementModelCollection<
     this.clientId = clientId;
   }
 
-  path() {
+  get path(): string {
     return `/a/${this.clientId}/${this.modelClass.collectionName}`;
   }
 

--- a/src/models/management-model.ts
+++ b/src/models/management-model.ts
@@ -7,9 +7,9 @@ export default class ManagementModel extends RestfulModel {
   constructor(
     connection: NylasConnection,
     clientId: string,
-    json: { [key: string]: any }
+    props: { [key: string]: any }
   ) {
-    super(connection, json);
+    super(connection, props);
     this.clientId = clientId;
   }
 }

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -51,7 +51,7 @@ export default class Message extends RestfulModel implements MessageProperties {
 
   constructor(connection: NylasConnection, props?: MessageProperties) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.to = [];
     }
   }

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -30,7 +30,7 @@ export interface MessageProperties {
 }
 
 export default class Message extends RestfulModel implements MessageProperties {
-  to = [];
+  to!: EmailParticipant[];
   subject?: string;
   from?: EmailParticipant[];
   replyTo?: EmailParticipant[];
@@ -51,6 +51,9 @@ export default class Message extends RestfulModel implements MessageProperties {
 
   constructor(connection: NylasConnection, props?: MessageProperties) {
     super(connection, props);
+    if(!props) {
+      this.to = [];
+    }
   }
 
   // We calculate the list of participants instead of grabbing it from

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -30,7 +30,7 @@ export interface MessageProperties {
 }
 
 export default class Message extends RestfulModel implements MessageProperties {
-  to!: EmailParticipant[];
+  to = [];
   subject?: string;
   from?: EmailParticipant[];
   replyTo?: EmailParticipant[];
@@ -51,9 +51,7 @@ export default class Message extends RestfulModel implements MessageProperties {
 
   constructor(connection: NylasConnection, props?: MessageProperties) {
     super(connection, props);
-    if (!props) {
-      this.to = [];
-    }
+    this.initAttributes(props);
   }
 
   // We calculate the list of participants instead of grabbing it from

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -8,7 +8,7 @@ const REQUEST_CHUNK_SIZE = 100;
 export default class ModelCollection<T extends Model> {
   connection: NylasConnection;
   modelClass: typeof Model;
-  private readonly _path: string;
+  path: string;
 
   constructor(
     modelClass: typeof Model,
@@ -17,17 +17,13 @@ export default class ModelCollection<T extends Model> {
   ) {
     this.modelClass = modelClass;
     this.connection = connection;
-    this._path = path;
+    this.path = path;
     if (!this.connection) {
       throw new Error('Connection object not provided');
     }
     if (!this.modelClass) {
       throw new Error('Model class not provided');
     }
-  }
-
-  get path(): string {
-    return this._path;
   }
 
   forEach(

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -216,7 +216,10 @@ export default class ModelCollection<T extends Model> {
     return new this.modelClass().fromJSON(json) as T;
   }
 
-  private getModel(id: string, params: { [key: string]: any } = {}): Promise<T> {
+  private getModel(
+    id: string,
+    params: { [key: string]: any } = {}
+  ): Promise<T> {
     return this.connection
       .request({
         method: 'GET',

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -1,0 +1,255 @@
+import NylasConnection from '../nylas-connection';
+import Model from './model';
+
+export type GetCallback = (error: Error | null, result?: Model) => void;
+
+const REQUEST_CHUNK_SIZE = 100;
+
+export default class ModelCollection<T extends Model> {
+  connection: NylasConnection;
+  modelClass: typeof Model;
+  private readonly _path: string;
+
+  constructor(
+    modelClass: typeof Model,
+    connection: NylasConnection,
+    path: string
+  ) {
+    this.modelClass = modelClass;
+    this.connection = connection;
+    this._path = path;
+    if (!this.connection) {
+      throw new Error('Connection object not provided');
+    }
+    if (!this.modelClass) {
+      throw new Error('Model class not provided');
+    }
+  }
+
+  get path(): string {
+    return this._path;
+  }
+
+  forEach(
+    params: { [key: string]: any } = {},
+    eachCallback: (item: T) => void,
+    completeCallback?: (err?: Error | null | undefined) => void
+  ) {
+    if (params.view == 'count') {
+      const err = new Error('forEach() cannot be called with the count view');
+      if (completeCallback) {
+        completeCallback(err);
+      }
+      return Promise.reject(err);
+    }
+
+    let offset = 0;
+
+    const iteratee = (): Promise<void> => {
+      return this._getItems(params, offset, REQUEST_CHUNK_SIZE).then(items => {
+        for (const item of items) {
+          eachCallback(item);
+        }
+        offset += items.length;
+        const finished = items.length < REQUEST_CHUNK_SIZE;
+        if (!finished) {
+          return iteratee();
+        }
+      });
+    };
+
+    iteratee().then(
+      () => {
+        if (completeCallback) {
+          completeCallback();
+        }
+      },
+      (err: Error) => {
+        if (completeCallback) {
+          return completeCallback(err);
+        }
+      }
+    );
+  }
+
+  list(
+    params: { [key: string]: any } = {},
+    callback?: (error: Error | null, obj?: T[]) => void
+  ) {
+    if (params.view == 'count') {
+      const err = new Error('list() cannot be called with the count view');
+      if (callback) {
+        callback(err);
+      }
+      return Promise.reject(err);
+    }
+
+    const limit = params.limit || Infinity;
+    const offset = params.offset;
+    return this._range({ params, offset, limit, callback });
+  }
+
+  find(
+    id: string,
+    paramsArg?: { [key: string]: any } | GetCallback | null,
+    callbackArg?: GetCallback | { [key: string]: any } | null
+  ) {
+    // callback used to be the second argument, and params was the third
+    let callback: GetCallback | undefined;
+    if (typeof callbackArg === 'function') {
+      callback = callbackArg as GetCallback;
+    } else if (typeof paramsArg === 'function') {
+      callback = paramsArg as GetCallback;
+    }
+
+    let params: { [key: string]: any } = {};
+    if (paramsArg && typeof paramsArg === 'object') {
+      params = paramsArg;
+    } else if (callbackArg && typeof callbackArg === 'object') {
+      params = callbackArg;
+    }
+
+    if (!id) {
+      const err = new Error('find() must be called with an item id');
+      if (callback) {
+        callback(err);
+      }
+      return Promise.reject(err);
+    }
+
+    if (params.view == 'count' || params.view == 'ids') {
+      const err = new Error(
+        'find() cannot be called with the count or ids view'
+      );
+      if (callback) {
+        callback(err);
+      }
+      return Promise.reject(err);
+    }
+
+    return this._getModel(id, params)
+      .then(model => {
+        if (callback) {
+          callback(null, model);
+        }
+        return Promise.resolve(model);
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      });
+  }
+
+  _range({
+    params = {},
+    offset = 0,
+    limit = 100,
+    callback,
+    path,
+  }: {
+    params?: { [key: string]: any };
+    offset?: number;
+    limit?: number;
+    callback?: (error: Error | null, results?: T[]) => void;
+    path?: string;
+  }) {
+    let accumulated: T[] = [];
+
+    const iteratee = (): Promise<void> => {
+      const chunkOffset = offset + accumulated.length;
+      const chunkLimit = Math.min(
+        REQUEST_CHUNK_SIZE,
+        limit - accumulated.length
+      );
+      return this._getItems(params, chunkOffset, chunkLimit, path).then(
+        items => {
+          accumulated = accumulated.concat(items);
+          const finished =
+            items.length < REQUEST_CHUNK_SIZE || accumulated.length >= limit;
+          if (!finished) {
+            return iteratee();
+          }
+        }
+      );
+    };
+
+    // do not return rejected promise when callback is provided
+    // to prevent unhandled rejection warning
+    return iteratee().then(
+      () => {
+        if (callback) {
+          return callback(null, accumulated);
+        }
+        return accumulated;
+      },
+      (err: Error) => {
+        if (callback) {
+          return callback(err);
+        }
+        throw err;
+      }
+    );
+  }
+
+  _getItems(
+    params: { [key: string]: any },
+    offset: number,
+    limit: number,
+    path?: string
+  ): Promise<T[]> {
+    // Items can be either models or ids
+
+    if (!path) {
+      path = this.path;
+    }
+
+    if (params.view == 'ids') {
+      return this.connection.request({
+        method: 'GET',
+        path,
+        qs: { ...params, offset, limit },
+      });
+    }
+
+    return this._getModelCollection(params, offset, limit, path);
+  }
+
+  _createModel(json: { [key: string]: any }): T {
+    return new this.modelClass(json) as T;
+  }
+
+  _getModel(id: string, params: { [key: string]: any } = {}): Promise<T> {
+    return this.connection
+      .request({
+        method: 'GET',
+        path: `${this.path}/${id}`,
+        qs: params,
+      })
+      .then((json: any) => {
+        const model = this._createModel(json);
+        return Promise.resolve(model);
+      });
+  }
+
+  _getModelCollection(
+    params: { [key: string]: any },
+    offset: number,
+    limit: number,
+    path: string
+  ): Promise<T[]> {
+    return this.connection
+      .request({
+        method: 'GET',
+        path,
+        qs: { ...params, offset, limit },
+      })
+      .then((jsonArray: any) => {
+        const models = jsonArray.map((json: any) => {
+          return this._createModel(json);
+        });
+        return Promise.resolve(models);
+      });
+  }
+}

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -213,8 +213,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   _createModel(json: { [key: string]: any }): T {
-    const props = this.modelClass.propsFromJSON(json, this);
-    return new this.modelClass(props) as T;
+    return new this.modelClass().fromJSON(json) as T;
   }
 
   _getModel(id: string, params: { [key: string]: any } = {}): Promise<T> {

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -34,13 +34,13 @@ export default class ModelCollection<T extends Model> {
     params: { [key: string]: any } = {},
     eachCallback: (item: T) => void,
     completeCallback?: (err?: Error | null | undefined) => void
-  ) {
+  ): void {
     if (params.view == 'count') {
       const err = new Error('forEach() cannot be called with the count view');
       if (completeCallback) {
         completeCallback(err);
       }
-      return Promise.reject(err);
+      throw err;
     }
 
     let offset = 0;
@@ -75,7 +75,7 @@ export default class ModelCollection<T extends Model> {
   list(
     params: { [key: string]: any } = {},
     callback?: (error: Error | null, obj?: T[]) => void
-  ) {
+  ): Promise<T[]> {
     if (params.view == 'count') {
       const err = new Error('list() cannot be called with the count view');
       if (callback) {
@@ -93,7 +93,7 @@ export default class ModelCollection<T extends Model> {
     id: string,
     paramsArg?: { [key: string]: any } | GetCallback | null,
     callbackArg?: GetCallback | { [key: string]: any } | null
-  ) {
+  ): Promise<T> {
     // callback used to be the second argument, and params was the third
     let callback: GetCallback | undefined;
     if (typeof callbackArg === 'function') {
@@ -154,7 +154,7 @@ export default class ModelCollection<T extends Model> {
     limit?: number;
     callback?: (error: Error | null, results?: T[]) => void;
     path?: string;
-  }) {
+  }): Promise<T[]> {
     let accumulated: T[] = [];
 
     const iteratee = (): Promise<void> => {
@@ -180,13 +180,13 @@ export default class ModelCollection<T extends Model> {
     return iteratee().then(
       () => {
         if (callback) {
-          return callback(null, accumulated);
+          callback(null, accumulated);
         }
         return accumulated;
       },
       (err: Error) => {
         if (callback) {
-          return callback(err);
+          callback(err);
         }
         throw err;
       }

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -213,7 +213,8 @@ export default class ModelCollection<T extends Model> {
   }
 
   _createModel(json: { [key: string]: any }): T {
-    return new this.modelClass(json) as T;
+    const props = this.modelClass.propsFromJSON(json, this);
+    return new this.modelClass(props) as T;
   }
 
   _getModel(id: string, params: { [key: string]: any } = {}): Promise<T> {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -5,12 +5,6 @@ export type SaveCallback = (error: Error | null, result?: any) => void;
 export default class Model {
   static attributes: { [key: string]: Attribute };
 
-  constructor(props?: { [key: string]: any }) {
-    if (props) {
-      this.initAttributes(props);
-    }
-  }
-
   static propsFromJSON(
     json: { [key: string]: any },
     parent: any
@@ -30,7 +24,7 @@ export default class Model {
   }
 
   //TODO::Maybe come up with a better name?
-  initAttributes(props: { [key: string]: any }): void {
+  initAttributes(props?: { [key: string]: any }): void {
     const attributes = this.attributes();
     for (const prop in props) {
       if (props.hasOwnProperty(prop)) {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -33,7 +33,7 @@ export default class Model {
   initAttributes(props: { [key: string]: any }): void {
     const attributes = this.attributes();
     for (const prop in props) {
-      if(props.hasOwnProperty(prop)) {
+      if (props.hasOwnProperty(prop)) {
         const attr = attributes[prop];
         if (attr) {
           (this as any)[prop] = attr.fromJSON(props[prop], this);

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,0 +1,44 @@
+import { Attribute } from './attributes';
+
+export type SaveCallback = (error: Error | null, result?: any) => void;
+
+export default class Model {
+  static attributes: { [key: string]: Attribute };
+
+  constructor(json?: any) {
+    if (json) {
+      this.fromJSON(json);
+    }
+  }
+
+  attributes(): { [key: string]: Attribute } {
+    return (this.constructor as any).attributes;
+  }
+
+  fromJSON(json?: any): Model {
+    const attributes = this.attributes();
+    for (const attrName in attributes) {
+      const attr = attributes[attrName];
+      if (json[attr.jsonKey] !== undefined) {
+        (this as any)[attrName] = attr.fromJSON(json[attr.jsonKey], this);
+      }
+    }
+    return this;
+  }
+
+  toJSON(enforceReadOnly?: boolean): any {
+    const json: any = {};
+    const attributes = this.attributes();
+    for (const attrName in attributes) {
+      if (!enforceReadOnly || !attributes[attrName].readOnly) {
+        const attr = attributes[attrName];
+        json[attr.jsonKey] = attr.toJSON((this as any)[attrName]);
+      }
+    }
+    return json;
+  }
+
+  toString(): string {
+    return JSON.stringify(this.toJSON());
+  }
+}

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -5,9 +5,9 @@ export type SaveCallback = (error: Error | null, result?: any) => void;
 export default class Model {
   static attributes: { [key: string]: Attribute };
 
-  constructor(json?: any) {
-    if (json) {
-      this.fromJSON(json);
+  constructor(props?: { [key: string]: any }) {
+    if (props) {
+      this.initAttributes(props);
     }
   }
 

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -11,11 +11,36 @@ export default class Model {
     }
   }
 
+  static propsFromJSON(
+    json: { [key: string]: any },
+    parent: any
+  ): { [key: string]: any } {
+    const props: { [key: string]: any } = {};
+    for (const attrName in this.attributes) {
+      const attr = this.attributes[attrName];
+      if (json[attr.jsonKey] !== undefined) {
+        props[attrName] = attr.fromJSON(json[attr.jsonKey], parent);
+      }
+    }
+    return props;
+  }
+
   attributes(): { [key: string]: Attribute } {
     return (this.constructor as any).attributes;
   }
 
-  fromJSON(json?: any): Model {
+  //TODO::Maybe come up with a better name?
+  initAttributes(props: { [key: string]: any }): void {
+    const attributes = this.attributes();
+    for (const prop in props) {
+      const attr = attributes[prop];
+      if (attr) {
+        (this as any)[prop] = attr.fromJSON(props[prop], this);
+      }
+    }
+  }
+
+  fromJSON(json?: any): this {
     const attributes = this.attributes();
     for (const attrName in attributes) {
       const attr = attributes[attrName];
@@ -32,7 +57,7 @@ export default class Model {
     for (const attrName in attributes) {
       if (!enforceReadOnly || !attributes[attrName].readOnly) {
         const attr = attributes[attrName];
-        json[attr.jsonKey] = attr.toJSON((this as any)[attrName]);
+        json[attr.jsonKey] = attr.toJSON((this as any)[attrName], this);
       }
     }
     return json;

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -33,9 +33,11 @@ export default class Model {
   initAttributes(props: { [key: string]: any }): void {
     const attributes = this.attributes();
     for (const prop in props) {
-      const attr = attributes[prop];
-      if (attr) {
-        (this as any)[prop] = attr.fromJSON(props[prop], this);
+      if(props.hasOwnProperty(prop)) {
+        const attr = attributes[prop];
+        if (attr) {
+          (this as any)[prop] = attr.fromJSON(props[prop], this);
+        }
       }
     }
   }

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -11,19 +11,14 @@ export interface CategorizeProperties {
 }
 
 export class Categorize extends Model implements CategorizeProperties {
-  category!: string;
-  categorizedAt!: Date;
-  modelVersion!: string;
-  subcategories!: string[];
+  category = '';
+  categorizedAt = new Date();
+  modelVersion = '';
+  subcategories = [];
 
   constructor(props?: CategorizeProperties) {
-    super(props);
-    if (!props) {
-      this.category = '';
-      this.categorizedAt = new Date();
-      this.modelVersion = '';
-      this.subcategories = [];
-    }
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -59,16 +54,14 @@ export interface NeuralCategorizerProperties extends MessageProperties {
 
 export default class NeuralCategorizer extends Message
   implements NeuralCategorizerProperties {
-  categorizer!: Categorize;
+  categorizer = new Categorize();
 
   constructor(
     connection: NylasConnection,
     props?: NeuralCategorizerProperties
   ) {
     super(connection, props);
-    if (!props) {
-      this.categorizer = new Categorize();
-    }
+    this.initAttributes(props);
   }
 
   reCategorize(category: string): Promise<NeuralCategorizer> {

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -1,12 +1,24 @@
 import Attributes from './attributes';
-import Message from './message';
+import Message, { MessageProperties } from './message';
 import Model from './model';
+import NylasConnection from '../nylas-connection';
 
-export class Categorize extends Model {
-  category?: string;
-  categorizedAt?: Date;
-  modelVersion?: string;
-  subcategories?: string[];
+export interface CategorizeProperties {
+  category: string;
+  categorizedAt: Date;
+  modelVersion: string;
+  subcategories: string[];
+}
+
+export class Categorize extends Model implements CategorizeProperties {
+  category = '';
+  categorizedAt = new Date();
+  modelVersion = '';
+  subcategories = [];
+
+  constructor(props?: CategorizeProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {
@@ -35,8 +47,20 @@ Categorize.attributes = {
   }),
 };
 
-export default class NeuralCategorizer extends Message {
-  categorizer?: Categorize;
+export interface NeuralCategorizerProperties extends MessageProperties {
+  categorizer: Categorize;
+}
+
+export default class NeuralCategorizer extends Message
+  implements NeuralCategorizerProperties {
+  categorizer = new Categorize();
+
+  constructor(
+    connection: NylasConnection,
+    props?: NeuralCategorizerProperties
+  ) {
+    super(connection, props);
+  }
 
   reCategorize(category: string): Promise<NeuralCategorizer> {
     return this.connection

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -11,13 +11,19 @@ export interface CategorizeProperties {
 }
 
 export class Categorize extends Model implements CategorizeProperties {
-  category = '';
-  categorizedAt = new Date();
-  modelVersion = '';
-  subcategories = [];
+  category!: string;
+  categorizedAt!: Date;
+  modelVersion!: string;
+  subcategories!: string[];
 
   constructor(props?: CategorizeProperties) {
     super(props);
+    if(!props) {
+      this.category = '';
+      this.categorizedAt = new Date();
+      this.modelVersion = '';
+      this.subcategories = [];
+    }
   }
 
   toJSON() {
@@ -53,13 +59,16 @@ export interface NeuralCategorizerProperties extends MessageProperties {
 
 export default class NeuralCategorizer extends Message
   implements NeuralCategorizerProperties {
-  categorizer = new Categorize();
+  categorizer!: Categorize;
 
   constructor(
     connection: NylasConnection,
     props?: NeuralCategorizerProperties
   ) {
     super(connection, props);
+    if(!props) {
+      this.categorizer = new Categorize();
+    }
   }
 
   reCategorize(category: string): Promise<NeuralCategorizer> {

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -18,7 +18,7 @@ export class Categorize extends Model implements CategorizeProperties {
 
   constructor(props?: CategorizeProperties) {
     super(props);
-    if(!props) {
+    if (!props) {
       this.category = '';
       this.categorizedAt = new Date();
       this.modelVersion = '';
@@ -66,7 +66,7 @@ export default class NeuralCategorizer extends Message
     props?: NeuralCategorizerProperties
   ) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.categorizer = new Categorize();
     }
   }

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -1,8 +1,8 @@
 import Attributes from './attributes';
 import Message from './message';
-import RestfulModel from './restful-model';
+import Model from './model';
 
-export class Categorize extends RestfulModel {
+export class Categorize extends Model {
   category?: string;
   categorizedAt?: Date;
   modelVersion?: string;
@@ -18,7 +18,6 @@ export class Categorize extends RestfulModel {
   }
 }
 
-Categorize.collectionName = 'categorize';
 Categorize.attributes = {
   category: Attributes.String({
     modelKey: 'category',

--- a/src/models/neural-clean-conversation.ts
+++ b/src/models/neural-clean-conversation.ts
@@ -12,14 +12,18 @@ export interface NeuralCleanConversationProperties extends MessageProperties {
 
 export default class NeuralCleanConversation extends Message
   implements NeuralCleanConversationProperties {
-  conversation = '';
-  modelVersion = '';
+  conversation!: string;
+  modelVersion!: string;
 
   constructor(
     connection: NylasConnection,
     props?: NeuralCleanConversationProperties
   ) {
     super(connection, props);
+    if(!props) {
+      this.conversation = '';
+      this.modelVersion = '';
+    }
   }
 
   extractImages(): Promise<File[]> {

--- a/src/models/neural-clean-conversation.ts
+++ b/src/models/neural-clean-conversation.ts
@@ -1,12 +1,26 @@
-import Message from './message';
+import Message, { MessageProperties } from './message';
 import Attributes from './attributes';
 import File from './file';
+import NylasConnection from '../nylas-connection';
 
 const IMAGE_REGEX = /[(']cid:(.)*[)']/g;
 
-export default class NeuralCleanConversation extends Message {
-  conversation?: string;
-  modelVersion?: string;
+export interface NeuralCleanConversationProperties extends MessageProperties {
+  conversation: string;
+  modelVersion: string;
+}
+
+export default class NeuralCleanConversation extends Message
+  implements NeuralCleanConversationProperties {
+  conversation = '';
+  modelVersion = '';
+
+  constructor(
+    connection: NylasConnection,
+    props?: NeuralCleanConversationProperties
+  ) {
+    super(connection, props);
+  }
 
   extractImages(): Promise<File[]> {
     const f: File[] = [];

--- a/src/models/neural-clean-conversation.ts
+++ b/src/models/neural-clean-conversation.ts
@@ -20,7 +20,7 @@ export default class NeuralCleanConversation extends Message
     props?: NeuralCleanConversationProperties
   ) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.conversation = '';
       this.modelVersion = '';
     }

--- a/src/models/neural-clean-conversation.ts
+++ b/src/models/neural-clean-conversation.ts
@@ -12,18 +12,15 @@ export interface NeuralCleanConversationProperties extends MessageProperties {
 
 export default class NeuralCleanConversation extends Message
   implements NeuralCleanConversationProperties {
-  conversation!: string;
-  modelVersion!: string;
+  conversation = '';
+  modelVersion = '';
 
   constructor(
     connection: NylasConnection,
     props?: NeuralCleanConversationProperties
   ) {
     super(connection, props);
-    if (!props) {
-      this.conversation = '';
-      this.modelVersion = '';
-    }
+    this.initAttributes(props);
   }
 
   extractImages(): Promise<File[]> {

--- a/src/models/neural-ocr.ts
+++ b/src/models/neural-ocr.ts
@@ -1,9 +1,19 @@
 import Attributes from './attributes';
-import File from './file';
+import File, { FileProperties } from './file';
+import NylasConnection from '../nylas-connection';
 
-export default class NeuralOcr extends File {
-  ocr?: string[];
-  processedPages?: number;
+export interface NeuralOcrProperties extends FileProperties {
+  ocr: string[];
+  processedPages: number;
+}
+
+export default class NeuralOcr extends File implements NeuralOcrProperties {
+  ocr = [];
+  processedPages = 0;
+
+  constructor(connection: NylasConnection, props?: NeuralOcrProperties) {
+    super(connection, props);
+  }
 }
 
 NeuralOcr.collectionName = 'ocr';

--- a/src/models/neural-ocr.ts
+++ b/src/models/neural-ocr.ts
@@ -8,15 +8,12 @@ export interface NeuralOcrProperties extends FileProperties {
 }
 
 export default class NeuralOcr extends File implements NeuralOcrProperties {
-  ocr!: string[];
-  processedPages!: number;
+  ocr = [];
+  processedPages = 0;
 
   constructor(connection: NylasConnection, props?: NeuralOcrProperties) {
     super(connection, props);
-    if (!props) {
-      this.ocr = [];
-      this.processedPages = 0;
-    }
+    this.initAttributes(props);
   }
 }
 

--- a/src/models/neural-ocr.ts
+++ b/src/models/neural-ocr.ts
@@ -8,11 +8,15 @@ export interface NeuralOcrProperties extends FileProperties {
 }
 
 export default class NeuralOcr extends File implements NeuralOcrProperties {
-  ocr = [];
-  processedPages = 0;
+  ocr!: string[];
+  processedPages!: number;
 
   constructor(connection: NylasConnection, props?: NeuralOcrProperties) {
     super(connection, props);
+    if(!props) {
+      this.ocr = [];
+      this.processedPages = 0;
+    }
   }
 }
 

--- a/src/models/neural-ocr.ts
+++ b/src/models/neural-ocr.ts
@@ -13,7 +13,7 @@ export default class NeuralOcr extends File implements NeuralOcrProperties {
 
   constructor(connection: NylasConnection, props?: NeuralOcrProperties) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.ocr = [];
       this.processedPages = 0;
     }

--- a/src/models/neural-sentiment-analysis.ts
+++ b/src/models/neural-sentiment-analysis.ts
@@ -12,17 +12,24 @@ export interface NeuralSentimentAnalysisProperties {
 
 export default class NeuralSentimentAnalysis extends RestfulModel
   implements NeuralSentimentAnalysisProperties {
-  accountId = '';
-  sentiment = '';
-  sentimentScore = 0;
-  processedLength = 0;
-  text = '';
+  accountId!: string;
+  sentiment!: string;
+  sentimentScore!: number;
+  processedLength!: number;
+  text!: string;
 
   constructor(
     connection: NylasConnection,
     props?: NeuralSentimentAnalysisProperties
   ) {
     super(connection, props);
+    if(props) {
+      this.accountId = '';
+      this.sentiment = '';
+      this.sentimentScore = 0;
+      this.processedLength = 0;
+      this.text = '';
+    }
   }
 }
 

--- a/src/models/neural-sentiment-analysis.ts
+++ b/src/models/neural-sentiment-analysis.ts
@@ -1,12 +1,29 @@
 import Attributes from './attributes';
 import RestfulModel from './restful-model';
+import NylasConnection from '../nylas-connection';
 
-export default class NeuralSentimentAnalysis extends RestfulModel {
-  account_id?: string;
-  sentiment?: string;
-  sentimentScore?: number;
-  processedLength?: number;
-  text?: string;
+export interface NeuralSentimentAnalysisProperties {
+  accountId: string;
+  sentiment: string;
+  sentimentScore: number;
+  processedLength: number;
+  text: string;
+}
+
+export default class NeuralSentimentAnalysis extends RestfulModel
+  implements NeuralSentimentAnalysisProperties {
+  accountId = '';
+  sentiment = '';
+  sentimentScore = 0;
+  processedLength = 0;
+  text = '';
+
+  constructor(
+    connection: NylasConnection,
+    props?: NeuralSentimentAnalysisProperties
+  ) {
+    super(connection, props);
+  }
 }
 
 NeuralSentimentAnalysis.collectionName = 'sentiment';

--- a/src/models/neural-sentiment-analysis.ts
+++ b/src/models/neural-sentiment-analysis.ts
@@ -23,7 +23,7 @@ export default class NeuralSentimentAnalysis extends RestfulModel
     props?: NeuralSentimentAnalysisProperties
   ) {
     super(connection, props);
-    if(props) {
+    if (props) {
       this.accountId = '';
       this.sentiment = '';
       this.sentimentScore = 0;

--- a/src/models/neural-sentiment-analysis.ts
+++ b/src/models/neural-sentiment-analysis.ts
@@ -12,24 +12,18 @@ export interface NeuralSentimentAnalysisProperties {
 
 export default class NeuralSentimentAnalysis extends RestfulModel
   implements NeuralSentimentAnalysisProperties {
-  accountId!: string;
-  sentiment!: string;
-  sentimentScore!: number;
-  processedLength!: number;
-  text!: string;
+  accountId = '';
+  sentiment = '';
+  sentimentScore = 0;
+  processedLength = 0;
+  text = '';
 
   constructor(
     connection: NylasConnection,
     props?: NeuralSentimentAnalysisProperties
   ) {
     super(connection, props);
-    if (props) {
-      this.accountId = '';
-      this.sentiment = '';
-      this.sentimentScore = 0;
-      this.processedLength = 0;
-      this.text = '';
-    }
+    this.initAttributes(props);
   }
 }
 

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -3,9 +3,18 @@ import { Contact, EmailAddress, PhoneNumber, WebPage } from './contact';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
 
-class Link extends Model {
+interface LinkProperties {
   description?: string;
   url?: string;
+}
+
+class Link extends Model implements LinkProperties {
+  description?: string;
+  url?: string;
+
+  constructor(props?: LinkProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {
@@ -24,9 +33,18 @@ Link.attributes = {
   }),
 };
 
-class Name extends Model {
+interface NameProperties {
   firstName?: string;
   lastName?: string;
+}
+
+class Name extends Model implements NameProperties {
+  firstName?: string;
+  lastName?: string;
+
+  constructor(props?: NameProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {
@@ -47,12 +65,25 @@ Name.attributes = {
   }),
 };
 
-export default class NeuralSignatureContact extends Model {
+export interface NeuralSignatureContactProperties {
   jobTitles?: string[];
   links?: Link[];
   phoneNumbers?: string[];
   emails?: string[];
   names?: Name[];
+}
+
+export default class NeuralSignatureContact extends Model
+  implements NeuralSignatureContactProperties {
+  jobTitles?: string[];
+  links?: Link[];
+  phoneNumbers?: string[];
+  emails?: string[];
+  names?: Name[];
+
+  constructor(props?: NeuralSignatureContactProperties) {
+    super(props);
+  }
 
   toJSON() {
     return {

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -1,8 +1,9 @@
-import RestfulModel from './restful-model';
 import Attributes from './attributes';
 import { Contact, EmailAddress, PhoneNumber, WebPage } from './contact';
+import Model from './model';
+import NylasConnection from '../nylas-connection';
 
-class Link extends RestfulModel {
+class Link extends Model {
   description?: string;
   url?: string;
 
@@ -14,7 +15,6 @@ class Link extends RestfulModel {
   }
 }
 
-Link.collectionName = 'link';
 Link.attributes = {
   description: Attributes.String({
     modelKey: 'description',
@@ -24,7 +24,7 @@ Link.attributes = {
   }),
 };
 
-class Name extends RestfulModel {
+class Name extends Model {
   firstName?: string;
   lastName?: string;
 
@@ -36,7 +36,6 @@ class Name extends RestfulModel {
   }
 }
 
-Name.collectionName = 'name';
 Name.attributes = {
   firstName: Attributes.String({
     modelKey: 'firstName',
@@ -48,7 +47,7 @@ Name.attributes = {
   }),
 };
 
-export default class NeuralSignatureContact extends RestfulModel {
+export default class NeuralSignatureContact extends Model {
   jobTitles?: string[];
   links?: Link[];
   phoneNumbers?: string[];
@@ -65,8 +64,9 @@ export default class NeuralSignatureContact extends RestfulModel {
     };
   }
 
-  toContactObject(): Contact {
-    const contact = new Contact(this.connection);
+  //TODO::Perhaps this gets moved out to Neural?
+  toContactObject(connection: NylasConnection): Contact {
+    const contact = new Contact(connection);
 
     if (this.names) {
       contact.givenName = this.names[0].firstName;
@@ -78,18 +78,14 @@ export default class NeuralSignatureContact extends RestfulModel {
     if (this.emails) {
       const contactEmails: EmailAddress[] = [];
       this.emails.forEach(email =>
-        contactEmails.push(
-          new EmailAddress(this.connection, { type: 'personal', email: email })
-        )
+        contactEmails.push(new EmailAddress({ type: 'personal', email: email }))
       );
       contact.emailAddresses = contactEmails;
     }
     if (this.phoneNumbers) {
       const contactNumbers: PhoneNumber[] = [];
       this.phoneNumbers.forEach(number =>
-        contactNumbers.push(
-          new PhoneNumber(this.connection, { type: 'mobile', number: number })
-        )
+        contactNumbers.push(new PhoneNumber({ type: 'mobile', number: number }))
       );
       contact.phoneNumbers = contactNumbers;
     }
@@ -97,9 +93,7 @@ export default class NeuralSignatureContact extends RestfulModel {
       const webPages: WebPage[] = [];
       this.links.forEach(link => {
         if (link['url']) {
-          webPages.push(
-            new WebPage(this.connection, { type: 'homepage', url: link['url'] })
-          );
+          webPages.push(new WebPage({ type: 'homepage', url: link['url'] }));
         }
       });
       contact.webPages = webPages;
@@ -109,7 +103,6 @@ export default class NeuralSignatureContact extends RestfulModel {
   }
 }
 
-NeuralSignatureContact.collectionName = 'signature_contact';
 NeuralSignatureContact.attributes = {
   jobTitles: Attributes.StringList({
     modelKey: 'jobTitles',

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -9,11 +9,12 @@ interface LinkProperties {
 }
 
 class Link extends Model implements LinkProperties {
-  description?: string;
-  url?: string;
+  description = '';
+  url = '';
 
   constructor(props?: LinkProperties) {
-    super(props);
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -39,11 +40,12 @@ interface NameProperties {
 }
 
 class Name extends Model implements NameProperties {
-  firstName?: string;
-  lastName?: string;
+  firstName = '';
+  lastName = '';
 
   constructor(props?: NameProperties) {
-    super(props);
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {
@@ -82,7 +84,8 @@ export default class NeuralSignatureContact extends Model
   names?: Name[];
 
   constructor(props?: NeuralSignatureContactProperties) {
-    super(props);
+    super();
+    this.initAttributes(props);
   }
 
   toJSON() {

--- a/src/models/neural-signature-extraction.ts
+++ b/src/models/neural-signature-extraction.ts
@@ -11,8 +11,8 @@ export interface NeuralSignatureExtractionProperties extends MessageProperties {
 
 export default class NeuralSignatureExtraction extends Message
   implements NeuralSignatureExtractionProperties {
-  signature!: string;
-  modelVersion!: string;
+  signature = '';
+  modelVersion = '';
   contacts?: NeuralSignatureContact;
 
   constructor(
@@ -20,10 +20,7 @@ export default class NeuralSignatureExtraction extends Message
     props?: NeuralSignatureExtractionProperties
   ) {
     super(connection, props);
-    if (!props) {
-      this.signature = '';
-      this.modelVersion = '';
-    }
+    this.initAttributes(props);
   }
 }
 

--- a/src/models/neural-signature-extraction.ts
+++ b/src/models/neural-signature-extraction.ts
@@ -20,7 +20,7 @@ export default class NeuralSignatureExtraction extends Message
     props?: NeuralSignatureExtractionProperties
   ) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.signature = '';
       this.modelVersion = '';
     }

--- a/src/models/neural-signature-extraction.ts
+++ b/src/models/neural-signature-extraction.ts
@@ -11,8 +11,8 @@ export interface NeuralSignatureExtractionProperties extends MessageProperties {
 
 export default class NeuralSignatureExtraction extends Message
   implements NeuralSignatureExtractionProperties {
-  signature = '';
-  modelVersion = '';
+  signature!: string;
+  modelVersion!: string;
   contacts?: NeuralSignatureContact;
 
   constructor(
@@ -20,6 +20,10 @@ export default class NeuralSignatureExtraction extends Message
     props?: NeuralSignatureExtractionProperties
   ) {
     super(connection, props);
+    if(!props) {
+      this.signature = '';
+      this.modelVersion = '';
+    }
   }
 }
 

--- a/src/models/neural-signature-extraction.ts
+++ b/src/models/neural-signature-extraction.ts
@@ -1,11 +1,26 @@
 import NeuralSignatureContact from './neural-signature-contact';
 import Attributes from './attributes';
-import Message from './message';
+import Message, { MessageProperties } from './message';
+import NylasConnection from '../nylas-connection';
 
-export default class NeuralSignatureExtraction extends Message {
-  signature?: string;
-  modelVersion?: string;
+export interface NeuralSignatureExtractionProperties extends MessageProperties {
+  signature: string;
+  modelVersion: string;
   contacts?: NeuralSignatureContact;
+}
+
+export default class NeuralSignatureExtraction extends Message
+  implements NeuralSignatureExtractionProperties {
+  signature = '';
+  modelVersion = '';
+  contacts?: NeuralSignatureContact;
+
+  constructor(
+    connection: NylasConnection,
+    props?: NeuralSignatureExtractionProperties
+  ) {
+    super(connection, props);
+  }
 }
 
 NeuralSignatureExtraction.collectionName = 'signature';

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -16,7 +16,8 @@ export interface NeuralMessageOptionsProperties {
   parseContacts?: boolean;
 }
 
-export class NeuralMessageOptions extends Model implements NeuralMessageOptionsProperties {
+export class NeuralMessageOptions extends Model
+  implements NeuralMessageOptionsProperties {
   ignoreLinks?: boolean;
   ignoreImages?: boolean;
   ignoreTables?: boolean;
@@ -31,8 +32,8 @@ export class NeuralMessageOptions extends Model implements NeuralMessageOptionsP
 
   toJSON(writeParseContact?: boolean): { [key: string]: boolean } {
     const body: { [key: string]: boolean } = super.toJSON();
-    if(writeParseContact !== true) {
-      delete body["parse_contacts"];
+    if (writeParseContact !== true) {
+      delete body['parse_contacts'];
     }
     return body;
   }
@@ -62,7 +63,7 @@ NeuralMessageOptions.attributes = {
     modelKey: 'parseContacts',
     jsonKey: 'parse_contacts',
   }),
-}
+};
 
 export default class Neural extends RestfulModel {
   sentimentAnalysisMessage(

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -4,14 +4,65 @@ import NeuralSignatureExtraction from './neural-signature-extraction';
 import NeuralOcr from './neural-ocr';
 import NeuralCategorizer from './neural-categorizer';
 import NeuralCleanConversation from './neural-clean-conversation';
+import Model from './model';
+import Attributes from './attributes';
 
-export type NeuralMessageOptions = {
-  ignore_links?: boolean;
-  ignore_images?: boolean;
-  ignore_tables?: boolean;
-  remove_conclusion_phrases?: boolean;
-  images_as_markdowns?: boolean;
-};
+export interface NeuralMessageOptionsProperties {
+  ignoreLinks?: boolean;
+  ignoreImages?: boolean;
+  ignoreTables?: boolean;
+  removeConclusionPhrases?: boolean;
+  imagesAsMarkdown?: boolean;
+  parseContacts?: boolean;
+}
+
+export class NeuralMessageOptions extends Model implements NeuralMessageOptionsProperties {
+  ignoreLinks?: boolean;
+  ignoreImages?: boolean;
+  ignoreTables?: boolean;
+  removeConclusionPhrases?: boolean;
+  imagesAsMarkdown?: boolean;
+  parseContacts?: boolean;
+
+  constructor(props?: NeuralMessageOptionsProperties) {
+    super();
+    this.initAttributes(props);
+  }
+
+  toJSON(writeParseContact?: boolean): { [key: string]: boolean } {
+    const body: { [key: string]: boolean } = super.toJSON();
+    if(writeParseContact !== true) {
+      delete body["parse_contacts"];
+    }
+    return body;
+  }
+}
+NeuralMessageOptions.attributes = {
+  ignoreLinks: Attributes.Boolean({
+    modelKey: 'ignoreLinks',
+    jsonKey: 'ignore_links',
+  }),
+  ignoreImages: Attributes.Boolean({
+    modelKey: 'ignoreImages',
+    jsonKey: 'ignore_images',
+  }),
+  ignoreTables: Attributes.Boolean({
+    modelKey: 'ignoreTables',
+    jsonKey: 'ignore_tables',
+  }),
+  removeConclusionPhrases: Attributes.Boolean({
+    modelKey: 'removeConclusionPhrases',
+    jsonKey: 'remove_conclusion_phrases',
+  }),
+  imagesAsMarkdown: Attributes.Boolean({
+    modelKey: 'imagesAsMarkdown',
+    jsonKey: 'images_as_markdown',
+  }),
+  parseContacts: Attributes.Boolean({
+    modelKey: 'parseContacts',
+    jsonKey: 'parse_contacts',
+  }),
+}
 
 export default class Neural extends RestfulModel {
   sentimentAnalysisMessage(
@@ -38,8 +89,7 @@ export default class Neural extends RestfulModel {
 
   extractSignature(
     messageIds: string[],
-    parseContact?: boolean,
-    options?: NeuralMessageOptions
+    options?: NeuralMessageOptionsProperties
   ): Promise<NeuralSignatureExtraction[]> {
     let body: { [key: string]: any } = { message_id: messageIds };
     const path = 'signature';
@@ -47,11 +97,8 @@ export default class Neural extends RestfulModel {
     if (options) {
       body = {
         ...body,
-        ...options,
+        ...new NeuralMessageOptions(options).toJSON(true),
       };
-    }
-    if (parseContact) {
-      body['parse_contact'] = parseContact;
     }
 
     return this.request(path, body).then((jsonArray: any) => {
@@ -87,7 +134,7 @@ export default class Neural extends RestfulModel {
 
   cleanConversation(
     messageIds: string[],
-    options?: NeuralMessageOptions
+    options?: NeuralMessageOptionsProperties
   ): Promise<NeuralCleanConversation[]> {
     let body: { [key: string]: any } = { message_id: messageIds };
     const path = 'conversation';

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -22,7 +22,7 @@ export default class Neural extends RestfulModel {
 
     return this._request(path, body).then((jsonArray: any) => {
       return jsonArray.map((json: any) => {
-        return new NeuralSentimentAnalysis(this.connection, json);
+        return new NeuralSentimentAnalysis(this.connection).fromJSON(json);
       });
     });
   }
@@ -32,7 +32,7 @@ export default class Neural extends RestfulModel {
     const path = 'sentiment';
 
     return this._request(path, body).then(json => {
-      return new NeuralSentimentAnalysis(this.connection, json);
+      return new NeuralSentimentAnalysis(this.connection).fromJSON(json);
     });
   }
 
@@ -56,7 +56,7 @@ export default class Neural extends RestfulModel {
 
     return this._request(path, body).then((jsonArray: any) => {
       return jsonArray.map((json: any) => {
-        return new NeuralSignatureExtraction(this.connection, json);
+        return new NeuralSignatureExtraction(this.connection).fromJSON(json);
       });
     });
   }
@@ -70,7 +70,7 @@ export default class Neural extends RestfulModel {
     }
 
     return this._request(path, body).then(json => {
-      return new NeuralOcr(this.connection, json);
+      return new NeuralOcr(this.connection).fromJSON(json);
     });
   }
 
@@ -80,7 +80,7 @@ export default class Neural extends RestfulModel {
 
     return this._request(path, body).then((jsonArray: any) => {
       return jsonArray.map((json: any) => {
-        return new NeuralCategorizer(this.connection, json);
+        return new NeuralCategorizer(this.connection).fromJSON(json);
       });
     });
   }
@@ -101,7 +101,7 @@ export default class Neural extends RestfulModel {
 
     return this._request(path, body).then((jsonArray: any) => {
       return jsonArray.map((json: any) => {
-        return new NeuralCleanConversation(this.connection, json);
+        return new NeuralCleanConversation(this.connection).fromJSON(json);
       });
     });
   }

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -106,10 +106,7 @@ export default class Neural extends RestfulModel {
     });
   }
 
-  _request(path?: string, body?: object): Promise<any> {
-    if (!path) {
-      path = (this.constructor as any).collectionName;
-    }
+  _request(path: string, body: object): Promise<any> {
     return this.connection.request({
       method: 'PUT',
       path: `/neural/${path}`,

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -1,13 +1,27 @@
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
+
+export interface ResourceProperties {
+  email: string;
+  name: string;
+  capacity: string;
+  building: string;
+  floorNumber: string;
+  floorName?: string;
+}
 
 export default class Resource extends RestfulModel {
-  email?: string;
-  name?: string;
-  capacity?: string;
-  building?: string;
+  email = '';
+  name = '';
+  capacity = '';
+  building = '';
+  floorNumber = '';
   floorName?: string;
-  floorNumber?: string;
+
+  constructor(connection: NylasConnection, props?: ResourceProperties) {
+    super(connection, props);
+  }
 }
 
 Resource.collectionName = 'resources';

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -12,22 +12,16 @@ export interface ResourceProperties {
 }
 
 export default class Resource extends RestfulModel {
-  email!: string;
-  name!: string;
-  capacity!: string;
-  building!: string;
-  floorNumber!: string;
+  email = '';
+  name = '';
+  capacity = '';
+  building = '';
+  floorNumber = '';
   floorName?: string;
 
   constructor(connection: NylasConnection, props?: ResourceProperties) {
     super(connection, props);
-    if (!props) {
-      this.email = '';
-      this.name = '';
-      this.capacity = '';
-      this.building = '';
-      this.floorNumber = '';
-    }
+    this.initAttributes(props);
   }
 }
 

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -12,15 +12,22 @@ export interface ResourceProperties {
 }
 
 export default class Resource extends RestfulModel {
-  email = '';
-  name = '';
-  capacity = '';
-  building = '';
-  floorNumber = '';
+  email!: string;
+  name!: string;
+  capacity!: string;
+  building!: string;
+  floorNumber!: string;
   floorName?: string;
 
   constructor(connection: NylasConnection, props?: ResourceProperties) {
     super(connection, props);
+    if(!props) {
+      this.email = '';
+      this.name = '';
+      this.capacity = '';
+      this.building = '';
+      this.floorNumber = '';
+    }
   }
 }
 

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -21,7 +21,7 @@ export default class Resource extends RestfulModel {
 
   constructor(connection: NylasConnection, props?: ResourceProperties) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.email = '';
       this.name = '';
       this.capacity = '';

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -118,7 +118,7 @@ export default class RestfulModelCollection<
     }
 
     const item =
-      typeof itemOrId === 'string' ? this.build({ id: itemOrId }) : itemOrId;
+      typeof itemOrId === 'string' ? this._build({ id: itemOrId }) : itemOrId;
 
     const options: { [key: string]: any } = item.deleteRequestOptions(params);
     options.item = item;
@@ -161,7 +161,7 @@ export default class RestfulModelCollection<
       });
   }
 
-  build(args: { [key: string]: any }): T {
+  _build(args: { [key: string]: any }): T {
     const model = this._createModel({});
     for (const key in args) {
       const val = args[key];

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -2,66 +2,18 @@ import Message from './message';
 import NylasConnection from '../nylas-connection';
 import RestfulModel from './restful-model';
 import Thread from './thread';
-
-const REQUEST_CHUNK_SIZE = 100;
+import ModelCollection from './model-collection';
 
 export type GetCallback = (error: Error | null, result?: RestfulModel) => void;
 
-export default class RestfulModelCollection<T extends RestfulModel> {
-  connection: NylasConnection;
+export default class RestfulModelCollection<
+  T extends RestfulModel
+> extends ModelCollection<any> {
   modelClass: typeof RestfulModel;
 
   constructor(modelClass: typeof RestfulModel, connection: NylasConnection) {
+    super(modelClass, connection, modelClass.collectionName);
     this.modelClass = modelClass;
-    this.connection = connection;
-    if (!(this.connection instanceof NylasConnection)) {
-      throw new Error('Connection object not provided');
-    }
-    if (!this.modelClass) {
-      throw new Error('Model class not provided');
-    }
-  }
-
-  forEach(
-    params: { [key: string]: any } = {},
-    eachCallback: (item: T) => void,
-    completeCallback?: (err?: Error | null | undefined) => void
-  ) {
-    if (params.view == 'count') {
-      const err = new Error('forEach() cannot be called with the count view');
-      if (completeCallback) {
-        completeCallback(err);
-      }
-      return Promise.reject(err);
-    }
-
-    let offset = 0;
-
-    const iteratee = (): Promise<void> => {
-      return this._getItems(params, offset, REQUEST_CHUNK_SIZE).then(items => {
-        for (const item of items) {
-          eachCallback(item);
-        }
-        offset += items.length;
-        const finished = items.length < REQUEST_CHUNK_SIZE;
-        if (finished === false) {
-          return iteratee();
-        }
-      });
-    };
-
-    iteratee().then(
-      () => {
-        if (completeCallback) {
-          completeCallback();
-        }
-      },
-      (err: Error) => {
-        if (completeCallback) {
-          return completeCallback(err);
-        }
-      }
-    );
   }
 
   count(
@@ -71,7 +23,7 @@ export default class RestfulModelCollection<T extends RestfulModel> {
     return this.connection
       .request({
         method: 'GET',
-        path: this.path(),
+        path: this.path,
         qs: { view: 'count', ...params },
       })
       .then((json: any) => {
@@ -115,76 +67,6 @@ export default class RestfulModelCollection<T extends RestfulModel> {
       });
   }
 
-  list(
-    params: { [key: string]: any } = {},
-    callback?: (error: Error | null, obj?: T[]) => void
-  ) {
-    if (params.view == 'count') {
-      const err = new Error('list() cannot be called with the count view');
-      if (callback) {
-        callback(err);
-      }
-      return Promise.reject(err);
-    }
-
-    const limit = params.limit || Infinity;
-    const offset = params.offset;
-    return this._range({ params, offset, limit, callback });
-  }
-
-  find(
-    id: string,
-    paramsArg?: { [key: string]: any } | GetCallback | null,
-    callbackArg?: GetCallback | { [key: string]: any } | null
-  ) {
-    // callback used to be the second argument, and params was the third
-    let callback: GetCallback | undefined;
-    if (typeof callbackArg === 'function') {
-      callback = callbackArg as GetCallback;
-    } else if (typeof paramsArg === 'function') {
-      callback = paramsArg as GetCallback;
-    }
-
-    let params: { [key: string]: any } = {};
-    if (paramsArg && typeof paramsArg === 'object') {
-      params = paramsArg;
-    } else if (callbackArg && typeof callbackArg === 'object') {
-      params = callbackArg;
-    }
-
-    if (!id) {
-      const err = new Error('find() must be called with an item id');
-      if (callback) {
-        callback(err);
-      }
-      return Promise.reject(err);
-    }
-
-    if (params.view == 'count' || params.view == 'ids') {
-      const err = new Error(
-        'find() cannot be called with the count or ids view'
-      );
-      if (callback) {
-        callback(err);
-      }
-      return Promise.reject(err);
-    }
-
-    return this._getModel(id, params)
-      .then(model => {
-        if (callback) {
-          callback(null, model);
-        }
-        return Promise.resolve(model);
-      })
-      .catch(err => {
-        if (callback) {
-          callback(err);
-        }
-        return Promise.reject(err);
-      });
-  }
-
   search(
     query: string,
     params: { [key: string]: any } = {},
@@ -211,7 +93,7 @@ export default class RestfulModelCollection<T extends RestfulModel> {
     params.q = query;
     const limit = params.limit || 40;
     const offset = params.offset;
-    const path = `${this.path()}/search`;
+    const path = `${this.path}/search`;
 
     return this._range({ params, offset, limit, path });
   }
@@ -262,7 +144,7 @@ export default class RestfulModelCollection<T extends RestfulModel> {
         method: 'DELETE',
         qs: qs,
         body: body,
-        path: `${this.path()}/${item.id}`,
+        path: `${this.path}/${item.id}`,
       })
       .then(data => {
         if (callback) {
@@ -287,118 +169,11 @@ export default class RestfulModelCollection<T extends RestfulModel> {
     return model;
   }
 
-  path() {
+  get path(): string {
     return `/${this.modelClass.collectionName}`;
-  }
-
-  _range({
-    params = {},
-    offset = 0,
-    limit = 100,
-    callback,
-    path,
-  }: {
-    params?: { [key: string]: any };
-    offset?: number;
-    limit?: number;
-    callback?: (error: Error | null, results?: T[]) => void;
-    path?: string;
-  }) {
-    let accumulated: T[] = [];
-
-    const iteratee = (): Promise<void> => {
-      const chunkOffset = offset + accumulated.length;
-      const chunkLimit = Math.min(
-        REQUEST_CHUNK_SIZE,
-        limit - accumulated.length
-      );
-      return this._getItems(params, chunkOffset, chunkLimit, path).then(
-        items => {
-          accumulated = accumulated.concat(items);
-          const finished =
-            items.length < REQUEST_CHUNK_SIZE || accumulated.length >= limit;
-          if (finished === false) {
-            return iteratee();
-          }
-        }
-      );
-    };
-
-    // do not return rejected promise when callback is provided
-    // to prevent unhandled rejection warning
-    return iteratee().then(
-      () => {
-        if (callback) {
-          return callback(null, accumulated);
-        }
-        return accumulated;
-      },
-      (err: Error) => {
-        if (callback) {
-          return callback(err);
-        }
-        throw err;
-      }
-    );
-  }
-
-  _getItems(
-    params: { [key: string]: any },
-    offset: number,
-    limit: number,
-    path?: string
-  ): Promise<T[]> {
-    // Items can be either models or ids
-
-    if (!path) {
-      path = this.path();
-    }
-
-    if (params.view == 'ids') {
-      return this.connection.request({
-        method: 'GET',
-        path,
-        qs: { ...params, offset, limit },
-      });
-    }
-
-    return this._getModelCollection(params, offset, limit, path);
   }
 
   _createModel(json: { [key: string]: any }) {
     return new this.modelClass(this.connection, json) as T;
-  }
-
-  _getModel(id: string, params: { [key: string]: any } = {}): Promise<T> {
-    return this.connection
-      .request({
-        method: 'GET',
-        path: `${this.path()}/${id}`,
-        qs: params,
-      })
-      .then((json: any) => {
-        const model = this._createModel(json);
-        return Promise.resolve(model);
-      });
-  }
-
-  _getModelCollection(
-    params: { [key: string]: any },
-    offset: number,
-    limit: number,
-    path: string
-  ): Promise<T[]> {
-    return this.connection
-      .request({
-        method: 'GET',
-        path,
-        qs: { ...params, offset, limit },
-      })
-      .then((jsonArray: any) => {
-        const models = jsonArray.map((json: any) => {
-          return this._createModel(json);
-        });
-        return Promise.resolve(models);
-      });
   }
 }

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -19,7 +19,7 @@ export default class RestfulModelCollection<
   count(
     params: { [key: string]: any } = {},
     callback?: (err: Error | null, num?: number) => void
-  ) {
+  ): Promise<number> {
     return this.connection
       .request({
         method: 'GET',
@@ -43,7 +43,7 @@ export default class RestfulModelCollection<
   first(
     params: { [key: string]: any } = {},
     callback?: (error: Error | null, model?: T) => void
-  ) {
+  ): Promise<T> {
     if (params.view == 'count') {
       const err = new Error('first() cannot be called with the count view');
       if (callback) {
@@ -71,7 +71,7 @@ export default class RestfulModelCollection<
     query: string,
     params: { [key: string]: any } = {},
     callback?: (error: Error | null) => void
-  ) {
+  ): Promise<T[]> {
     if (this.modelClass != Message && this.modelClass != Thread) {
       const err = new Error(
         'search() can only be called for messages and threads'
@@ -102,7 +102,7 @@ export default class RestfulModelCollection<
     itemOrId: T | string,
     params: { [key: string]: any } = {},
     callback?: (error: Error | null) => void
-  ) {
+  ): any {
     if (!itemOrId) {
       const err = new Error('delete() requires an item or an id');
       if (callback) {
@@ -128,7 +128,7 @@ export default class RestfulModelCollection<
   deleteItem(
     options: { [key: string]: any },
     callbackArg?: (error: Error | null) => void
-  ) {
+  ): any {
     const item = options.item;
     // callback used to be in the options object
     const callback = options.callback ? options.callback : callbackArg;
@@ -160,7 +160,7 @@ export default class RestfulModelCollection<
       });
   }
 
-  build(args: { [key: string]: any }) {
+  build(args: { [key: string]: any }): T {
     const model = this._createModel({});
     for (const key in args) {
       const val = args[key];
@@ -173,7 +173,7 @@ export default class RestfulModelCollection<
     return `/${this.modelClass.collectionName}`;
   }
 
-  _createModel(json: { [key: string]: any }) {
+  _createModel(json: { [key: string]: any }): T {
     return new this.modelClass(this.connection, json) as T;
   }
 }

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -171,6 +171,7 @@ export default class RestfulModelCollection<
   }
 
   _createModel(json: { [key: string]: any }): T {
-    return new this.modelClass(this.connection, json) as T;
+    const props = this.modelClass.propsFromJSON(json, this);
+    return new this.modelClass(this.connection, props) as T;
   }
 }

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -14,6 +14,7 @@ export default class RestfulModelCollection<
   constructor(modelClass: typeof RestfulModel, connection: NylasConnection) {
     super(modelClass, connection, modelClass.collectionName);
     this.modelClass = modelClass;
+    this.path = `/${this.modelClass.collectionName}`;
   }
 
   count(
@@ -167,10 +168,6 @@ export default class RestfulModelCollection<
       (model as any)[key] = val;
     }
     return model;
-  }
-
-  get path(): string {
-    return `/${this.modelClass.collectionName}`;
   }
 
   _createModel(json: { [key: string]: any }): T {

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -171,7 +171,6 @@ export default class RestfulModelCollection<
   }
 
   _createModel(json: { [key: string]: any }): T {
-    const props = this.modelClass.propsFromJSON(json, this);
-    return new this.modelClass(this.connection, props) as T;
+    return new this.modelClass(this.connection).fromJSON(json) as T;
   }
 }

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -28,8 +28,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
         qs: params,
       })
       .then(json => {
-        const props = this.modelClass.propsFromJSON(json, this);
-        const model = new this.modelClass(this.connection, props) as T;
+        const model = new this.modelClass(this.connection).fromJSON(json) as T;
         return Promise.resolve(model);
       });
   }

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -28,7 +28,8 @@ export default class RestfulModelInstance<T extends RestfulModel> {
         qs: params,
       })
       .then(json => {
-        const model = new this.modelClass(this.connection, json) as T;
+        const props = this.modelClass.propsFromJSON(json, this);
+        const model = new this.modelClass(this.connection, props) as T;
         return Promise.resolve(model);
       });
   }

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -16,7 +16,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
     }
   }
 
-  get path(): string {
+  path(): string {
     return `/${this.modelClass.endpointName}`;
   }
 
@@ -24,7 +24,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
     return this.connection
       .request({
         method: 'GET',
-        path: this.path,
+        path: this.path(),
         qs: params,
       })
       .then(json => {

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -16,7 +16,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
     }
   }
 
-  path() {
+  get path(): string {
     return `/${this.modelClass.endpointName}`;
   }
 
@@ -24,7 +24,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
     return this.connection
       .request({
         method: 'GET',
-        path: this.path(),
+        path: this.path,
         qs: params,
       })
       .then(json => {

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -31,6 +31,13 @@ export default class RestfulModel extends Model {
     }
   }
 
+  static propsFromJSON(
+    json: Partial<RestfulModelJSON> = {},
+    parent: any
+  ): Partial<RestfulModelJSON> {
+    return super.propsFromJSON(json, parent);
+  }
+
   isEqual(other: RestfulModel): boolean {
     return (
       (other ? other.id : undefined) === this.id &&

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -31,7 +31,7 @@ export default class RestfulModel extends Model {
     }
   }
 
-  isEqual(other: RestfulModel) {
+  isEqual(other: RestfulModel): boolean {
     return (
       (other ? other.id : undefined) === this.id &&
       (other ? other.constructor : undefined) === this.constructor
@@ -50,32 +50,32 @@ export default class RestfulModel extends Model {
   }
 
   // Subclasses should override this method.
-  pathPrefix() {
+  pathPrefix(): string {
     return '';
   }
 
-  saveEndpoint() {
+  saveEndpoint(): string {
     const collectionName = (this.constructor as any).collectionName;
     return `${this.pathPrefix()}/${collectionName}`;
   }
 
   // saveRequestBody is used by save(). It returns a JSON dict containing only the
   // fields the API allows updating. Subclasses should override this method.
-  saveRequestBody() {
+  saveRequestBody(): any {
     return this.toJSON(true);
   }
 
   // deleteRequestQueryString is used by delete(). Subclasses should override this method.
-  deleteRequestQueryString(_params: { [key: string]: any }) {
+  deleteRequestQueryString(_params: { [key: string]: any }): any {
     return {};
   }
   // deleteRequestBody is used by delete(). Subclasses should override this method.
-  deleteRequestBody(_params: { [key: string]: any }) {
+  deleteRequestBody(_params: { [key: string]: any }): any {
     return {};
   }
 
   // deleteRequestOptions is used by delete(). Subclasses should override this method.
-  deleteRequestOptions(params: { [key: string]: any }) {
+  deleteRequestOptions(params: { [key: string]: any }): any {
     return {
       body: this.deleteRequestBody(params),
       qs: this.deleteRequestQueryString(params),
@@ -85,7 +85,7 @@ export default class RestfulModel extends Model {
   // Not every model needs to have a save function, but those who
   // do shouldn't have to reimplement the same boilerplate.
   // They should instead define a save() function which calls _save.
-  _save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  _save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     if (typeof params === 'function') {
       callback = params as SaveCallback;
       params = {};
@@ -118,7 +118,7 @@ export default class RestfulModel extends Model {
     params: { [key: string]: any } = {},
     callback?: (error: Error | null, result?: any) => void,
     pathSuffix = ''
-  ) {
+  ): Promise<any> {
     const collectionName = (this.constructor as any).collectionName;
     return this.connection
       .request({

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -20,14 +20,14 @@ export default class RestfulModel extends Model {
   id?: string;
   object?: string;
 
-  constructor(connection: NylasConnection, json?: Partial<RestfulModelJSON>) {
+  constructor(connection: NylasConnection, props?: Partial<RestfulModelJSON>) {
     super();
     this.connection = connection;
     if (!this.connection) {
       throw new Error('Connection object not provided');
     }
-    if (json) {
-      this.fromJSON(json);
+    if (props) {
+      super.initAttributes(props);
     }
   }
 
@@ -45,15 +45,8 @@ export default class RestfulModel extends Model {
     );
   }
 
-  fromJSON(json: Partial<RestfulModelJSON> = {}): RestfulModel {
-    const attributes = this.attributes();
-    for (const attrName in attributes) {
-      const attr = attributes[attrName];
-      if (json[attr.jsonKey] !== undefined) {
-        (this as any)[attrName] = attr.fromJSON(json[attr.jsonKey], this);
-      }
-    }
-    return this;
+  fromJSON(json: Partial<RestfulModelJSON> = {}): this {
+    return super.fromJSON(json) as this;
   }
 
   // Subclasses should override this method.
@@ -92,7 +85,10 @@ export default class RestfulModel extends Model {
   // Not every model needs to have a save function, but those who
   // do shouldn't have to reimplement the same boilerplate.
   // They should instead define a save() function which calls _save.
-  _save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
+  _save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<this> {
     if (typeof params === 'function') {
       callback = params as SaveCallback;
       params = {};

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -23,12 +23,13 @@ export default class RestfulModel extends Model {
   constructor(connection: NylasConnection, props?: Partial<RestfulModelJSON>) {
     super();
     this.connection = connection;
+    //TODO::Can we remove this?
     if (!this.connection) {
       throw new Error('Connection object not provided');
     }
-    if (props) {
-      super.initAttributes(props);
-    }
+    this.id = props?.id ? props.id : undefined;
+    this.accountId = props?.accountId ? props.accountId : undefined;
+    this.object = props?.object ? props.object : undefined;
   }
 
   static propsFromJSON(

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -1,31 +1,55 @@
-import Message from './message';
+import Message, { MessageProperties } from './message';
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
-import EmailParticipant from './email-participant';
-import { Label, Folder } from './folder';
+import EmailParticipant, { EmailParticipantProperties } from './email-participant';
+import { Label, Folder, FolderProperties } from './folder';
+import NylasConnection from '../nylas-connection';
 
-export default class Thread extends RestfulModel {
-  subject?: string;
-  participants?: EmailParticipant[];
-  lastMessageTimestamp?: Date;
-  lastMessageReceivedTimestamp?: Date;
-  lastMessageSentTimestamp?: Date;
-  firstMessageTimestamp?: Date;
-  snippet?: string;
-  unread?: boolean;
-  starred?: boolean;
+export interface ThreadProperties {
+  subject: string;
+  participants: EmailParticipantProperties[];
+  lastMessageTimestamp: Date;
+  lastMessageReceivedTimestamp: Date;
+  firstMessageTimestamp: Date;
+  messageIds: string[];
+  snippet: string;
+  unread: boolean;
+  starred: boolean;
+  version: string;
   hasAttachments?: boolean;
-  version?: string;
+  lastMessageSentTimestamp?: Date;
+  folders?: FolderProperties[];
+  labels?: FolderProperties[];
+  draftIds?: string[];
+  messages?: MessageProperties[];
+  drafts?: MessageProperties[];
+}
+
+export default class Thread extends RestfulModel implements ThreadProperties {
+  subject = '';
+  participants = [];
+  lastMessageTimestamp = new Date();
+  lastMessageReceivedTimestamp = new Date();
+  firstMessageTimestamp = new Date();
+  messageIds = [];
+  snippet = '';
+  unread = false;
+  starred = false;
+  version = '';
+  hasAttachments?: boolean;
+  lastMessageSentTimestamp?: Date;
   folders?: Folder[];
   labels?: Label[];
-  messageIds?: string[];
   draftIds?: string[];
   messages?: Message[];
   drafts?: Message[];
 
-  fromJSON(json: { [key: string]: any }) {
-    super.fromJSON(json);
-    return this;
+  constructor(connection: NylasConnection, props?: ThreadProperties) {
+    super(connection, props);
+  }
+
+  toJSON(enforceReadOnly?: boolean): ThreadProperties {
+    return super.toJSON(enforceReadOnly);
   }
 
   saveRequestBody() {

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -28,16 +28,16 @@ export interface ThreadProperties {
 }
 
 export default class Thread extends RestfulModel implements ThreadProperties {
-  subject!: string;
-  participants!: EmailParticipantProperties[];
-  lastMessageTimestamp!: Date;
-  lastMessageReceivedTimestamp!: Date;
-  firstMessageTimestamp!: Date;
-  messageIds!: string[];
-  snippet!: string;
-  unread!: boolean;
-  starred!: boolean;
-  version!: string;
+  subject = '';
+  participants = [];
+  lastMessageTimestamp = new Date();
+  lastMessageReceivedTimestamp = new Date();
+  firstMessageTimestamp = new Date();
+  messageIds = [];
+  snippet = '';
+  unread = false;
+  starred = false;
+  version = '';
   hasAttachments?: boolean;
   lastMessageSentTimestamp?: Date;
   folders?: Folder[];
@@ -48,18 +48,7 @@ export default class Thread extends RestfulModel implements ThreadProperties {
 
   constructor(connection: NylasConnection, props?: ThreadProperties) {
     super(connection, props);
-    if (!props) {
-      this.subject = '';
-      this.participants = [];
-      this.lastMessageTimestamp = new Date();
-      this.lastMessageReceivedTimestamp = new Date();
-      this.firstMessageTimestamp = new Date();
-      this.messageIds = [];
-      this.snippet = '';
-      this.unread = false;
-      this.starred = false;
-      this.version = '';
-    }
+    this.initAttributes(props);
   }
 
   toJSON(enforceReadOnly?: boolean): ThreadProperties {

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -1,7 +1,9 @@
 import Message, { MessageProperties } from './message';
 import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
-import EmailParticipant, { EmailParticipantProperties } from './email-participant';
+import EmailParticipant, {
+  EmailParticipantProperties,
+} from './email-participant';
 import { Label, Folder, FolderProperties } from './folder';
 import NylasConnection from '../nylas-connection';
 
@@ -46,7 +48,7 @@ export default class Thread extends RestfulModel implements ThreadProperties {
 
   constructor(connection: NylasConnection, props?: ThreadProperties) {
     super(connection, props);
-    if(!props) {
+    if (!props) {
       this.subject = '';
       this.participants = [];
       this.lastMessageTimestamp = new Date();

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -26,16 +26,16 @@ export interface ThreadProperties {
 }
 
 export default class Thread extends RestfulModel implements ThreadProperties {
-  subject = '';
-  participants = [];
-  lastMessageTimestamp = new Date();
-  lastMessageReceivedTimestamp = new Date();
-  firstMessageTimestamp = new Date();
-  messageIds = [];
-  snippet = '';
-  unread = false;
-  starred = false;
-  version = '';
+  subject!: string;
+  participants!: EmailParticipantProperties[];
+  lastMessageTimestamp!: Date;
+  lastMessageReceivedTimestamp!: Date;
+  firstMessageTimestamp!: Date;
+  messageIds!: string[];
+  snippet!: string;
+  unread!: boolean;
+  starred!: boolean;
+  version!: string;
   hasAttachments?: boolean;
   lastMessageSentTimestamp?: Date;
   folders?: Folder[];
@@ -46,6 +46,18 @@ export default class Thread extends RestfulModel implements ThreadProperties {
 
   constructor(connection: NylasConnection, props?: ThreadProperties) {
     super(connection, props);
+    if(!props) {
+      this.subject = '';
+      this.participants = [];
+      this.lastMessageTimestamp = new Date();
+      this.lastMessageReceivedTimestamp = new Date();
+      this.firstMessageTimestamp = new Date();
+      this.messageIds = [];
+      this.snippet = '';
+      this.unread = false;
+      this.starred = false;
+      this.version = '';
+    }
   }
 
   toJSON(enforceReadOnly?: boolean): ThreadProperties {

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -1,14 +1,33 @@
 import ManagementModel from './management-model';
 import Attributes from './attributes';
 import { SaveCallback } from './restful-model';
+import NylasConnection from '../nylas-connection';
 
-export default class Webhook extends ManagementModel {
+export interface WebhookProperties {
+  callbackUrl: string;
+  state: string;
+  triggers: string[];
   id?: string;
   applicationId?: string;
-  callbackUrl?: string;
-  state?: string;
-  triggers?: string[];
   version?: string;
+}
+
+export default class Webhook extends ManagementModel
+  implements WebhookProperties {
+  callbackUrl = '';
+  state = '';
+  triggers = [];
+  id?: string;
+  applicationId?: string;
+  version?: string;
+
+  constructor(
+    connection: NylasConnection,
+    clientId: string,
+    props: WebhookProperties
+  ) {
+    super(connection, clientId, props);
+  }
 
   pathPrefix() {
     return `/a/${this.clientId}`;

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -14,9 +14,9 @@ export interface WebhookProperties {
 
 export default class Webhook extends ManagementModel
   implements WebhookProperties {
-  callbackUrl: string;
-  state: string;
-  triggers: string[];
+  callbackUrl = '';
+  state = '';
+  triggers = [];
   id?: string;
   applicationId?: string;
   version?: string;
@@ -27,9 +27,7 @@ export default class Webhook extends ManagementModel
     props: WebhookProperties
   ) {
     super(connection, clientId, props);
-    this.callbackUrl = props.callbackUrl;
-    this.state = props.state;
-    this.triggers = props.triggers;
+    this.initAttributes(props);
   }
 
   pathPrefix() {

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -14,9 +14,9 @@ export interface WebhookProperties {
 
 export default class Webhook extends ManagementModel
   implements WebhookProperties {
-  callbackUrl = '';
-  state = '';
-  triggers = [];
+  callbackUrl: string;
+  state: string;
+  triggers: string[];
   id?: string;
   applicationId?: string;
   version?: string;
@@ -27,6 +27,9 @@ export default class Webhook extends ManagementModel
     props: WebhookProperties
   ) {
     super(connection, clientId, props);
+    this.callbackUrl = props.callbackUrl;
+    this.state = props.state;
+    this.triggers = props.triggers;
   }
 
   pathPrefix() {

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -1,7 +1,7 @@
 import Model from './model';
 import Attributes from './attributes';
 
-type WhenProperties = {
+export interface WhenProperties {
   startTime?: number;
   endTime?: number;
   time?: number;
@@ -9,7 +9,7 @@ type WhenProperties = {
   endDate?: string;
   date?: string;
   object?: string;
-};
+}
 
 export default class When extends Model implements WhenProperties {
   startTime?: number;

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -1,0 +1,67 @@
+import Model from './model';
+import Attributes from './attributes';
+
+type WhenProperties = {
+  startTime?: number;
+  endTime?: number;
+  time?: number;
+  startDate?: string;
+  endDate?: string;
+  date?: string;
+  object?: string;
+}
+
+export default class When extends Model {
+  startTime?: number;
+  endTime?: number;
+  time?: number;
+  startDate?: string;
+  endDate?: string;
+  date?: string;
+  object?: string;
+
+  constructor(props?: WhenProperties) {
+    super();
+    if(props) {
+      this.startTime = props.startTime;
+      this.endTime = props.endTime;
+      this.time = props.time;
+      this.startDate = props.startDate;
+      this.endDate = props.endDate;
+      this.date = props.date;
+      this.object = props.object;
+    }
+  }
+
+  toJSON(): any {
+    return super.toJSON();
+  }
+}
+
+When.attributes = {
+  startTime: Attributes.Number({
+    modelKey: 'startTime',
+    jsonKey: 'start_time',
+  }),
+  endTime: Attributes.Number({
+    modelKey: 'endTime',
+    jsonKey: 'end_time',
+  }),
+  time: Attributes.Number({
+    modelKey: 'time',
+  }),
+  startDate: Attributes.String({
+    modelKey: 'startDate',
+    jsonKey: 'start_date',
+  }),
+  endDate: Attributes.String({
+    modelKey: 'endDate',
+    jsonKey: 'end_date',
+  }),
+  date: Attributes.String({
+    modelKey: 'date',
+  }),
+  object: Attributes.String({
+    modelKey: 'object',
+  }),
+};

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -21,7 +21,8 @@ export default class When extends Model implements WhenProperties {
   object?: string;
 
   constructor(props?: WhenProperties) {
-    super(props);
+    super();
+    this.initAttributes(props);
   }
 
   toJSON(): WhenProperties {

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -9,9 +9,9 @@ type WhenProperties = {
   endDate?: string;
   date?: string;
   object?: string;
-}
+};
 
-export default class When extends Model {
+export default class When extends Model implements WhenProperties {
   startTime?: number;
   endTime?: number;
   time?: number;
@@ -21,19 +21,10 @@ export default class When extends Model {
   object?: string;
 
   constructor(props?: WhenProperties) {
-    super();
-    if(props) {
-      this.startTime = props.startTime;
-      this.endTime = props.endTime;
-      this.time = props.time;
-      this.startDate = props.startDate;
-      this.endDate = props.endDate;
-      this.date = props.date;
-      this.object = props.object;
-    }
+    super(props);
   }
 
-  toJSON(): any {
+  toJSON(): WhenProperties {
     return super.toJSON();
   }
 }

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -71,7 +71,7 @@ class Nylas {
         ManagementAccount,
         conn,
         this.clientId!
-      );
+      ) as ManagementModelCollection<ManagementAccount>;
     } else {
       this.accounts = new RestfulModelCollection(Account, conn);
     }


### PR DESCRIPTION
This PR is a big one, it's aimed at two things -- improving how we deserialize objects while improving how users can create objects using the SDK.

Now, each `Model` type has an accompanying interface that represents an object of parameters that the `Model` will use, as well as the **proper** strictness dictated by what values will always be present in any scenario (GET, POST, PUT). In the constructor of each model, we now specify that we can take in an optional `props` property of the Model interface's type. This helps to hint the user as to what properties they must pass in during the initialization of the object. This also helps us with the strictness of the typing in each model as now we properly outline what properties are needed at a bare minimum.

This `props` method property is left as optional because it allows some flexibility to the SDK user to just instantiate a type of object then either:
- performing [model].fromJSON()
- or, setting the property values individually via [model].[property] = value
If taking this route, we initialize all the required types to a default value in order not to upset Typescript's strictness requirements.

With this, we also deprecate the `Nylas.[model].build()` method as it provides a way for the user to bypass the constructor typing requirements and pass in whatever object they want. It also does not provide any type hinting to the user when trying to initialize the object, rendering this work useless. Here's an example of the before and after:

```javascript
const Nylas = require('nylas');
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

// before, user can put whatever they want
const event = nylas.events.build({foo: "bar"});

// now, this way the user has to abide by EventProperties or else face a warning from Typescript

// throws warning:
const event = new Event(nylas, {foo: "bar"});

// does not throw warning
const event = new Event(nylas, {calendarId: "id", when: {startTime: 1234, endTime: 4321}});

// also does not throw warning, inits and object that has default values
const event = new Event(nylas);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.