### PR TITLE
[65926] Fix webhook example throwing error if body is not a raw body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix issue where JSON.stringify would omit read-only values
+* Fix webhook example throwing error if body is not a raw body
 
 ### 5.7.0 / 2021-08-18
 * Fix minor issues with Neural API implementation

--- a/example/webhooks/index.js
+++ b/example/webhooks/index.js
@@ -22,7 +22,7 @@ app.use(function(req, res, next) {
     // because the stream has been consumed, other parsers like bodyParser.json 
     // cannot stream the request data and will time out so we must explicitly parse the body
     try {
-      req.body = JSON.parse(req.rawBody);
+      req.body = req.rawBody.length ? JSON.parse(req.rawBody) : {};
       next();
     } catch (err) {
       res.status(500).send('Error parsing body');


### PR DESCRIPTION
# Description
`JSON.parse(req.rawBody)` was throwing an error if `req.rawBody` was an empty string.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.