### PR TITLE
[63533] Improve Node SDK typing

### DIFF
--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -45,7 +45,7 @@ describe('CalendarRestfulModelCollection', () => {
     fetch.mockImplementation(() => Promise.resolve(response));
   });
 
-  test('[FREE BUSY] should fetch results with camelcase params', done => {
+  test('[FREE BUSY] should fetch results with params', done => {
     const response = {
       status: 200,
       buffer: () => {
@@ -107,81 +107,50 @@ describe('CalendarRestfulModelCollection', () => {
     });
   });
 
-  const evaluateAvailability = () => {
-    const options = testContext.connection.request.mock.calls[0][0];
-    expect(options.url.toString()).toEqual(
-      'https://api.nylas.com/calendars/availability'
-    );
-    expect(options.method).toEqual('POST');
-    expect(JSON.parse(options.body)).toEqual({
-      start_time: '1590454800',
-      end_time: '1590780800',
-      interval_minutes: 5,
-      duration_minutes: 30,
-      emails: ['jane@email.com'],
-      free_busy: [],
-      open_hours: [
-        {
-          emails: ['swag@nylas.com'],
-          days: ['0'],
-          timezone: 'America/Chicago',
-          start: '10:00',
-          end: '14:00',
-          object_type: 'open_hours',
-        },
-      ],
-    });
-    expect(options.headers['authorization']).toEqual(
-      `Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`
-    );
-  };
-
-  test('[AVAILABILITY] should fetch results with snakecase params', done => {
-    const params = {
-      start_time: '1590454800',
-      end_time: '1590780800',
-      interval: 5,
-      duration: 30,
-      emails: ['jane@email.com'],
-      open_hours: [
-        {
-          emails: ['swag@nylas.com'],
-          days: ['0'],
-          timezone: 'America/Chicago',
-          start: '10:00',
-          end: '14:00',
-          object_type: 'open_hours',
-        },
-      ],
-    };
-
-    return testContext.connection.calendars.availability(params).then(() => {
-      evaluateAvailability();
-      done();
-    });
-  });
-
-  test('[AVAILABILITY] should fetch results with camelcase params', done => {
+  test('[AVAILABILITY] should fetch results with params', done => {
     const params = {
       startTime: '1590454800',
       endTime: '1590780800',
       interval: 5,
       duration: 30,
       emails: ['jane@email.com'],
-      open_hours: [
+      openHours: [
         {
           emails: ['swag@nylas.com'],
           days: ['0'],
           timezone: 'America/Chicago',
           start: '10:00',
           end: '14:00',
-          object_type: 'open_hours',
         },
       ],
     };
 
     return testContext.connection.calendars.availability(params).then(() => {
-      evaluateAvailability();
+      const options = testContext.connection.request.mock.calls[0][0];
+      expect(options.url.toString()).toEqual(
+        'https://api.nylas.com/calendars/availability'
+      );
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        start_time: '1590454800',
+        end_time: '1590780800',
+        interval_minutes: 5,
+        duration_minutes: 30,
+        emails: ['jane@email.com'],
+        free_busy: [],
+        open_hours: [
+          {
+            emails: ['swag@nylas.com'],
+            days: ['0'],
+            timezone: 'America/Chicago',
+            start: '10:00',
+            end: '14:00',
+          },
+        ],
+      });
+      expect(options.headers['authorization']).toEqual(
+        `Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString('base64')}`
+      );
       done();
     });
   });

--- a/__tests__/connect-spec.js
+++ b/__tests__/connect-spec.js
@@ -1,16 +1,23 @@
 import Nylas from '../src/nylas';
+import { NativeAuthenticationProvider, Scope } from '../src/models/connect';
 
 describe('Connect', () => {
   const name = 'Connect Test';
   const password = 'connecting123';
-  const scopes = 'email.modify,email.send,calendar,contacts';
+  const scopeString = 'email.modify,email.send,calendar,contacts';
+  const scopes = [
+    Scope.EmailModify,
+    Scope.EmailSend,
+    Scope.Calendar,
+    Scope.Contacts,
+  ];
   const exchangeEmail = 'connect_test@outlook.com';
   const CLIENT_ID = 'abc';
   const CLIENT_SECRET = 'xyz';
   const authorizeOptions = (email, provider, settings) => {
     return {
       name: name,
-      email_address: email,
+      emailAddress: email,
       provider: provider,
       settings: settings,
       scopes: scopes,
@@ -43,7 +50,11 @@ describe('Connect', () => {
       const settings = { username: exchangeEmail, password: password };
       expect(() =>
         Nylas.connect.authorize(
-          authorizeOptions(exchangeEmail, 'exchange', settings)
+          authorizeOptions(
+            exchangeEmail,
+            NativeAuthenticationProvider.Exchange,
+            settings
+          )
         )
       ).toThrow();
       expect(() => Nylas.connect.token(authorizeJSON.code)).toThrow();
@@ -66,7 +77,13 @@ describe('Connect', () => {
         Promise.resolve(authorizeJSON)
       );
       Nylas.connect
-        .authorize(authorizeOptions(exchangeEmail, 'exchange', settings))
+        .authorize(
+          authorizeOptions(
+            exchangeEmail,
+            NativeAuthenticationProvider.Exchange,
+            settings
+          )
+        )
         .then(resp => {
           expect(resp).toEqual(authorizeJSON);
           expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
@@ -78,7 +95,7 @@ describe('Connect', () => {
               email_address: exchangeEmail,
               provider: 'exchange',
               settings: { username: exchangeEmail, password: password },
-              scopes: scopes,
+              scopes: scopeString,
             },
           });
           done();
@@ -91,7 +108,7 @@ describe('Connect', () => {
         Promise.resolve(tokenJSON)
       );
       Nylas.connect.token(authorizeJSON.code).then(resp => {
-        expect(resp).toEqual(tokenJSON);
+        expect(resp.toJSON()).toEqual(tokenJSON);
         expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           path: '/connect/token',

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -233,7 +233,7 @@ describe('ManagementAccount', () => {
             method: 'GET',
             path: `/a/${CLIENT_ID}/ip_addresses`,
           });
-          expect(resp.updated_at).toBe(1544658529);
+          expect(resp.updatedAt).toBe(1544658529);
           done();
         });
     });
@@ -279,16 +279,16 @@ describe('ManagementAccount', () => {
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/token-info`,
             body: { access_token: 'abc123' },
           });
-          expect(resp.created_at).toBe(1563496685);
+          expect(resp.createdAt).toBe(1563496685);
           expect(resp.scopes).toBe('calendar,email,contacts');
           expect(resp.state).toBe('valid');
-          expect(resp.updated_at).toBe(1563496685);
+          expect(resp.updatedAt).toBe(1563496685);
           done();
         });
     });
 
     test('should error when no access token passed in', done => {
-      expect.assertions(4);
+      expect.assertions(3);
       const requestMock = jest.fn();
       requestMock
         .mockReturnValueOnce(
@@ -302,12 +302,12 @@ describe('ManagementAccount', () => {
             },
           ])
         )
-        .mockReturnValueOnce(Promise.resolve('Error: No access_token passed.'));
+        .mockReturnValueOnce(Promise.reject('Error: No access_token passed.'));
       Nylas.accounts.connection.request = requestMock;
       Nylas.accounts
         .first()
         .then(account => account.tokenInfo())
-        .then(resp => {
+        .catch(() => {
           expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
           expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
@@ -319,7 +319,6 @@ describe('ManagementAccount', () => {
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/token-info`,
             body: { access_token: undefined },
           });
-          expect(resp).toBe('Error: No access_token passed.');
           done();
         });
     });

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -10,6 +10,7 @@ export interface AccountProperties {
   syncState: string;
   linkedAt: Date;
   billingState?: string;
+  accessToken?: string;
 }
 
 export default class Account extends RestfulModel implements AccountProperties {
@@ -20,6 +21,7 @@ export default class Account extends RestfulModel implements AccountProperties {
   syncState = '';
   linkedAt = new Date();
   billingState?: string;
+  accessToken?: string;
 
   constructor(connection: NylasConnection, props?: AccountProperties) {
     super(connection, props);
@@ -61,5 +63,10 @@ Account.attributes = {
   linkedAt: Attributes.DateTime({
     modelKey: 'linkedAt',
     jsonKey: 'linked_at',
+  }),
+
+  accessToken: Attributes.String({
+    modelKey: 'accessToken',
+    jsonKey: 'access_token',
   }),
 };

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -2,7 +2,7 @@ import RestfulModel from './restful-model';
 import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
 
-export interface AccountProperties {
+export type AccountProperties = {
   name: string;
   emailAddress: string;
   provider: string;
@@ -11,7 +11,7 @@ export interface AccountProperties {
   linkedAt: Date;
   billingState?: string;
   accessToken?: string;
-}
+};
 
 export default class Account extends RestfulModel implements AccountProperties {
   name = '';

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -1,5 +1,6 @@
 import Model from './model';
 import RestfulModel from './restful-model';
+import { NativeAuthenticationProvider } from './connect';
 
 // The Attribute class represents a single model attribute, like 'namespace_id'
 // Subclasses of Attribute like AttributeDateTime know how to covert between
@@ -210,6 +211,73 @@ class AttributeCollection extends Attribute {
   }
 }
 
+class AttributeEnum extends Attribute {
+  itemClass: any;
+
+  constructor({
+    modelKey,
+    itemClass,
+    jsonKey,
+    readOnly,
+  }: {
+    modelKey: string;
+    itemClass: any;
+    jsonKey?: string;
+    readOnly?: boolean;
+  }) {
+    super({ modelKey, jsonKey, readOnly });
+    this.itemClass = itemClass;
+  }
+
+  toJSON(val: any): string {
+    return val.toString();
+  }
+
+  fromJSON(val: any, _parent: any): any {
+    if (Object.values(this.itemClass).includes(val)) {
+      return val;
+    }
+    return;
+  }
+}
+
+class AttributeEnumList extends Attribute {
+  itemClass: any;
+
+  constructor({
+    modelKey,
+    itemClass,
+    jsonKey,
+    readOnly,
+  }: {
+    modelKey: string;
+    itemClass: any;
+    jsonKey?: string;
+    readOnly?: boolean;
+  }) {
+    super({ modelKey, jsonKey, readOnly });
+    this.itemClass = itemClass;
+  }
+
+  toJSON(val: any[]): string[] {
+    const enumList: string[] = [];
+    for (const v in val) {
+      enumList.push(v.toString());
+    }
+    return enumList;
+  }
+
+  fromJSON(val: any[], _parent: any): any[] {
+    const enumList: any[] = [];
+    for (const v in val) {
+      if (Object.values(this.itemClass).includes(val[v])) {
+        enumList.push(val[v]);
+      }
+    }
+    return enumList;
+  }
+}
+
 const Attributes = {
   Number(
     ...args: ConstructorParameters<typeof AttributeNumber>
@@ -248,6 +316,14 @@ const Attributes = {
     ...args: ConstructorParameters<typeof AttributeObject>
   ): AttributeObject {
     return new AttributeObject(...args);
+  },
+  Enum(...args: ConstructorParameters<typeof AttributeEnum>): AttributeEnum {
+    return new AttributeEnum(...args);
+  },
+  EnumList(
+    ...args: ConstructorParameters<typeof AttributeEnumList>
+  ): AttributeEnumList {
+    return new AttributeEnumList(...args);
   },
 };
 export default Attributes;

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -25,10 +25,10 @@ export class Attribute {
     this.readOnly = readOnly || false;
   }
 
-  toJSON(val: any, _parent?: any) {
+  toJSON(val: any, _parent?: any): any {
     return val;
   }
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): any {
     return val || null;
   }
 }
@@ -51,7 +51,7 @@ class AttributeObject extends Attribute {
     this.itemClass = itemClass;
   }
 
-  toJSON(val: any, _parent: any) {
+  toJSON(val: any, _parent: any): any {
     if (!val) {
       return val;
     }
@@ -61,7 +61,7 @@ class AttributeObject extends Attribute {
     return val;
   }
 
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): any {
     if (!val || !this.itemClass) {
       return val;
     }
@@ -74,10 +74,10 @@ class AttributeObject extends Attribute {
 }
 
 class AttributeNumber extends Attribute {
-  toJSON(val: any) {
+  toJSON(val: any): any {
     return val;
   }
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): number | null {
     if (!isNaN(val)) {
       return Number(val);
     } else {
@@ -87,34 +87,34 @@ class AttributeNumber extends Attribute {
 }
 
 class AttributeBoolean extends Attribute {
-  toJSON(val: any) {
+  toJSON(val: any): any {
     return val;
   }
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): boolean {
     return val === 'true' || val === true || false;
   }
 }
 
 class AttributeString extends Attribute {
-  toJSON(val: any) {
+  toJSON(val: any): any {
     return val;
   }
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): any {
     return val || '';
   }
 }
 
 class AttributeStringList extends Attribute {
-  toJSON(val: any) {
+  toJSON(val: any): any {
     return val;
   }
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): any {
     return val || [];
   }
 }
 
 class AttributeDate extends Attribute {
-  toJSON(val: any) {
+  toJSON(val: any): any {
     if (!val) {
       return val;
     }
@@ -128,7 +128,7 @@ class AttributeDate extends Attribute {
     return val.toISOString();
   }
 
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): Date | null {
     if (!val) {
       return null;
     }
@@ -137,7 +137,7 @@ class AttributeDate extends Attribute {
 }
 
 class AttributeDateTime extends Attribute {
-  toJSON(val: any) {
+  toJSON(val: any): number | null {
     if (!val) {
       return null;
     }
@@ -151,7 +151,7 @@ class AttributeDateTime extends Attribute {
     return val.getTime() / 1000.0;
   }
 
-  fromJSON(val: any, _parent: any) {
+  fromJSON(val: any, _parent: any): Date | null {
     if (!val) {
       return null;
     }
@@ -160,7 +160,6 @@ class AttributeDateTime extends Attribute {
 }
 
 class AttributeCollection extends Attribute {
-  //TODO::Do we still do this? or jsut typeof model?
   itemClass: typeof Model | typeof RestfulModel;
 
   constructor({
@@ -178,7 +177,7 @@ class AttributeCollection extends Attribute {
     this.itemClass = itemClass;
   }
 
-  toJSON(vals: any, _parent: any) {
+  toJSON(vals: any, _parent: any): any[] {
     if (!vals) {
       return [];
     }
@@ -193,7 +192,7 @@ class AttributeCollection extends Attribute {
     return json;
   }
 
-  fromJSON(json: any, _parent: any) {
+  fromJSON(json: any, _parent: any): any[] {
     if (!json || !(json instanceof Array)) {
       return [];
     }
@@ -212,28 +211,42 @@ class AttributeCollection extends Attribute {
 }
 
 const Attributes = {
-  Number(...args: ConstructorParameters<typeof AttributeNumber>) {
+  Number(
+    ...args: ConstructorParameters<typeof AttributeNumber>
+  ): AttributeNumber {
     return new AttributeNumber(...args);
   },
-  String(...args: ConstructorParameters<typeof AttributeString>) {
+  String(
+    ...args: ConstructorParameters<typeof AttributeString>
+  ): AttributeString {
     return new AttributeString(...args);
   },
-  StringList(...args: ConstructorParameters<typeof AttributeStringList>) {
+  StringList(
+    ...args: ConstructorParameters<typeof AttributeStringList>
+  ): AttributeStringList {
     return new AttributeStringList(...args);
   },
-  DateTime(...args: ConstructorParameters<typeof AttributeDateTime>) {
+  DateTime(
+    ...args: ConstructorParameters<typeof AttributeDateTime>
+  ): AttributeDateTime {
     return new AttributeDateTime(...args);
   },
-  Date(...args: ConstructorParameters<typeof AttributeDate>) {
+  Date(...args: ConstructorParameters<typeof AttributeDate>): AttributeDate {
     return new AttributeDate(...args);
   },
-  Collection(...args: ConstructorParameters<typeof AttributeCollection>) {
+  Collection(
+    ...args: ConstructorParameters<typeof AttributeCollection>
+  ): AttributeCollection {
     return new AttributeCollection(...args);
   },
-  Boolean(...args: ConstructorParameters<typeof AttributeBoolean>) {
+  Boolean(
+    ...args: ConstructorParameters<typeof AttributeBoolean>
+  ): AttributeBoolean {
     return new AttributeBoolean(...args);
   },
-  Object(...args: ConstructorParameters<typeof AttributeObject>) {
+  Object(
+    ...args: ConstructorParameters<typeof AttributeObject>
+  ): AttributeObject {
     return new AttributeObject(...args);
   },
 };

--- a/src/models/calendar-availability.ts
+++ b/src/models/calendar-availability.ts
@@ -2,13 +2,13 @@ import Model from './model';
 import Attributes from './attributes';
 import { TimeSlot, TimeSlotProperties } from './free-busy';
 
-export interface OpenHoursProperties {
+export type OpenHoursProperties = {
   emails: string[];
   days: string[];
   timezone: string;
   start: string;
   end: string;
-}
+};
 
 export class OpenHours extends Model implements OpenHoursProperties {
   objectType = 'open_hours';
@@ -45,9 +45,9 @@ OpenHours.attributes = {
   }),
 };
 
-export interface CalendarAvailabilityProperties {
+export type CalendarAvailabilityProperties = {
   timeSlots: TimeSlotProperties[];
-}
+};
 
 export default class CalendarAvailability extends Model
   implements CalendarAvailabilityProperties {

--- a/src/models/calendar-availability.ts
+++ b/src/models/calendar-availability.ts
@@ -29,7 +29,7 @@ OpenHours.attributes = {
     jsonKey: 'object_type',
   }),
   emails: Attributes.StringList({
-    modelKey: 'emails'
+    modelKey: 'emails',
   }),
   days: Attributes.StringList({
     modelKey: 'days',
@@ -43,13 +43,14 @@ OpenHours.attributes = {
   end: Attributes.String({
     modelKey: 'end',
   }),
-}
+};
 
 export interface CalendarAvailabilityProperties {
   timeSlots: TimeSlotProperties[];
 }
 
-export default class CalendarAvailability extends Model implements CalendarAvailabilityProperties {
+export default class CalendarAvailability extends Model
+  implements CalendarAvailabilityProperties {
   object = 'availability';
   timeSlots: TimeSlot[] = [];
 

--- a/src/models/calendar-availability.ts
+++ b/src/models/calendar-availability.ts
@@ -1,0 +1,60 @@
+import Model from './model';
+import Attributes from './attributes';
+import { TimeSlot, TimeSlotProperties } from './free-busy';
+
+export interface OpenHoursProperties {
+  emails: string[];
+  days: string[];
+  timezone: string;
+  start: string;
+  end: string;
+}
+
+export class OpenHours extends Model implements OpenHoursProperties {
+  objectType = 'open_hours';
+  emails = [];
+  days = [];
+  timezone = '';
+  start = '';
+  end = '';
+
+  constructor(props?: OpenHoursProperties) {
+    super();
+    this.initAttributes(props);
+  }
+}
+OpenHours.attributes = {
+  objectType: Attributes.String({
+    modelKey: 'objectType',
+    jsonKey: 'object_type',
+  }),
+  emails: Attributes.StringList({
+    modelKey: 'emails'
+  }),
+  days: Attributes.StringList({
+    modelKey: 'days',
+  }),
+  timezone: Attributes.String({
+    modelKey: 'timezone',
+  }),
+  start: Attributes.String({
+    modelKey: 'start',
+  }),
+  end: Attributes.String({
+    modelKey: 'end',
+  }),
+}
+
+export interface CalendarAvailabilityProperties {
+  timeSlots: TimeSlotProperties[];
+}
+
+export default class CalendarAvailability extends Model implements CalendarAvailabilityProperties {
+  object = 'availability';
+  timeSlots: TimeSlot[] = [];
+
+  constructor(props?: CalendarAvailabilityProperties) {
+    super();
+    this.initAttributes(props);
+  }
+}

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -24,7 +24,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       endTime: number;
       emails: string[];
     },
-    callback?: (error: Error | null, data?: { [key: string]: any }) => void
+    callback?: (error: Error | null, data?: Record<string, any>) => void
   ): Promise<FreeBusy[]> {
     return this.connection
       .request({
@@ -64,7 +64,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       freeBusy?: FreeBusyProperties[];
       openHours?: OpenHoursProperties[];
     },
-    callback?: (error: Error | null, data?: { [key: string]: any }) => void
+    callback?: (error: Error | null, data?: Record<string, any>) => void
   ): Promise<CalendarAvailability> {
     return this.connection
       .request({

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -2,11 +2,13 @@ import Calendar from './calendar';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
 import FreeBusy, { FreeBusyProperties } from './free-busy';
-import CalendarAvailability, { OpenHoursProperties } from './calendar-availability';
+import CalendarAvailability, {
+  OpenHoursProperties,
+} from './calendar-availability';
 
 export default class CalendarRestfulModelCollection extends RestfulModelCollection<
   Calendar
-  > {
+> {
   connection: NylasConnection;
   modelClass: typeof Calendar;
 

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -24,7 +24,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       endTime: number;
       emails: string[];
     },
-    callback?: (error: Error | null, data?: Record<string, any>) => void
+    callback?: (error: Error | null, data?: Record<string, unknown>) => void
   ): Promise<FreeBusy[]> {
     return this.connection
       .request({

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -61,7 +61,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       interval: number;
       startTime: string;
       endTime: string;
-      freeBusy: FreeBusyProperties[];
+      freeBusy?: FreeBusyProperties[];
       openHours?: OpenHoursProperties[];
     },
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
@@ -76,7 +76,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
           interval_minutes: options.interval,
           start_time: options.startTime,
           end_time: options.endTime,
-          free_busy: options.freeBusy,
+          free_busy: options.freeBusy || [],
           open_hours: options.openHours || [],
         },
       })

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -1,11 +1,12 @@
 import Calendar from './calendar';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
-import FreeBusy from './free-busy';
+import FreeBusy, { FreeBusyProperties } from './free-busy';
+import CalendarAvailability, { OpenHoursProperties } from './calendar-availability';
 
 export default class CalendarRestfulModelCollection extends RestfulModelCollection<
   Calendar
-> {
+  > {
   connection: NylasConnection;
   modelClass: typeof Calendar;
 
@@ -56,31 +57,13 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       emails: string[];
       duration: number;
       interval: number;
-      start_time?: string;
-      startTime?: string;
-      end_time?: string;
-      endTime?: string;
-      free_busy?: Array<{
-        emails: string;
-        object: string;
-        time_slots: Array<{
-          object: string;
-          status: string;
-          start_time: string;
-          end_time: string;
-        }>;
-      }>;
-      open_hours: Array<{
-        emails: string[];
-        days: string[];
-        timezone: string;
-        start: string;
-        end: string;
-        object_type: string;
-      }>;
+      startTime: string;
+      endTime: string;
+      freeBusy: FreeBusyProperties[];
+      openHours?: OpenHoursProperties[];
     },
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
-  ) {
+  ): Promise<CalendarAvailability> {
     return this.connection
       .request({
         method: 'POST',
@@ -89,17 +72,17 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
           emails: options.emails,
           duration_minutes: options.duration,
           interval_minutes: options.interval,
-          start_time: options.startTime || options.start_time,
-          end_time: options.endTime || options.end_time,
-          free_busy: options.free_busy || [],
-          open_hours: options.open_hours,
+          start_time: options.startTime,
+          end_time: options.endTime,
+          free_busy: options.freeBusy,
+          open_hours: options.openHours || [],
         },
       })
       .then(json => {
         if (callback) {
           callback(null, json);
         }
-        return Promise.resolve(json);
+        return Promise.resolve(new CalendarAvailability().fromJSON(json));
       })
       .catch(err => {
         if (callback) {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -2,6 +2,7 @@ import RestfulModel, { SaveCallback } from './restful-model';
 import { GetCallback } from './restful-model-collection';
 import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
+import JobStatus from './job-status';
 
 export interface CalendarProperties {
   name: string;
@@ -28,21 +29,14 @@ export default class Calendar extends RestfulModel
     this.initAttributes(props);
   }
 
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<Calendar> {
     return super.save(params, callback);
   }
 
-  saveRequestBody() {
-    const calendarJSON = super.saveRequestBody();
-    return {
-      name: calendarJSON.name,
-      description: calendarJSON.description,
-      location: calendarJSON.location,
-      timezone: calendarJSON.timezone,
-    };
-  }
-
-  getJobStatus(callback?: GetCallback) {
+  getJobStatus(callback?: GetCallback): Promise<JobStatus> {
     if (typeof this.jobStatusId === 'undefined') {
       const err = new Error('jobStatusId must be defined');
       if (callback) {
@@ -66,6 +60,7 @@ Calendar.attributes = {
   readOnly: Attributes.Boolean({
     modelKey: 'readOnly',
     jsonKey: 'read_only',
+    readOnly: true,
   }),
   location: Attributes.String({
     modelKey: 'location',
@@ -76,9 +71,11 @@ Calendar.attributes = {
   isPrimary: Attributes.Boolean({
     modelKey: 'isPrimary',
     jsonKey: 'is_primary',
+    readOnly: true,
   }),
   jobStatusId: Attributes.String({
     modelKey: 'jobStatusId',
     jsonKey: 'job_status_id',
+    readOnly: true,
   }),
 };

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -4,7 +4,7 @@ import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
 import JobStatus from './job-status';
 
-export interface CalendarProperties {
+export type CalendarProperties = {
   name: string;
   description: string;
   location: string;
@@ -12,7 +12,7 @@ export interface CalendarProperties {
   readOnly?: boolean;
   isPrimary?: boolean;
   jobStatusId?: string;
-}
+};
 
 export default class Calendar extends RestfulModel
   implements CalendarProperties {
@@ -29,10 +29,7 @@ export default class Calendar extends RestfulModel
     this.initAttributes(props);
   }
 
-  save(
-    params: {} | SaveCallback = {},
-    callback?: SaveCallback
-  ): Promise<Calendar> {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     return super.save(params, callback);
   }
 

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -11,7 +11,8 @@ export interface VirtualCalendarProperties {
   settings?: { [key: string]: string };
 }
 
-export class VirtualCalendar extends Model implements VirtualCalendarProperties {
+export class VirtualCalendar extends Model
+  implements VirtualCalendarProperties {
   provider = 'nylas';
   clientId = '';
   scopes = '';
@@ -44,32 +45,32 @@ VirtualCalendar.attributes = {
   settings: Attributes.Object({
     modelKey: 'settings',
   }),
-}
+};
 
 export enum Scopes {
-  EmailModify = "email.modify",
-  EmailReadOnly = "email.read_only",
-  EmailSend = "email.send",
-  EmailFoldersAndLabels = "email.folders_and_labels",
-  EmailMetadata = "email.metadata",
-  EmailDrafts = "email.drafts",
-  Calendar = "calendar",
-  CalendarReadOnly = "calendar.read_only",
-  RoomResourcesReadOnly = "room_resources.read_only",
-  Contacts = "contacts",
-  ContactsReadOnly = "contacts.read_only"
+  EmailModify = 'email.modify',
+  EmailReadOnly = 'email.read_only',
+  EmailSend = 'email.send',
+  EmailFoldersAndLabels = 'email.folders_and_labels',
+  EmailMetadata = 'email.metadata',
+  EmailDrafts = 'email.drafts',
+  Calendar = 'calendar',
+  CalendarReadOnly = 'calendar.read_only',
+  RoomResourcesReadOnly = 'room_resources.read_only',
+  Contacts = 'contacts',
+  ContactsReadOnly = 'contacts.read_only',
 }
 
 export enum NativeAuthenticationProvider {
-  Gmail = "gmail",
-  Yahoo = "yahoo",
-  Exchange = "exchange",
-  Outlook = "outlook",
-  Imap = "imap",
-  Icloud = "icloud",
-  Hotmail = "hotmail",
-  Aol = "aol",
-  Office365 = "office365"
+  Gmail = 'gmail',
+  Yahoo = 'yahoo',
+  Exchange = 'exchange',
+  Outlook = 'outlook',
+  Imap = 'imap',
+  Icloud = 'icloud',
+  Hotmail = 'hotmail',
+  Aol = 'aol',
+  Office365 = 'office365',
 }
 
 export interface NativeAuthenticationProperties {
@@ -83,9 +84,10 @@ export interface NativeAuthenticationProperties {
 
 type AuthorizationCode = {
   code: string;
-}
+};
 
-export class NativeAuthentication extends Model implements NativeAuthenticationProperties {
+export class NativeAuthentication extends Model
+  implements NativeAuthenticationProperties {
   clientId = '';
   name = '';
   emailAddress = '';
@@ -100,7 +102,7 @@ export class NativeAuthentication extends Model implements NativeAuthenticationP
 
   toJSON(): any {
     const json = super.toJSON();
-    json["scopes"] = this.scopes.join();
+    json['scopes'] = this.scopes.join();
     return json;
   }
 }
@@ -120,7 +122,9 @@ export default class Connect {
     this.clientSecret = clientSecret;
   }
 
-  authorize(auth: VirtualCalendarProperties | NativeAuthenticationProperties): Promise<AuthorizationCode> {
+  authorize(
+    auth: VirtualCalendarProperties | NativeAuthenticationProperties
+  ): Promise<AuthorizationCode> {
     // https://docs.nylas.com/reference#connectauthorize
     if (!this.clientId) {
       throw new Error(
@@ -129,19 +133,23 @@ export default class Connect {
     }
 
     let authClass: VirtualCalendar | NativeAuthentication;
-    if(auth.hasOwnProperty("scope")) {
-      authClass = new NativeAuthentication(auth as NativeAuthenticationProperties);
+    if (auth.hasOwnProperty('scope')) {
+      authClass = new NativeAuthentication(
+        auth as NativeAuthenticationProperties
+      );
     } else {
       authClass = new VirtualCalendar(auth as VirtualCalendarProperties);
     }
 
-    return this.connection.request({
-      method: 'POST',
-      path: '/connect/authorize',
-      body: authClass.toJSON(),
-    }).then((json: AuthorizationCode) => {
-      return json;
-    });
+    return this.connection
+      .request({
+        method: 'POST',
+        path: '/connect/authorize',
+        body: authClass.toJSON(),
+      })
+      .then((json: AuthorizationCode) => {
+        return json;
+      });
   }
 
   token(code: string): Promise<Account> {
@@ -156,16 +164,18 @@ export default class Connect {
         'connect.token() cannot be called until you provide a clientSecret via Nylas.config()'
       );
     }
-    return this.connection.request({
-      method: 'POST',
-      path: '/connect/token',
-      body: {
-        client_id: this.clientId,
-        client_secret: this.clientSecret,
-        code: code,
-      },
-    }).then(json => {
-      return new Account(this.connection).fromJSON(json);
-    });
+    return this.connection
+      .request({
+        method: 'POST',
+        path: '/connect/token',
+        body: {
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          code: code,
+        },
+      })
+      .then(json => {
+        return new Account(this.connection).fromJSON(json);
+      });
   }
 }

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -8,7 +8,7 @@ export interface VirtualCalendarProperties {
   email: string;
   name: string;
   clientId?: string;
-  settings?: { [key: string]: string };
+  settings?: Record<string, string>;
 }
 
 export class VirtualCalendar extends Model
@@ -18,7 +18,7 @@ export class VirtualCalendar extends Model
   scopes = '';
   email = '';
   name = '';
-  settings?: { [key: string]: string };
+  settings?: Record<string, string>;
 
   constructor(props?: VirtualCalendarProperties) {
     super();
@@ -79,7 +79,7 @@ export interface NativeAuthenticationProperties {
   provider: NativeAuthenticationProvider;
   scopes: Scope[];
   clientId?: string;
-  settings?: { [key: string]: string };
+  settings?: Record<string, string>;
 }
 
 type AuthorizationCode = {
@@ -93,7 +93,7 @@ export class NativeAuthentication extends Model
   emailAddress = '';
   provider = NativeAuthenticationProvider.Gmail;
   scopes: Scope[] = [];
-  settings?: { [key: string]: string };
+  settings?: Record<string, string>;
 
   constructor(props?: NativeAuthenticationProperties) {
     super();
@@ -106,7 +106,7 @@ export class NativeAuthentication extends Model
     return json;
   }
 
-  fromJSON(json: { [p: string]: any }): NativeAuthentication {
+  fromJSON(json: Record<string, any>): NativeAuthentication {
     if (json['scopes']) {
       json['scopes'] = json['scopes'].split(',');
     }

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -3,13 +3,13 @@ import Model from './model';
 import Attributes from './attributes';
 import Account from './account';
 
-export interface VirtualCalendarProperties {
+export type VirtualCalendarProperties = {
   scopes: string;
   email: string;
   name: string;
   clientId?: string;
   settings?: Record<string, string>;
-}
+};
 
 export class VirtualCalendar extends Model
   implements VirtualCalendarProperties {
@@ -22,7 +22,7 @@ export class VirtualCalendar extends Model
 
   constructor(props?: VirtualCalendarProperties) {
     super();
-    super.initAttributes(props);
+    this.initAttributes(props);
   }
 }
 VirtualCalendar.attributes = {
@@ -73,14 +73,14 @@ export enum NativeAuthenticationProvider {
   Office365 = 'office365',
 }
 
-export interface NativeAuthenticationProperties {
+export type NativeAuthenticationProperties = {
   name: string;
   emailAddress: string;
   provider: NativeAuthenticationProvider;
   scopes: Scope[];
   clientId?: string;
   settings?: Record<string, string>;
-}
+};
 
 type AuthorizationCode = {
   code: string;
@@ -100,13 +100,13 @@ export class NativeAuthentication extends Model
     this.initAttributes(props);
   }
 
-  toJSON(): any {
+  toJSON(): Record<string, unknown> {
     const json = super.toJSON();
     json['scopes'] = this.scopes.join();
     return json;
   }
 
-  fromJSON(json: Record<string, any>): NativeAuthentication {
+  fromJSON(json: Record<string, any>): this {
     if (json['scopes']) {
       json['scopes'] = json['scopes'].split(',');
     }

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -1,4 +1,109 @@
 import NylasConnection from '../nylas-connection';
+import Model from './model';
+import Attributes from './attributes';
+import Account from './account';
+
+export interface VirtualCalendarProperties {
+  clientId: string;
+  scopes: string;
+  email: string;
+  name: string;
+  settings?: { [key: string]: string };
+}
+
+export class VirtualCalendar extends Model implements VirtualCalendarProperties {
+  provider = 'nylas';
+  clientId = '';
+  scopes = '';
+  email = '';
+  name = '';
+  settings?: { [key: string]: string };
+
+  constructor(props?: VirtualCalendarProperties) {
+    super();
+    super.initAttributes(props);
+  }
+}
+VirtualCalendar.attributes = {
+  provider: Attributes.String({
+    modelKey: 'provider',
+  }),
+  clientId: Attributes.String({
+    modelKey: 'clientId',
+    jsonKey: 'client_id',
+  }),
+  scopes: Attributes.String({
+    modelKey: 'scopes',
+  }),
+  email: Attributes.String({
+    modelKey: 'email',
+  }),
+  name: Attributes.String({
+    modelKey: 'name',
+  }),
+  settings: Attributes.Object({
+    modelKey: 'settings',
+  }),
+}
+
+export enum Scopes {
+  EmailModify = "email.modify",
+  EmailReadOnly = "email.read_only",
+  EmailSend = "email.send",
+  EmailFoldersAndLabels = "email.folders_and_labels",
+  EmailMetadata = "email.metadata",
+  EmailDrafts = "email.drafts",
+  Calendar = "calendar",
+  CalendarReadOnly = "calendar.read_only",
+  RoomResourcesReadOnly = "room_resources.read_only",
+  Contacts = "contacts",
+  ContactsReadOnly = "contacts.read_only"
+}
+
+export enum NativeAuthenticationProvider {
+  Gmail = "gmail",
+  Yahoo = "yahoo",
+  Exchange = "exchange",
+  Outlook = "outlook",
+  Imap = "imap",
+  Icloud = "icloud",
+  Hotmail = "hotmail",
+  Aol = "aol",
+  Office365 = "office365"
+}
+
+export interface NativeAuthenticationProperties {
+  clientId: string;
+  name: string;
+  emailAddress: string;
+  provider: NativeAuthenticationProvider;
+  scopes: Scopes[];
+  settings?: { [key: string]: string };
+}
+
+type AuthorizationCode = {
+  code: string;
+}
+
+export class NativeAuthentication extends Model implements NativeAuthenticationProperties {
+  clientId = '';
+  name = '';
+  emailAddress = '';
+  provider = NativeAuthenticationProvider.Gmail;
+  scopes: Scopes[] = [];
+  settings?: { [key: string]: string };
+
+  constructor(props?: NativeAuthenticationProperties) {
+    super();
+    this.initAttributes(props);
+  }
+
+  toJSON(): any {
+    const json = super.toJSON();
+    json["scopes"] = this.scopes.join();
+    return json;
+  }
+}
 
 export default class Connect {
   connection: NylasConnection;
@@ -15,28 +120,31 @@ export default class Connect {
     this.clientSecret = clientSecret;
   }
 
-  authorize(options: { [key: string]: any } = {}) {
+  authorize(auth: VirtualCalendarProperties | NativeAuthenticationProperties): Promise<AuthorizationCode> {
     // https://docs.nylas.com/reference#connectauthorize
     if (!this.clientId) {
       throw new Error(
         'connect.authorize() cannot be called until you provide a clientId via Nylas.config()'
       );
     }
+
+    let authClass: VirtualCalendar | NativeAuthentication;
+    if(auth.hasOwnProperty("scope")) {
+      authClass = new NativeAuthentication(auth as NativeAuthenticationProperties);
+    } else {
+      authClass = new VirtualCalendar(auth as VirtualCalendarProperties);
+    }
+
     return this.connection.request({
       method: 'POST',
       path: '/connect/authorize',
-      body: {
-        client_id: this.clientId,
-        name: options.name,
-        email_address: options.email_address,
-        provider: options.provider,
-        settings: options.settings,
-        scopes: options.scopes,
-      },
+      body: authClass.toJSON(),
+    }).then((json: AuthorizationCode) => {
+      return json;
     });
   }
 
-  token(code: string) {
+  token(code: string): Promise<Account> {
     // https://docs.nylas.com/reference#connecttoken
     if (!this.clientId) {
       throw new Error(
@@ -56,10 +164,8 @@ export default class Connect {
         client_secret: this.clientSecret,
         code: code,
       },
+    }).then(json => {
+      return new Account(this.connection).fromJSON(json);
     });
-  }
-
-  newAccount() {
-    // this.authorize() -> this.token()
   }
 }

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -16,14 +16,14 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
 
   groups(
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
-  ) {
+  ): Promise<Group[]> {
     return this.connection
       .request({
         method: 'GET',
         path: `/contacts/groups`,
       })
       .then(json => {
-        const groups = json.map((group: { [key: string]: any }) => {
+        const groups: Group[] = json.map((group: { [key: string]: any }) => {
           return new Group().fromJSON(group);
         });
         if (callback) {

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -15,7 +15,7 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
   }
 
   groups(
-    callback?: (error: Error | null, data?: { [key: string]: any }) => void
+    callback?: (error: Error | null, data?: Record<string, any>) => void
   ): Promise<Group[]> {
     return this.connection
       .request({
@@ -23,7 +23,7 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
         path: `/contacts/groups`,
       })
       .then(json => {
-        const groups: Group[] = json.map((group: { [key: string]: any }) => {
+        const groups: Group[] = json.map((group: Record<string, any>) => {
           return new Group().fromJSON(group);
         });
         if (callback) {

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,12 +1,12 @@
-import RestfulModel, { SaveCallback } from './restful-model';
+import RestfulModel from './restful-model';
 import Attributes from './attributes';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
 
-export interface EmailAddressProperties {
+export type EmailAddressProperties = {
   type: string;
   email: string;
-}
+};
 
 export class EmailAddress extends Model implements EmailAddressProperties {
   type = '';
@@ -27,11 +27,10 @@ EmailAddress.attributes = {
   }),
 };
 
-// eslint-disable-next-line @typescript-eslint/interface-name-prefix
-export interface IMAddressProperties {
+export type IMAddressProperties = {
   type: string;
   imAddress: string;
-}
+};
 
 export class IMAddress extends Model implements IMAddressProperties {
   type = '';
@@ -53,7 +52,7 @@ IMAddress.attributes = {
   }),
 };
 
-export interface PhysicalAddressProperties {
+export type PhysicalAddressProperties = {
   type: string;
   format: string;
   streetAddress: string;
@@ -62,7 +61,7 @@ export interface PhysicalAddressProperties {
   state: string;
   country: string;
   address?: string;
-}
+};
 
 class PhysicalAddress extends Model implements PhysicalAddressProperties {
   type = '';
@@ -126,10 +125,10 @@ PhysicalAddress.attributes = {
   }),
 };
 
-export interface PhoneNumberProperties {
+export type PhoneNumberProperties = {
   type: string;
   number: string;
-}
+};
 
 export class PhoneNumber extends Model implements PhoneNumberProperties {
   type = '';
@@ -150,10 +149,10 @@ PhoneNumber.attributes = {
   }),
 };
 
-export interface WebPageProperties {
+export type WebPageProperties = {
   type: string;
   url: string;
-}
+};
 
 export class WebPage extends Model implements WebPageProperties {
   type = '';
@@ -174,13 +173,13 @@ WebPage.attributes = {
   }),
 };
 
-export interface GroupProperties {
+export type GroupProperties = {
   name: string;
   path: string;
   id?: string;
   accountId?: string;
   object?: string;
-}
+};
 
 export class Group extends Model implements GroupProperties {
   name = '';
@@ -217,7 +216,7 @@ Group.attributes = {
   }),
 };
 
-export interface ContactProperties {
+export type ContactProperties = {
   givenName?: string;
   middleName?: string;
   surname?: string;
@@ -236,7 +235,7 @@ export interface ContactProperties {
   webPages?: WebPageProperties[];
   groups?: GroupProperties[];
   source?: string;
-}
+};
 
 export class Contact extends RestfulModel implements ContactProperties {
   givenName?: string;

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -16,14 +16,6 @@ export class EmailAddress extends Model implements EmailAddressProperties {
     super();
     this.initAttributes(props);
   }
-
-  // TODO::Can probably remove toJSONs in classes that extend Model
-  toJSON() {
-    return {
-      type: this.type,
-      email: this.email,
-    };
-  }
 }
 
 EmailAddress.attributes = {
@@ -49,13 +41,6 @@ export class IMAddress extends Model implements IMAddressProperties {
     super();
     this.initAttributes(props);
   }
-
-  toJSON() {
-    return {
-      type: this.type,
-      im_address: this.imAddress,
-    };
-  }
 }
 
 IMAddress.attributes = {
@@ -68,7 +53,6 @@ IMAddress.attributes = {
   }),
 };
 
-// TODO::Check if "address" is deprecated
 export interface PhysicalAddressProperties {
   type: string;
   format: string;
@@ -95,7 +79,7 @@ class PhysicalAddress extends Model implements PhysicalAddressProperties {
     this.initAttributes(props);
   }
 
-  toJSON() {
+  toJSON(): { [key: string]: any } {
     const json: { [key: string]: any } = {
       type: this.type,
       format: this.format,
@@ -155,13 +139,6 @@ export class PhoneNumber extends Model implements PhoneNumberProperties {
     super();
     this.initAttributes(props);
   }
-
-  toJSON() {
-    return {
-      type: this.type,
-      number: this.number,
-    };
-  }
 }
 
 PhoneNumber.attributes = {
@@ -185,14 +162,6 @@ export class WebPage extends Model implements WebPageProperties {
   constructor(props?: WebPageProperties) {
     super();
     this.initAttributes(props);
-  }
-
-  toJSON() {
-    const json = {
-      type: this.type,
-      url: this.url,
-    };
-    return json;
   }
 }
 
@@ -294,14 +263,10 @@ export class Contact extends RestfulModel implements ContactProperties {
     this.initAttributes(props);
   }
 
-  save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
-    return super.save(params, callback);
-  }
-
   getPicture(
     params: { [key: string]: any } = {},
     callback?: (error: Error | null, result?: any) => void
-  ) {
+  ): any {
     return this.get(params, callback, '/picture');
   }
 }

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -79,8 +79,8 @@ class PhysicalAddress extends Model implements PhysicalAddressProperties {
     this.initAttributes(props);
   }
 
-  toJSON(): { [key: string]: any } {
-    const json: { [key: string]: any } = {
+  toJSON(): Record<string, string> {
+    const json: Record<string, string> = {
       type: this.type,
       format: this.format,
     };
@@ -264,7 +264,7 @@ export class Contact extends RestfulModel implements ContactProperties {
   }
 
   getPicture(
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (error: Error | null, result?: any) => void
   ): any {
     return this.get(params, callback, '/picture');

--- a/src/models/delta-stream.ts
+++ b/src/models/delta-stream.ts
@@ -46,7 +46,7 @@ export default class DeltaStream extends EventEmitter {
   constructor(
     connection: NylasConnection,
     cursor: string,
-    params: { [key: string]: any } = {}
+    params: Record<string, any> = {}
   ) {
     super();
     this.connection = connection;
@@ -83,7 +83,7 @@ export default class DeltaStream extends EventEmitter {
     const path = '/delta/streaming';
     const { excludeTypes = [], includeTypes = [], ...params } = this.params;
 
-    const queryObj: { [key: string]: any } = {
+    const queryObj: Record<string, any> = {
       ...params,
       cursor: this.cursor,
     };

--- a/src/models/delta-stream.ts
+++ b/src/models/delta-stream.ts
@@ -68,7 +68,7 @@ export default class DeltaStream extends EventEmitter {
       });
   }
 
-  close() {
+  close(): void {
     clearTimeout(this.timeoutId);
     delete this.timeoutId;
     this.restartBackoff.reset();
@@ -78,7 +78,7 @@ export default class DeltaStream extends EventEmitter {
     delete this.requestInfo;
   }
 
-  async open() {
+  async open(): Promise<void> {
     this.close();
     const path = '/delta/streaming';
     const { excludeTypes = [], includeTypes = [], ...params } = this.params;
@@ -140,7 +140,7 @@ export default class DeltaStream extends EventEmitter {
     }
   }
 
-  private onDataReceived() {
+  private onDataReceived(): void {
     // Nylas sends a newline heartbeat in the raw data stream once every 5 seconds.
     // Automatically restart the connection if we haven't gotten any data in
     // Delta.streamingTimeoutMs. The connection will restart with the last
@@ -153,12 +153,12 @@ export default class DeltaStream extends EventEmitter {
     ) as any;
   }
 
-  private onError(err: Error) {
+  private onError(err: Error): void {
     this.emit('error', err);
     return this.restartBackoff.reset();
   }
 
-  private restartConnection(n: number) {
+  private restartConnection(n: number): Promise<void> {
     this.emit(
       'info',
       `Restarting Nylas DeltaStream connection (attempt ${n + 1}): ${

--- a/src/models/delta-stream.ts
+++ b/src/models/delta-stream.ts
@@ -46,7 +46,7 @@ export default class DeltaStream extends EventEmitter {
   constructor(
     connection: NylasConnection,
     cursor: string,
-    params: Record<string, any> = {}
+    params: Record<string, unknown> = {}
   ) {
     super();
     this.connection = connection;
@@ -83,7 +83,7 @@ export default class DeltaStream extends EventEmitter {
     const path = '/delta/streaming';
     const { excludeTypes = [], includeTypes = [], ...params } = this.params;
 
-    const queryObj: Record<string, any> = {
+    const queryObj: Record<string, unknown> = {
       ...params,
       cursor: this.cursor,
     };

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -42,7 +42,7 @@ export default class Delta {
 
   async startStream(
     cursor: string,
-    params: Record<string, any> = {}
+    params: Record<string, unknown> = {}
   ): Promise<DeltaStream> {
     const stream = new DeltaStream(this.connection, cursor, params);
     await stream.open();

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -3,7 +3,7 @@ import DeltaStream from './delta-stream';
 
 export type LatestCursor = {
   cursor: string;
-}
+};
 
 export default class Delta {
   connection: NylasConnection;
@@ -16,7 +16,9 @@ export default class Delta {
     }
   }
 
-  latestCursor(callback: (error: Error | null, cursor: string | null) => void): Promise<LatestCursor> {
+  latestCursor(
+    callback: (error: Error | null, cursor: string | null) => void
+  ): Promise<string> {
     const reqOpts = {
       method: 'POST',
       path: '/delta/latest_cursor',
@@ -28,7 +30,7 @@ export default class Delta {
         if (callback) {
           callback(null, response.cursor);
         }
-        return Promise.resolve(response);
+        return Promise.resolve(response.cursor);
       })
       .catch(err => {
         if (callback) {
@@ -38,7 +40,10 @@ export default class Delta {
       });
   }
 
-  async startStream(cursor: string, params: { [key: string]: any } = {}): Promise<DeltaStream> {
+  async startStream(
+    cursor: string,
+    params: { [key: string]: any } = {}
+  ): Promise<DeltaStream> {
     const stream = new DeltaStream(this.connection, cursor, params);
     await stream.open();
     return stream;

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -42,7 +42,7 @@ export default class Delta {
 
   async startStream(
     cursor: string,
-    params: { [key: string]: any } = {}
+    params: Record<string, any> = {}
   ): Promise<DeltaStream> {
     const stream = new DeltaStream(this.connection, cursor, params);
     await stream.open();

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -5,7 +5,7 @@ import NylasConnection from '../nylas-connection';
 
 export type SendCallback = (
   err: Error | null,
-  json?: { [key: string]: any }
+  json?: Record<string, any>
 ) => void;
 
 export interface DraftProperties extends MessageProperties {
@@ -24,7 +24,7 @@ export default class Draft extends Message implements DraftProperties {
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
+  toJSON(enforceReadOnly?: boolean): Record<string, any> {
     if (this.rawMime) {
       throw Error('toJSON() cannot be called for raw MIME drafts');
     }
@@ -48,17 +48,15 @@ export default class Draft extends Message implements DraftProperties {
     return super.save(params, callback);
   }
 
-  saveRequestBody(): { [key: string]: any } {
+  saveRequestBody(): Record<string, any> {
     if (this.rawMime) {
       throw Error('saveRequestBody() cannot be called for raw MIME drafts');
     }
     return super.saveRequestBody();
   }
 
-  deleteRequestBody(
-    params: { [key: string]: any } = {}
-  ): { [key: string]: any } {
-    const body: { [key: string]: any } = {};
+  deleteRequestBody(params: Record<string, any> = {}): Record<string, any> {
+    const body: Record<string, any> = {};
     body.version = params.hasOwnProperty('version')
       ? params.version
       : this.version;
@@ -73,8 +71,8 @@ export default class Draft extends Message implements DraftProperties {
   }
 
   send(
-    trackingArg?: { [key: string]: any } | SendCallback | null,
-    callbackArg?: SendCallback | { [key: string]: any } | null
+    trackingArg?: Record<string, any> | SendCallback | null,
+    callbackArg?: SendCallback | Record<string, any> | null
   ): Promise<Message> {
     // callback used to be the first argument, and tracking was the second
     let callback: SendCallback | undefined;
@@ -83,7 +81,7 @@ export default class Draft extends Message implements DraftProperties {
     } else if (typeof trackingArg === 'function') {
       callback = trackingArg as SendCallback;
     }
-    let tracking: { [key: string]: any } | undefined;
+    let tracking: Record<string, any> | undefined;
     if (trackingArg && typeof trackingArg === 'object') {
       tracking = trackingArg;
     } else if (callbackArg && typeof callbackArg === 'object') {
@@ -91,7 +89,7 @@ export default class Draft extends Message implements DraftProperties {
     }
 
     let body: any = this.rawMime,
-      headers: { [key: string]: any } = { 'Content-Type': 'message/rfc822' },
+      headers: Record<string, string> = { 'Content-Type': 'message/rfc822' },
       json = false;
 
     if (!this.rawMime) {

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -8,11 +8,11 @@ export type SendCallback = (
   json?: Record<string, any>
 ) => void;
 
-export interface DraftProperties extends MessageProperties {
+export type DraftProperties = MessageProperties & {
   rawMime?: string;
   replyToMessageId?: string;
   version?: number;
-}
+};
 
 export default class Draft extends Message implements DraftProperties {
   rawMime?: string;
@@ -34,10 +34,7 @@ export default class Draft extends Message implements DraftProperties {
     return json;
   }
 
-  save(
-    params: {} | SaveCallback = {},
-    callback?: SaveCallback
-  ): Promise<Draft> {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     if (this.rawMime) {
       const err = new Error('save() cannot be called for raw MIME drafts');
       if (callback) {
@@ -48,15 +45,17 @@ export default class Draft extends Message implements DraftProperties {
     return super.save(params, callback);
   }
 
-  saveRequestBody(): Record<string, any> {
+  saveRequestBody(): Record<string, unknown> {
     if (this.rawMime) {
       throw Error('saveRequestBody() cannot be called for raw MIME drafts');
     }
     return super.saveRequestBody();
   }
 
-  deleteRequestBody(params: Record<string, any> = {}): Record<string, any> {
-    const body: Record<string, any> = {};
+  deleteRequestBody(
+    params: Record<string, unknown> = {}
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {};
     body.version = params.hasOwnProperty('version')
       ? params.version
       : this.version;

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -34,7 +34,10 @@ export default class Draft extends Message implements DraftProperties {
     return json;
   }
 
-  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Draft> {
+  save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<Draft> {
     if (this.rawMime) {
       const err = new Error('save() cannot be called for raw MIME drafts');
       if (callback) {
@@ -52,7 +55,9 @@ export default class Draft extends Message implements DraftProperties {
     return super.saveRequestBody();
   }
 
-  deleteRequestBody(params: { [key: string]: any } = {}): { [key: string]: any } {
+  deleteRequestBody(
+    params: { [key: string]: any } = {}
+  ): { [key: string]: any } {
     const body: { [key: string]: any } = {};
     body.version = params.hasOwnProperty('version')
       ? params.version

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -24,7 +24,7 @@ export default class Draft extends Message implements DraftProperties {
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean) {
+  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
     if (this.rawMime) {
       throw Error('toJSON() cannot be called for raw MIME drafts');
     }
@@ -34,7 +34,7 @@ export default class Draft extends Message implements DraftProperties {
     return json;
   }
 
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Draft> {
     if (this.rawMime) {
       const err = new Error('save() cannot be called for raw MIME drafts');
       if (callback) {
@@ -45,14 +45,14 @@ export default class Draft extends Message implements DraftProperties {
     return super.save(params, callback);
   }
 
-  saveRequestBody() {
+  saveRequestBody(): { [key: string]: any } {
     if (this.rawMime) {
       throw Error('saveRequestBody() cannot be called for raw MIME drafts');
     }
     return super.saveRequestBody();
   }
 
-  deleteRequestBody(params: { [key: string]: any } = {}) {
+  deleteRequestBody(params: { [key: string]: any } = {}): { [key: string]: any } {
     const body: { [key: string]: any } = {};
     body.version = params.hasOwnProperty('version')
       ? params.version
@@ -60,7 +60,7 @@ export default class Draft extends Message implements DraftProperties {
     return body;
   }
 
-  toString() {
+  toString(): string {
     if (this.rawMime) {
       throw Error('toString() cannot be called for raw MIME drafts');
     }
@@ -70,7 +70,7 @@ export default class Draft extends Message implements DraftProperties {
   send(
     trackingArg?: { [key: string]: any } | SendCallback | null,
     callbackArg?: SendCallback | { [key: string]: any } | null
-  ) {
+  ): Promise<Message> {
     // callback used to be the first argument, and tracking was the second
     let callback: SendCallback | undefined;
     if (typeof callbackArg === 'function') {

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -16,7 +16,7 @@ export default class EmailParticipant extends Model
     this.initAttributes(props);
   }
 
-  toJSON(): EmailParticipantProperties {
+  toJSON(): { [key: string]: any } {
     const json = super.toJSON();
     if (!json['name']) {
       json['name'] = json['email'];

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -1,10 +1,10 @@
 import Attributes from './attributes';
 import Model from './model';
 
-export interface EmailParticipantProperties {
+export type EmailParticipantProperties = {
   email: string;
   name?: string;
-}
+};
 
 export default class EmailParticipant extends Model
   implements EmailParticipantProperties {
@@ -16,7 +16,7 @@ export default class EmailParticipant extends Model
     this.initAttributes(props);
   }
 
-  toJSON(): Record<string, any> {
+  toJSON(): Record<string, unknown> {
     const json = super.toJSON();
     if (!json['name']) {
       json['name'] = json['email'];

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -16,7 +16,7 @@ export default class EmailParticipant extends Model
     this.initAttributes(props);
   }
 
-  toJSON(): { [key: string]: any } {
+  toJSON(): Record<string, any> {
     const json = super.toJSON();
     if (!json['name']) {
       json['name'] = json['email'];

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -55,7 +55,7 @@ export class EventConferencing extends Model
   provider = '';
   details?: EventConferencingDetails;
   autocreate?: {
-    settings?: { [key: string]: string };
+    settings?: Record<string, string>;
   };
 
   constructor(props?: EventConferencingProperties) {

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -1,13 +1,13 @@
 import Attributes from './attributes';
 import Model from './model';
 
-export interface EventConferencingDetailsProperties {
+export type EventConferencingDetailsProperties = {
   meetingCode?: string;
   phone?: string[];
   password?: string;
   pin?: string;
   url?: string;
-}
+};
 
 class EventConferencingDetails extends Model
   implements EventConferencingDetailsProperties {
@@ -42,13 +42,13 @@ EventConferencingDetails.attributes = {
   }),
 };
 
-export interface EventConferencingProperties {
+export type EventConferencingProperties = {
   provider: string;
   details?: EventConferencingDetailsProperties;
   autocreate?: {
     settings?: object;
   };
-}
+};
 
 export class EventConferencing extends Model
   implements EventConferencingProperties {

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -21,16 +21,6 @@ class EventConferencingDetails extends Model
     super();
     this.initAttributes(props);
   }
-
-  toJSON() {
-    return {
-      meeting_code: this.meetingCode,
-      phone: this.phone,
-      password: this.password,
-      pin: this.pin,
-      url: this.url,
-    };
-  }
 }
 
 EventConferencingDetails.attributes = {
@@ -71,14 +61,6 @@ export class EventConferencing extends Model
   constructor(props?: EventConferencingProperties) {
     super();
     this.initAttributes(props);
-  }
-
-  toJSON(): any {
-    return {
-      details: this.details,
-      provider: this.provider,
-      autocreate: this.autocreate,
-    };
   }
 }
 

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -1,11 +1,11 @@
 import Attributes from './attributes';
 import Model from './model';
 
-export interface EventParticipantProperties {
+export type EventParticipantProperties = {
   email: string;
   name?: string;
   status?: string;
-}
+};
 
 export default class EventParticipant extends Model
   implements EventParticipantProperties {
@@ -19,7 +19,7 @@ export default class EventParticipant extends Model
   }
 
   toJSON(enforceReadOnly?: boolean): Record<string, string> {
-    const json = super.toJSON(enforceReadOnly);
+    const json = super.toJSON(enforceReadOnly) as Record<string, string>;
     if (!json['name']) {
       json['name'] = json['email'];
     }

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -18,7 +18,7 @@ export default class EventParticipant extends Model
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
+  toJSON(enforceReadOnly?: boolean): Record<string, string> {
     const json = super.toJSON(enforceReadOnly);
     if (!json['name']) {
       json['name'] = json['email'];

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -18,7 +18,7 @@ export default class EventParticipant extends Model
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean) {
+  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
     const json = super.toJSON(enforceReadOnly);
     if (!json['name']) {
       json['name'] = json['email'];

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -136,7 +136,7 @@ export default class Event extends RestfulModel {
     }
   }
 
-  deleteRequestQueryString(params: { [key: string]: any } = {}) {
+  deleteRequestQueryString(params: { [key: string]: any } = {}): { [key: string]: any } {
     const qs: { [key: string]: any } = {};
     if (params.hasOwnProperty('notify_participants')) {
       qs.notify_participants = params.notify_participants;
@@ -144,7 +144,7 @@ export default class Event extends RestfulModel {
     return qs;
   }
 
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Event> {
     if (
       this.conferencing &&
       this.conferencing.details &&
@@ -163,7 +163,7 @@ export default class Event extends RestfulModel {
     status: string,
     comment: string,
     callback?: (error: Error | null, data?: Event) => void
-  ) {
+  ): Promise<Event> {
     return this.connection
       .request({
         method: 'POST',

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -10,7 +10,7 @@ import {
 import When, { WhenProperties } from './when';
 import NylasConnection from '../nylas-connection';
 
-export interface EventProperties {
+export type EventProperties = {
   calendarId: string;
   when: WhenProperties;
   iCalUID?: string;
@@ -32,7 +32,7 @@ export interface EventProperties {
   conferencing?: EventConferencingProperties;
   metadata?: object;
   jobStatusId?: string;
-}
+};
 
 export default class Event extends RestfulModel {
   calendarId = '';
@@ -137,19 +137,16 @@ export default class Event extends RestfulModel {
   }
 
   deleteRequestQueryString(
-    params: Record<string, any> = {}
-  ): Record<string, any> {
-    const qs: Record<string, any> = {};
+    params: Record<string, unknown> = {}
+  ): Record<string, unknown> {
+    const qs: Record<string, unknown> = {};
     if (params.hasOwnProperty('notify_participants')) {
       qs.notify_participants = params.notify_participants;
     }
     return qs;
   }
 
-  save(
-    params: {} | SaveCallback = {},
-    callback?: SaveCallback
-  ): Promise<Event> {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     if (
       this.conferencing &&
       this.conferencing.details &&

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -136,7 +136,9 @@ export default class Event extends RestfulModel {
     }
   }
 
-  deleteRequestQueryString(params: { [key: string]: any } = {}): { [key: string]: any } {
+  deleteRequestQueryString(
+    params: { [key: string]: any } = {}
+  ): { [key: string]: any } {
     const qs: { [key: string]: any } = {};
     if (params.hasOwnProperty('notify_participants')) {
       qs.notify_participants = params.notify_participants;
@@ -144,7 +146,10 @@ export default class Event extends RestfulModel {
     return qs;
   }
 
-  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Event> {
+  save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<Event> {
     if (
       this.conferencing &&
       this.conferencing.details &&

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -137,9 +137,9 @@ export default class Event extends RestfulModel {
   }
 
   deleteRequestQueryString(
-    params: { [key: string]: any } = {}
-  ): { [key: string]: any } {
-    const qs: { [key: string]: any } = {};
+    params: Record<string, any> = {}
+  ): Record<string, any> {
+    const qs: Record<string, any> = {};
     if (params.hasOwnProperty('notify_participants')) {
       qs.notify_participants = params.notify_participants;
     }

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -26,7 +26,9 @@ export default class File extends RestfulModel implements FileProperties {
     this.initAttributes(props);
   }
 
-  upload(callback?: (error: Error | null, model?: File) => void): Promise<File> {
+  upload(
+    callback?: (error: Error | null, model?: File) => void
+  ): Promise<File> {
     if (!this.filename) {
       throw new Error('Please define a filename');
     }

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -39,7 +39,7 @@ export default class File extends RestfulModel implements FileProperties {
       throw new Error('Please define a content-type');
     }
 
-    const formOptions: { [key: string]: any } = {
+    const formOptions: Record<string, any> = {
       filename: this.filename,
       contentType: this.contentType,
     };
@@ -113,7 +113,7 @@ export default class File extends RestfulModel implements FileProperties {
 
   //TODO::Probably deprecate this? All it does is call /files/{id}
   metadata(
-    callback?: (error: Error | null, data?: { [key: string]: any }) => void
+    callback?: (error: Error | null, data?: Record<string, any>) => void
   ) {
     return this.connection
       .request({

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -26,7 +26,7 @@ export default class File extends RestfulModel implements FileProperties {
     this.initAttributes(props);
   }
 
-  upload(callback?: (error: Error | null, model?: File) => void) {
+  upload(callback?: (error: Error | null, model?: File) => void): Promise<File> {
     if (!this.filename) {
       throw new Error('Please define a filename');
     }
@@ -85,7 +85,7 @@ export default class File extends RestfulModel implements FileProperties {
       error: Error | null,
       file?: { body: any; [key: string]: any }
     ) => void
-  ) {
+  ): Promise<any> {
     if (!this.id) {
       throw new Error('Please provide a File id');
     }
@@ -109,6 +109,7 @@ export default class File extends RestfulModel implements FileProperties {
       });
   }
 
+  //TODO::Probably deprecate this? All it does is call /files/{id}
   metadata(
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
   ) {

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -2,15 +2,15 @@ import Attributes from './attributes';
 import RestfulModel from './restful-model';
 import NylasConnection from '../nylas-connection';
 
-export interface FileProperties {
+export type FileProperties = {
   contentType?: string;
   size?: number;
   filename?: string;
   messageIds?: string[];
   contentId?: string;
   contentDisposition?: string;
-  data?: any;
-}
+  data?: unknown;
+};
 
 export default class File extends RestfulModel implements FileProperties {
   contentType?: string;
@@ -19,7 +19,7 @@ export default class File extends RestfulModel implements FileProperties {
   messageIds?: string[];
   contentId?: string;
   contentDisposition?: string;
-  data?: any;
+  data?: unknown;
 
   constructor(connection: NylasConnection, props?: FileProperties) {
     super(connection, props);

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -16,14 +16,7 @@ export class Folder extends RestfulModel implements FolderProperties {
     this.initAttributes(props);
   }
 
-  saveRequestBody() {
-    const json: { [key: string]: any } = {};
-    json['display_name'] = this.displayName;
-    json['name'] = this.name;
-    return json;
-  }
-
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Folder> {
     return super.save(params, callback);
   }
 }
@@ -45,7 +38,7 @@ export class Label extends Folder {
     super(connection, props);
   }
 
-  saveRequestBody() {
+  saveRequestBody(): { [key: string]: any } {
     return { display_name: this.displayName };
   }
 }

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -2,10 +2,10 @@ import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
 
-export interface FolderProperties {
+export type FolderProperties = {
   displayName?: string;
   name?: string;
-}
+};
 
 export class Folder extends RestfulModel implements FolderProperties {
   displayName?: string;
@@ -16,10 +16,7 @@ export class Folder extends RestfulModel implements FolderProperties {
     this.initAttributes(props);
   }
 
-  save(
-    params: {} | SaveCallback = {},
-    callback?: SaveCallback
-  ): Promise<Folder> {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     return super.save(params, callback);
   }
 }

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -16,7 +16,10 @@ export class Folder extends RestfulModel implements FolderProperties {
     this.initAttributes(props);
   }
 
-  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Folder> {
+  save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<Folder> {
     return super.save(params, callback);
   }
 }

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -41,7 +41,7 @@ export class Label extends Folder {
     super(connection, props);
   }
 
-  saveRequestBody(): { [key: string]: any } {
+  saveRequestBody(): Record<string, any> {
     return { display_name: this.displayName };
   }
 }

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -1,14 +1,13 @@
 import Model from './model';
 import Attributes from './attributes';
 
-interface TimeSlotProperties {
-  object: string;
+export interface TimeSlotProperties {
   status: string;
   startTime: number;
   endTime: number;
 }
 
-class TimeSlot extends Model implements TimeSlotProperties {
+export class TimeSlot extends Model implements TimeSlotProperties {
   object = 'time_slot';
   status = '';
   startTime = 0;
@@ -34,10 +33,9 @@ TimeSlot.attributes = {
     modelKey: 'endTime',
     jsonKey: 'end_time',
   }),
-};
+}
 
-interface FreeBusyProperties {
-  object: string;
+export interface FreeBusyProperties {
   email: string;
   timeSlots: TimeSlotProperties[];
 }
@@ -45,7 +43,7 @@ interface FreeBusyProperties {
 export default class FreeBusy extends Model implements FreeBusyProperties {
   object = 'free_busy';
   email = '';
-  timeSlots = [];
+  timeSlots: TimeSlot[] = [];
 
   constructor(props?: FreeBusyProperties) {
     super();
@@ -64,4 +62,4 @@ FreeBusy.attributes = {
     jsonKey: 'time_slots',
     itemClass: TimeSlot,
   }),
-};
+}

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -33,7 +33,7 @@ TimeSlot.attributes = {
     modelKey: 'endTime',
     jsonKey: 'end_time',
   }),
-}
+};
 
 export interface FreeBusyProperties {
   email: string;
@@ -62,4 +62,4 @@ FreeBusy.attributes = {
     jsonKey: 'time_slots',
     itemClass: TimeSlot,
   }),
-}
+};

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -1,11 +1,11 @@
 import Model from './model';
 import Attributes from './attributes';
 
-export interface TimeSlotProperties {
+export type TimeSlotProperties = {
   status: string;
   startTime: number;
   endTime: number;
-}
+};
 
 export class TimeSlot extends Model implements TimeSlotProperties {
   object = 'time_slot';
@@ -35,10 +35,10 @@ TimeSlot.attributes = {
   }),
 };
 
-export interface FreeBusyProperties {
+export type FreeBusyProperties = {
   email: string;
   timeSlots: TimeSlotProperties[];
-}
+};
 
 export default class FreeBusy extends Model implements FreeBusyProperties {
   object = 'free_busy';

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -2,12 +2,12 @@ import RestfulModel from './restful-model';
 import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
 
-export interface JobStatusProperties {
+export type JobStatusProperties = {
   action?: string;
   createdAt?: Date;
   jobStatusId?: string;
   status?: string;
-}
+};
 
 export default class JobStatus extends RestfulModel
   implements JobStatusProperties {

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -3,10 +3,10 @@ import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
 import Model from './model';
 
-export interface ApplicationIPAddressesProperties {
+export type ApplicationIPAddressesProperties = {
   ipAddresses: string[];
   updatedAt: number;
-}
+};
 
 export class ApplicationIPAddresses extends Model
   implements ApplicationIPAddressesProperties {
@@ -29,12 +29,12 @@ ApplicationIPAddresses.attributes = {
   }),
 };
 
-export interface AccountTokenInfoProperties {
+export type AccountTokenInfoProperties = {
   scopes: string;
   state: string;
   createdAt: number;
   updatedAt: number;
-}
+};
 
 export class AccountTokenInfo extends Model
   implements AccountTokenInfoProperties {
@@ -65,14 +65,14 @@ AccountTokenInfo.attributes = {
   }),
 };
 
-export interface ManagementAccountProperties {
+export type ManagementAccountProperties = {
   billingState: string;
   emailAddress: string;
   namespaceId: string;
   provider: string;
   syncState: string;
   trial: boolean;
-}
+};
 
 export type AccountOperationResponse = {
   success: boolean;

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -8,7 +8,8 @@ export interface ApplicationIPAddressesProperties {
   updatedAt: number;
 }
 
-export class ApplicationIPAddresses extends Model implements ApplicationIPAddressesProperties {
+export class ApplicationIPAddresses extends Model
+  implements ApplicationIPAddressesProperties {
   ipAddresses = [];
   updatedAt = 0;
 
@@ -26,7 +27,7 @@ ApplicationIPAddresses.attributes = {
     modelKey: 'updatedAt',
     jsonKey: 'updated_at',
   }),
-}
+};
 
 export interface AccountTokenInfoProperties {
   scopes: string;
@@ -35,7 +36,8 @@ export interface AccountTokenInfoProperties {
   updatedAt: number;
 }
 
-export class AccountTokenInfo extends Model implements AccountTokenInfoProperties {
+export class AccountTokenInfo extends Model
+  implements AccountTokenInfoProperties {
   scopes = '';
   state = '';
   createdAt = 0;
@@ -61,7 +63,7 @@ AccountTokenInfo.attributes = {
     modelKey: 'updatedAt',
     jsonKey: 'updated_at',
   }),
-}
+};
 
 export interface ManagementAccountProperties {
   billingState: string;
@@ -74,7 +76,7 @@ export interface ManagementAccountProperties {
 
 export type AccountOperationResponse = {
   success: boolean;
-}
+};
 
 export default class ManagementAccount extends ManagementModel
   implements ManagementAccountProperties {
@@ -137,7 +139,9 @@ export default class ManagementAccount extends ManagementModel
         method: 'GET',
         path: `/a/${this.clientId}/ip_addresses`,
       })
-      .then(json => Promise.resolve(new ApplicationIPAddresses().fromJSON(json)))
+      .then(json =>
+        Promise.resolve(new ApplicationIPAddresses().fromJSON(json))
+      )
       .catch(err => Promise.reject(err));
   }
 

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -22,7 +22,7 @@ export default class ManagementModelCollection<
     return super.build(args);
   }
 
-  protected createModel(json: { [key: string]: any }) {
+  protected createModel(json: { [key: string]: any }): T {
     const props = this.modelClass.propsFromJSON(json, this);
     return new (this.modelClass as any)(this.connection, this.clientId, props);
   }

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -18,11 +18,11 @@ export default class ManagementModelCollection<
     this.path = `/a/${this.clientId}/${this.modelClass.collectionName}`;
   }
 
-  build(args: { [key: string]: any }): T {
+  build(args: Record<string, any>): T {
     return super.build(args);
   }
 
-  protected createModel(json: { [key: string]: any }): T {
+  protected createModel(json: Record<string, any>): T {
     const props = this.modelClass.propsFromJSON(json, this);
     return new (this.modelClass as any)(this.connection, this.clientId, props);
   }

--- a/src/models/management-model-collection.ts
+++ b/src/models/management-model-collection.ts
@@ -18,11 +18,11 @@ export default class ManagementModelCollection<
     this.path = `/a/${this.clientId}/${this.modelClass.collectionName}`;
   }
 
-  build(args: Record<string, any>): T {
+  build(args: Record<string, unknown>): T {
     return super.build(args);
   }
 
-  protected createModel(json: Record<string, any>): T {
+  protected createModel(json: Record<string, unknown>): T {
     const props = this.modelClass.propsFromJSON(json, this);
     return new (this.modelClass as any)(this.connection, this.clientId, props);
   }

--- a/src/models/management-model.ts
+++ b/src/models/management-model.ts
@@ -7,7 +7,7 @@ export default class ManagementModel extends RestfulModel {
   constructor(
     connection: NylasConnection,
     clientId: string,
-    props: Record<string, any>
+    props: Record<string, unknown>
   ) {
     super(connection, props);
     this.clientId = clientId;

--- a/src/models/management-model.ts
+++ b/src/models/management-model.ts
@@ -7,7 +7,7 @@ export default class ManagementModel extends RestfulModel {
   constructor(
     connection: NylasConnection,
     clientId: string,
-    props: { [key: string]: any }
+    props: Record<string, any>
   ) {
     super(connection, props);
     this.clientId = clientId;

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -25,7 +25,7 @@ export interface MessageProperties {
   events?: EventProperties[];
   folder?: Folder;
   labels?: FolderProperties[];
-  headers?: { [key: string]: string };
+  headers?: Record<string, string>;
   failures?: any;
 }
 
@@ -46,7 +46,7 @@ export default class Message extends RestfulModel implements MessageProperties {
   events?: Event[];
   folder?: Folder;
   labels?: Label[];
-  headers?: { [key: string]: string };
+  headers?: Record<string, string>;
   failures?: any;
 
   constructor(connection: NylasConnection, props?: MessageProperties) {
@@ -58,7 +58,7 @@ export default class Message extends RestfulModel implements MessageProperties {
   // a parent because it is a better source of ground truth, and saves us
   // from more dependencies.
   participants(): EmailParticipant[] {
-    const participants: { [key: string]: EmailParticipant } = {};
+    const participants: Record<string, EmailParticipant> = {};
     const to = this.to || [];
     const cc = this.cc || [];
     const from = this.from || [];
@@ -91,14 +91,14 @@ export default class Message extends RestfulModel implements MessageProperties {
       .catch(err => Promise.reject(err));
   }
 
-  saveRequestBody(): { [key: string]: any } {
+  saveRequestBody(): Record<string, any> {
     // It's possible to update most of the fields of a draft.
     if (this.constructor.name === 'Draft') {
       return super.saveRequestBody();
     }
 
     // Messages are more limited, though.
-    const json: { [key: string]: any } = {};
+    const json: Record<string, any> = {};
     if (this.labels) {
       json['label_ids'] = Array.from(this.labels).map(label => label.id);
     } else if (this.folder) {

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -57,7 +57,7 @@ export default class Message extends RestfulModel implements MessageProperties {
   // We calculate the list of participants instead of grabbing it from
   // a parent because it is a better source of ground truth, and saves us
   // from more dependencies.
-  participants() {
+  participants(): EmailParticipant[] {
     const participants: { [key: string]: EmailParticipant } = {};
     const to = this.to || [];
     const cc = this.cc || [];
@@ -75,11 +75,11 @@ export default class Message extends RestfulModel implements MessageProperties {
     return Object.values(participants);
   }
 
-  fileIds() {
+  fileIds(): (string | undefined)[] {
     return this.files ? this.files.map(file => file.id) : [];
   }
 
-  getRaw() {
+  getRaw(): Promise<string> {
     return this.connection
       .request({
         method: 'GET',
@@ -91,7 +91,7 @@ export default class Message extends RestfulModel implements MessageProperties {
       .catch(err => Promise.reject(err));
   }
 
-  saveRequestBody() {
+  saveRequestBody(): { [key: string]: any } {
     // It's possible to update most of the fields of a draft.
     if (this.constructor.name === 'Draft') {
       return super.saveRequestBody();
@@ -108,10 +108,6 @@ export default class Message extends RestfulModel implements MessageProperties {
     json['starred'] = this.starred;
     json['unread'] = this.unread;
     return json;
-  }
-
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
-    return super.save(params, callback);
   }
 }
 Message.collectionName = 'messages';

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -8,7 +8,7 @@ import EmailParticipant, {
 import { Label, Folder, FolderProperties } from './folder';
 import NylasConnection from '../nylas-connection';
 
-export interface MessageProperties {
+export type MessageProperties = {
   to: EmailParticipantProperties[];
   subject?: string;
   from?: EmailParticipantProperties[];
@@ -26,8 +26,7 @@ export interface MessageProperties {
   folder?: Folder;
   labels?: FolderProperties[];
   headers?: Record<string, string>;
-  failures?: any;
-}
+};
 
 export default class Message extends RestfulModel implements MessageProperties {
   to = [];
@@ -47,7 +46,6 @@ export default class Message extends RestfulModel implements MessageProperties {
   folder?: Folder;
   labels?: Label[];
   headers?: Record<string, string>;
-  failures?: any;
 
   constructor(connection: NylasConnection, props?: MessageProperties) {
     super(connection, props);
@@ -91,14 +89,14 @@ export default class Message extends RestfulModel implements MessageProperties {
       .catch(err => Promise.reject(err));
   }
 
-  saveRequestBody(): Record<string, any> {
+  saveRequestBody(): Record<string, unknown> {
     // It's possible to update most of the fields of a draft.
     if (this.constructor.name === 'Draft') {
       return super.saveRequestBody();
     }
 
     // Messages are more limited, though.
-    const json: Record<string, any> = {};
+    const json: Record<string, unknown> = {};
     if (this.labels) {
       json['label_ids'] = Array.from(this.labels).map(label => label.id);
     } else if (this.folder) {

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -23,7 +23,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   forEach(
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     eachCallback: (item: T) => void,
     completeCallback?: (err?: Error | null | undefined) => void
   ): void {
@@ -65,7 +65,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   list(
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (error: Error | null, obj?: T[]) => void
   ): Promise<T[]> {
     if (params.view == 'count') {
@@ -83,8 +83,8 @@ export default class ModelCollection<T extends Model> {
 
   find(
     id: string,
-    paramsArg?: { [key: string]: any } | GetCallback | null,
-    callbackArg?: GetCallback | { [key: string]: any } | null
+    paramsArg?: Record<string, any> | GetCallback | null,
+    callbackArg?: GetCallback | Record<string, any> | null
   ): Promise<T> {
     // callback used to be the second argument, and params was the third
     let callback: GetCallback | undefined;
@@ -94,7 +94,7 @@ export default class ModelCollection<T extends Model> {
       callback = paramsArg as GetCallback;
     }
 
-    let params: { [key: string]: any } = {};
+    let params: Record<string, any> = {};
     if (paramsArg && typeof paramsArg === 'object') {
       params = paramsArg;
     } else if (callbackArg && typeof callbackArg === 'object') {
@@ -141,7 +141,7 @@ export default class ModelCollection<T extends Model> {
     callback,
     path,
   }: {
-    params?: { [key: string]: any };
+    params?: Record<string, any>;
     offset?: number;
     limit?: number;
     callback?: (error: Error | null, results?: T[]) => void;
@@ -186,7 +186,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   protected getItems(
-    params: { [key: string]: any },
+    params: Record<string, any>,
     offset: number,
     limit: number,
     path?: string
@@ -208,14 +208,11 @@ export default class ModelCollection<T extends Model> {
     return this.getModelCollection(params, offset, limit, path);
   }
 
-  protected createModel(json: { [key: string]: any }): T {
+  protected createModel(json: Record<string, any>): T {
     return new this.modelClass().fromJSON(json) as T;
   }
 
-  private getModel(
-    id: string,
-    params: { [key: string]: any } = {}
-  ): Promise<T> {
+  private getModel(id: string, params: Record<string, any> = {}): Promise<T> {
     return this.connection
       .request({
         method: 'GET',
@@ -229,7 +226,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   private getModelCollection(
-    params: { [key: string]: any },
+    params: Record<string, any>,
     offset: number,
     limit: number,
     path: string

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -23,7 +23,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   forEach(
-    params: Record<string, any> = {},
+    params: Record<string, unknown> = {},
     eachCallback: (item: T) => void,
     completeCallback?: (err?: Error | null | undefined) => void
   ): void {
@@ -65,7 +65,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   list(
-    params: Record<string, any> = {},
+    params: Record<string, unknown> = {},
     callback?: (error: Error | null, obj?: T[]) => void
   ): Promise<T[]> {
     if (params.view == 'count') {
@@ -76,15 +76,15 @@ export default class ModelCollection<T extends Model> {
       return Promise.reject(err);
     }
 
-    const limit = params.limit || Infinity;
-    const offset = params.offset;
+    const limit = (params.limit as number) || Infinity;
+    const offset = params.offset as number;
     return this.range({ params, offset, limit, callback });
   }
 
   find(
     id: string,
-    paramsArg?: Record<string, any> | GetCallback | null,
-    callbackArg?: GetCallback | Record<string, any> | null
+    paramsArg?: Record<string, unknown> | GetCallback | null,
+    callbackArg?: GetCallback | Record<string, unknown> | null
   ): Promise<T> {
     // callback used to be the second argument, and params was the third
     let callback: GetCallback | undefined;
@@ -94,7 +94,7 @@ export default class ModelCollection<T extends Model> {
       callback = paramsArg as GetCallback;
     }
 
-    let params: Record<string, any> = {};
+    let params: Record<string, unknown> = {};
     if (paramsArg && typeof paramsArg === 'object') {
       params = paramsArg;
     } else if (callbackArg && typeof callbackArg === 'object') {
@@ -141,7 +141,7 @@ export default class ModelCollection<T extends Model> {
     callback,
     path,
   }: {
-    params?: Record<string, any>;
+    params?: Record<string, unknown>;
     offset?: number;
     limit?: number;
     callback?: (error: Error | null, results?: T[]) => void;
@@ -186,7 +186,7 @@ export default class ModelCollection<T extends Model> {
   }
 
   protected getItems(
-    params: Record<string, any>,
+    params: Record<string, unknown>,
     offset: number,
     limit: number,
     path?: string
@@ -208,25 +208,28 @@ export default class ModelCollection<T extends Model> {
     return this.getModelCollection(params, offset, limit, path);
   }
 
-  protected createModel(json: Record<string, any>): T {
+  protected createModel(json: Record<string, unknown>): T {
     return new this.modelClass().fromJSON(json) as T;
   }
 
-  private getModel(id: string, params: Record<string, any> = {}): Promise<T> {
+  private getModel(
+    id: string,
+    params: Record<string, unknown> = {}
+  ): Promise<T> {
     return this.connection
       .request({
         method: 'GET',
         path: `${this.path}/${id}`,
         qs: params,
       })
-      .then((json: any) => {
+      .then(json => {
         const model = this.createModel(json);
         return Promise.resolve(model);
       });
   }
 
   private getModelCollection(
-    params: Record<string, any>,
+    params: Record<string, unknown>,
     offset: number,
     limit: number,
     path: string
@@ -237,8 +240,8 @@ export default class ModelCollection<T extends Model> {
         path,
         qs: { ...params, offset, limit },
       })
-      .then((jsonArray: any) => {
-        const models = jsonArray.map((json: any) => {
+      .then((jsonArray: []) => {
+        const models = jsonArray.map(json => {
           return this.createModel(json);
         });
         return Promise.resolve(models);

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -7,14 +7,10 @@ const REQUEST_CHUNK_SIZE = 100;
 
 export default class ModelCollection<T extends Model> {
   connection: NylasConnection;
-  modelClass: typeof Model;
+  modelClass: any;
   path: string;
 
-  constructor(
-    modelClass: typeof Model,
-    connection: NylasConnection,
-    path: string
-  ) {
+  constructor(modelClass: any, connection: NylasConnection, path: string) {
     this.modelClass = modelClass;
     this.connection = connection;
     this.path = path;

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -6,10 +6,10 @@ export default class Model {
   static attributes: Record<string, Attribute>;
 
   static propsFromJSON(
-    json: Record<string, any>,
-    parent: any
-  ): Record<string, any> {
-    const props: Record<string, any> = {};
+    json: Record<string, unknown>,
+    parent: unknown
+  ): Record<string, unknown> {
+    const props: Record<string, unknown> = {};
     for (const attrName in this.attributes) {
       const attr = this.attributes[attrName];
       if (json[attr.jsonKey] !== undefined) {
@@ -24,7 +24,7 @@ export default class Model {
   }
 
   //TODO::Maybe come up with a better name?
-  initAttributes(props?: Record<string, any>): void {
+  initAttributes(props?: Record<string, unknown>): void {
     const attributes = this.attributes();
     for (const prop in props) {
       if (props.hasOwnProperty(prop)) {
@@ -36,7 +36,7 @@ export default class Model {
     }
   }
 
-  fromJSON(json: Record<string, any>): any {
+  fromJSON(json: Record<string, unknown>): this {
     const attributes = this.attributes();
     for (const attrName in attributes) {
       const attr = attributes[attrName];
@@ -47,8 +47,8 @@ export default class Model {
     return this;
   }
 
-  toJSON(enforceReadOnly?: boolean): Record<string, any> {
-    const json: any = {};
+  toJSON(enforceReadOnly?: boolean): Record<string, unknown> {
+    const json: Record<string, unknown> = {};
     const attributes = this.attributes();
     for (const attrName in attributes) {
       if (!enforceReadOnly || !attributes[attrName].readOnly) {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -36,7 +36,7 @@ export default class Model {
     }
   }
 
-  fromJSON(json: { [key: string]: any }): this {
+  fromJSON(json: { [key: string]: any }): any {
     const attributes = this.attributes();
     for (const attrName in attributes) {
       const attr = attributes[attrName];

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -36,7 +36,7 @@ export default class Model {
     }
   }
 
-  fromJSON(json?: any): this {
+  fromJSON(json: { [key: string]: any }): this {
     const attributes = this.attributes();
     for (const attrName in attributes) {
       const attr = attributes[attrName];
@@ -47,7 +47,7 @@ export default class Model {
     return this;
   }
 
-  toJSON(enforceReadOnly?: boolean): any {
+  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
     const json: any = {};
     const attributes = this.attributes();
     for (const attrName in attributes) {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -3,13 +3,13 @@ import { Attribute } from './attributes';
 export type SaveCallback = (error: Error | null, result?: any) => void;
 
 export default class Model {
-  static attributes: { [key: string]: Attribute };
+  static attributes: Record<string, Attribute>;
 
   static propsFromJSON(
-    json: { [key: string]: any },
+    json: Record<string, any>,
     parent: any
-  ): { [key: string]: any } {
-    const props: { [key: string]: any } = {};
+  ): Record<string, any> {
+    const props: Record<string, any> = {};
     for (const attrName in this.attributes) {
       const attr = this.attributes[attrName];
       if (json[attr.jsonKey] !== undefined) {
@@ -19,12 +19,12 @@ export default class Model {
     return props;
   }
 
-  attributes(): { [key: string]: Attribute } {
+  attributes(): Record<string, Attribute> {
     return (this.constructor as any).attributes;
   }
 
   //TODO::Maybe come up with a better name?
-  initAttributes(props?: { [key: string]: any }): void {
+  initAttributes(props?: Record<string, any>): void {
     const attributes = this.attributes();
     for (const prop in props) {
       if (props.hasOwnProperty(prop)) {
@@ -36,7 +36,7 @@ export default class Model {
     }
   }
 
-  fromJSON(json: { [key: string]: any }): any {
+  fromJSON(json: Record<string, any>): any {
     const attributes = this.attributes();
     for (const attrName in attributes) {
       const attr = attributes[attrName];
@@ -47,7 +47,7 @@ export default class Model {
     return this;
   }
 
-  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
+  toJSON(enforceReadOnly?: boolean): Record<string, any> {
     const json: any = {};
     const attributes = this.attributes();
     for (const attrName in attributes) {

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -3,12 +3,12 @@ import Message, { MessageProperties } from './message';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
 
-export interface CategorizeProperties {
+export type CategorizeProperties = {
   category: string;
   categorizedAt: Date;
   modelVersion: string;
   subcategories: string[];
-}
+};
 
 export class Categorize extends Model implements CategorizeProperties {
   category = '';
@@ -39,9 +39,9 @@ Categorize.attributes = {
   }),
 };
 
-export interface NeuralCategorizerProperties extends MessageProperties {
+export type NeuralCategorizerProperties = MessageProperties & {
   categorizer: Categorize;
-}
+};
 
 export default class NeuralCategorizer extends Message
   implements NeuralCategorizerProperties {

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -20,15 +20,6 @@ export class Categorize extends Model implements CategorizeProperties {
     super();
     this.initAttributes(props);
   }
-
-  toJSON() {
-    return {
-      category: this.category,
-      categorized_at: this.categorizedAt,
-      model_version: this.modelVersion,
-      subcategories: this.subcategories,
-    };
-  }
 }
 
 Categorize.attributes = {

--- a/src/models/neural-clean-conversation.ts
+++ b/src/models/neural-clean-conversation.ts
@@ -5,10 +5,10 @@ import NylasConnection from '../nylas-connection';
 
 const IMAGE_REGEX = /[(']cid:(.)*[)']/g;
 
-export interface NeuralCleanConversationProperties extends MessageProperties {
+export type NeuralCleanConversationProperties = MessageProperties & {
   conversation: string;
   modelVersion: string;
-}
+};
 
 export default class NeuralCleanConversation extends Message
   implements NeuralCleanConversationProperties {

--- a/src/models/neural-ocr.ts
+++ b/src/models/neural-ocr.ts
@@ -2,10 +2,10 @@ import Attributes from './attributes';
 import File, { FileProperties } from './file';
 import NylasConnection from '../nylas-connection';
 
-export interface NeuralOcrProperties extends FileProperties {
+export type NeuralOcrProperties = FileProperties & {
   ocr: string[];
   processedPages: number;
-}
+};
 
 export default class NeuralOcr extends File implements NeuralOcrProperties {
   ocr = [];

--- a/src/models/neural-sentiment-analysis.ts
+++ b/src/models/neural-sentiment-analysis.ts
@@ -2,13 +2,13 @@ import Attributes from './attributes';
 import RestfulModel from './restful-model';
 import NylasConnection from '../nylas-connection';
 
-export interface NeuralSentimentAnalysisProperties {
+export type NeuralSentimentAnalysisProperties = {
   accountId: string;
   sentiment: string;
   sentimentScore: number;
   processedLength: number;
   text: string;
-}
+};
 
 export default class NeuralSentimentAnalysis extends RestfulModel
   implements NeuralSentimentAnalysisProperties {

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -88,7 +88,7 @@ export default class NeuralSignatureContact extends Model
     this.initAttributes(props);
   }
 
-  toJSON(): { [key: string]: any } {
+  toJSON(): Record<string, any> {
     return {
       job_titles: this.jobTitles,
       links: this.links,

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -3,10 +3,10 @@ import { Contact, EmailAddress, PhoneNumber, WebPage } from './contact';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
 
-interface LinkProperties {
+type LinkProperties = {
   description?: string;
   url?: string;
-}
+};
 
 class Link extends Model implements LinkProperties {
   description = '';
@@ -15,13 +15,6 @@ class Link extends Model implements LinkProperties {
   constructor(props?: LinkProperties) {
     super();
     this.initAttributes(props);
-  }
-
-  toJSON() {
-    return {
-      description: this.description,
-      url: this.url,
-    };
   }
 }
 
@@ -34,10 +27,10 @@ Link.attributes = {
   }),
 };
 
-interface NameProperties {
+type NameProperties = {
   firstName?: string;
   lastName?: string;
-}
+};
 
 class Name extends Model implements NameProperties {
   firstName = '';
@@ -46,13 +39,6 @@ class Name extends Model implements NameProperties {
   constructor(props?: NameProperties) {
     super();
     this.initAttributes(props);
-  }
-
-  toJSON() {
-    return {
-      type: this.firstName,
-      email: this.lastName,
-    };
   }
 }
 
@@ -67,13 +53,13 @@ Name.attributes = {
   }),
 };
 
-export interface NeuralSignatureContactProperties {
+export type NeuralSignatureContactProperties = {
   jobTitles?: string[];
   links?: Link[];
   phoneNumbers?: string[];
   emails?: string[];
   names?: Name[];
-}
+};
 
 export default class NeuralSignatureContact extends Model
   implements NeuralSignatureContactProperties {
@@ -88,7 +74,7 @@ export default class NeuralSignatureContact extends Model
     this.initAttributes(props);
   }
 
-  toJSON(): Record<string, any> {
+  toJSON(): Record<string, unknown> {
     return {
       job_titles: this.jobTitles,
       links: this.links,

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -88,7 +88,7 @@ export default class NeuralSignatureContact extends Model
     this.initAttributes(props);
   }
 
-  toJSON() {
+  toJSON(): { [key: string]: any } {
     return {
       job_titles: this.jobTitles,
       links: this.links,

--- a/src/models/neural-signature-extraction.ts
+++ b/src/models/neural-signature-extraction.ts
@@ -3,11 +3,11 @@ import Attributes from './attributes';
 import Message, { MessageProperties } from './message';
 import NylasConnection from '../nylas-connection';
 
-export interface NeuralSignatureExtractionProperties extends MessageProperties {
+export type NeuralSignatureExtractionProperties = MessageProperties & {
   signature: string;
   modelVersion: string;
   contacts?: NeuralSignatureContact;
-}
+};
 
 export default class NeuralSignatureExtraction extends Message
   implements NeuralSignatureExtractionProperties {

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -7,14 +7,14 @@ import NeuralCleanConversation from './neural-clean-conversation';
 import Model from './model';
 import Attributes from './attributes';
 
-export interface NeuralMessageOptionsProperties {
+export type NeuralMessageOptionsProperties = {
   ignoreLinks?: boolean;
   ignoreImages?: boolean;
   ignoreTables?: boolean;
   removeConclusionPhrases?: boolean;
   imagesAsMarkdown?: boolean;
   parseContacts?: boolean;
-}
+};
 
 export class NeuralMessageOptions extends Model
   implements NeuralMessageOptionsProperties {
@@ -31,7 +31,7 @@ export class NeuralMessageOptions extends Model
   }
 
   toJSON(writeParseContact?: boolean): Record<string, boolean> {
-    const body: Record<string, boolean> = super.toJSON();
+    const body = super.toJSON() as Record<string, boolean>;
     if (writeParseContact !== true) {
       delete body['parse_contacts'];
     }
@@ -72,8 +72,8 @@ export default class Neural extends RestfulModel {
     const body = { message_id: messageIds };
     const path = 'sentiment';
 
-    return this.request(path, body).then((jsonArray: any) => {
-      return jsonArray.map((json: any) => {
+    return this.request(path, body).then((jsonArray: []) => {
+      return jsonArray.map(json => {
         return new NeuralSentimentAnalysis(this.connection).fromJSON(json);
       });
     });
@@ -92,7 +92,7 @@ export default class Neural extends RestfulModel {
     messageIds: string[],
     options?: NeuralMessageOptionsProperties
   ): Promise<NeuralSignatureExtraction[]> {
-    let body: Record<string, any> = { message_id: messageIds };
+    let body: Record<string, unknown> = { message_id: messageIds };
     const path = 'signature';
 
     if (options) {
@@ -102,15 +102,15 @@ export default class Neural extends RestfulModel {
       };
     }
 
-    return this.request(path, body).then((jsonArray: any) => {
-      return jsonArray.map((json: any) => {
+    return this.request(path, body).then((jsonArray: []) => {
+      return jsonArray.map(json => {
         return new NeuralSignatureExtraction(this.connection).fromJSON(json);
       });
     });
   }
 
   ocrRequest(fileId: string, pages?: number[]): Promise<NeuralOcr> {
-    const body: Record<string, any> = { file_id: fileId };
+    const body: Record<string, string | number[]> = { file_id: fileId };
     const path = 'ocr';
 
     if (pages) {
@@ -126,8 +126,8 @@ export default class Neural extends RestfulModel {
     const body = { message_id: messageIds };
     const path = 'categorize';
 
-    return this.request(path, body).then((jsonArray: any) => {
-      return jsonArray.map((json: any) => {
+    return this.request(path, body).then((jsonArray: []) => {
+      return jsonArray.map(json => {
         return new NeuralCategorizer(this.connection).fromJSON(json);
       });
     });
@@ -137,7 +137,7 @@ export default class Neural extends RestfulModel {
     messageIds: string[],
     options?: NeuralMessageOptionsProperties
   ): Promise<NeuralCleanConversation[]> {
-    let body: Record<string, any> = { message_id: messageIds };
+    let body: Record<string, unknown> = { message_id: messageIds };
     const path = 'conversation';
 
     if (options) {
@@ -147,8 +147,8 @@ export default class Neural extends RestfulModel {
       };
     }
 
-    return this.request(path, body).then((jsonArray: any) => {
-      return jsonArray.map((json: any) => {
+    return this.request(path, body).then((jsonArray: []) => {
+      return jsonArray.map(json => {
         return new NeuralCleanConversation(this.connection).fromJSON(json);
       });
     });

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -30,8 +30,8 @@ export class NeuralMessageOptions extends Model
     this.initAttributes(props);
   }
 
-  toJSON(writeParseContact?: boolean): { [key: string]: boolean } {
-    const body: { [key: string]: boolean } = super.toJSON();
+  toJSON(writeParseContact?: boolean): Record<string, boolean> {
+    const body: Record<string, boolean> = super.toJSON();
     if (writeParseContact !== true) {
       delete body['parse_contacts'];
     }
@@ -92,7 +92,7 @@ export default class Neural extends RestfulModel {
     messageIds: string[],
     options?: NeuralMessageOptionsProperties
   ): Promise<NeuralSignatureExtraction[]> {
-    let body: { [key: string]: any } = { message_id: messageIds };
+    let body: Record<string, any> = { message_id: messageIds };
     const path = 'signature';
 
     if (options) {
@@ -110,7 +110,7 @@ export default class Neural extends RestfulModel {
   }
 
   ocrRequest(fileId: string, pages?: number[]): Promise<NeuralOcr> {
-    const body: { [key: string]: any } = { file_id: fileId };
+    const body: Record<string, any> = { file_id: fileId };
     const path = 'ocr';
 
     if (pages) {
@@ -137,7 +137,7 @@ export default class Neural extends RestfulModel {
     messageIds: string[],
     options?: NeuralMessageOptionsProperties
   ): Promise<NeuralCleanConversation[]> {
-    let body: { [key: string]: any } = { message_id: messageIds };
+    let body: Record<string, any> = { message_id: messageIds };
     const path = 'conversation';
 
     if (options) {

--- a/src/models/nylas-api-error.ts
+++ b/src/models/nylas-api-error.ts
@@ -22,7 +22,7 @@ export default class NylasApiError extends Error {
    * For more details on what each status code means head to
    * https://developer.nylas.com/docs/developer-tools/api/errors/
    */
-  errorMapping: { [statusCode: number]: string } = {
+  errorMapping: Record<number, string> = {
     400: 'Bad Request',
     401: 'Unauthorized',
     402: 'Request Failed or Payment Required',

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -2,14 +2,14 @@ import RestfulModel from './restful-model';
 import Attributes from './attributes';
 import NylasConnection from '../nylas-connection';
 
-export interface ResourceProperties {
+export type ResourceProperties = {
   email: string;
   name: string;
   capacity: string;
   building: string;
   floorNumber: string;
   floorName?: string;
-}
+};
 
 export default class Resource extends RestfulModel {
   email = '';

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -18,7 +18,7 @@ export default class RestfulModelCollection<
   }
 
   count(
-    params: Record<string, any> = {},
+    params: Record<string, unknown> = {},
     callback?: (err: Error | null, num?: number) => void
   ): Promise<number> {
     return this.connection
@@ -42,7 +42,7 @@ export default class RestfulModelCollection<
   }
 
   first(
-    params: Record<string, any> = {},
+    params: Record<string, unknown> = {},
     callback?: (error: Error | null, model?: T) => void
   ): Promise<T> {
     if (params.view == 'count') {
@@ -70,7 +70,7 @@ export default class RestfulModelCollection<
 
   search(
     query: string,
-    params: Record<string, any> = {},
+    params: Record<string, unknown> = {},
     callback?: (error: Error | null) => void
   ): Promise<T[]> {
     if (this.modelClass != Message && this.modelClass != Thread) {
@@ -92,8 +92,8 @@ export default class RestfulModelCollection<
     }
 
     params.q = query;
-    const limit = params.limit || 40;
-    const offset = params.offset;
+    const limit = (params.limit as number) || 40;
+    const offset = params.offset as number;
     const path = `${this.path}/search`;
 
     return this.range({ params, offset, limit, path });
@@ -101,7 +101,7 @@ export default class RestfulModelCollection<
 
   delete(
     itemOrId: T | string,
-    params: Record<string, any> = {},
+    params: Record<string, unknown> = {},
     callback?: (error: Error | null) => void
   ): any {
     if (!itemOrId) {
@@ -161,7 +161,7 @@ export default class RestfulModelCollection<
       });
   }
 
-  protected build(args: Record<string, any>): T {
+  protected build(args: Record<string, unknown>): T {
     const model = this.createModel({});
     for (const key in args) {
       (model as any)[key] = args[key];
@@ -169,7 +169,7 @@ export default class RestfulModelCollection<
     return model;
   }
 
-  protected createModel(json: Record<string, any>): T {
+  protected createModel(json: Record<string, unknown>): T {
     return new this.modelClass(this.connection).fromJSON(json) as T;
   }
 }

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -18,7 +18,7 @@ export default class RestfulModelCollection<
   }
 
   count(
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (err: Error | null, num?: number) => void
   ): Promise<number> {
     return this.connection
@@ -42,7 +42,7 @@ export default class RestfulModelCollection<
   }
 
   first(
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (error: Error | null, model?: T) => void
   ): Promise<T> {
     if (params.view == 'count') {
@@ -70,7 +70,7 @@ export default class RestfulModelCollection<
 
   search(
     query: string,
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (error: Error | null) => void
   ): Promise<T[]> {
     if (this.modelClass != Message && this.modelClass != Thread) {
@@ -101,7 +101,7 @@ export default class RestfulModelCollection<
 
   delete(
     itemOrId: T | string,
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (error: Error | null) => void
   ): any {
     if (!itemOrId) {
@@ -120,14 +120,14 @@ export default class RestfulModelCollection<
     const item =
       typeof itemOrId === 'string' ? this.build({ id: itemOrId }) : itemOrId;
 
-    const options: { [key: string]: any } = item.deleteRequestOptions(params);
+    const options: Record<string, any> = item.deleteRequestOptions(params);
     options.item = item;
 
     return this.deleteItem(options, callback);
   }
 
   deleteItem(
-    options: { [key: string]: any },
+    options: Record<string, any>,
     callbackArg?: (error: Error | null) => void
   ): any {
     const item = options.item;
@@ -161,7 +161,7 @@ export default class RestfulModelCollection<
       });
   }
 
-  protected build(args: { [key: string]: any }): T {
+  protected build(args: Record<string, any>): T {
     const model = this.createModel({});
     for (const key in args) {
       (model as any)[key] = args[key];
@@ -169,7 +169,7 @@ export default class RestfulModelCollection<
     return model;
   }
 
-  protected createModel(json: { [key: string]: any }): T {
+  protected createModel(json: Record<string, any>): T {
     return new this.modelClass(this.connection).fromJSON(json) as T;
   }
 }

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -164,8 +164,7 @@ export default class RestfulModelCollection<
   protected build(args: { [key: string]: any }): T {
     const model = this.createModel({});
     for (const key in args) {
-      const val = args[key];
-      (model as any)[key] = val;
+      (model as any)[key] = args[key];
     }
     return model;
   }

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -20,7 +20,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
     return `/${this.modelClass.endpointName}`;
   }
 
-  get(params: Record<string, any> = {}): Promise<T> {
+  get(params: Record<string, unknown> = {}): Promise<T> {
     return this.connection
       .request({
         method: 'GET',

--- a/src/models/restful-model-instance.ts
+++ b/src/models/restful-model-instance.ts
@@ -20,7 +20,7 @@ export default class RestfulModelInstance<T extends RestfulModel> {
     return `/${this.modelClass.endpointName}`;
   }
 
-  get(params: { [key: string]: any } = {}): Promise<T> {
+  get(params: Record<string, any> = {}): Promise<T> {
     return this.connection
       .request({
         method: 'GET',

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -12,8 +12,8 @@ interface RestfulModelJSON {
 }
 
 type requestOptions = {
-  body: { [key: string]: any };
-  qs: { [key: string]: any };
+  body: Record<string, any>;
+  qs: Record<string, any>;
 };
 
 export default class RestfulModel extends Model {
@@ -67,23 +67,21 @@ export default class RestfulModel extends Model {
 
   // saveRequestBody is used by save(). It returns a JSON dict containing only the
   // fields the API allows updating. Subclasses should override this method.
-  saveRequestBody(): { [key: string]: any } {
+  saveRequestBody(): Record<string, any> {
     return this.toJSON(true);
   }
 
   // deleteRequestQueryString is used by delete(). Subclasses should override this method.
-  deleteRequestQueryString(_params: {
-    [key: string]: any;
-  }): { [key: string]: any } {
+  deleteRequestQueryString(_params: Record<string, any>): Record<string, any> {
     return {};
   }
   // deleteRequestBody is used by delete(). Subclasses should override this method.
-  deleteRequestBody(_params: { [key: string]: any }): { [key: string]: any } {
+  deleteRequestBody(_params: Record<string, any>): Record<string, any> {
     return {};
   }
 
   // deleteRequestOptions is used by delete(). Subclasses should override this method.
-  deleteRequestOptions(params: { [key: string]: any }): requestOptions {
+  deleteRequestOptions(params: Record<string, any>): requestOptions {
     return {
       body: this.deleteRequestBody(params),
       qs: this.deleteRequestQueryString(params),
@@ -126,7 +124,7 @@ export default class RestfulModel extends Model {
   }
 
   protected get(
-    params: { [key: string]: any } = {},
+    params: Record<string, any> = {},
     callback?: (error: Error | null, result?: any) => void,
     pathSuffix = ''
   ): Promise<any> {

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -11,6 +11,11 @@ interface RestfulModelJSON {
   [key: string]: any;
 }
 
+type requestOptions = {
+  body: { [key: string]: any };
+  qs: { [key: string]: any };
+};
+
 export default class RestfulModel extends Model {
   static endpointName = ''; // overrridden in subclasses
   static collectionName = ''; // overrridden in subclasses
@@ -62,21 +67,23 @@ export default class RestfulModel extends Model {
 
   // saveRequestBody is used by save(). It returns a JSON dict containing only the
   // fields the API allows updating. Subclasses should override this method.
-  saveRequestBody(): any {
+  saveRequestBody(): { [key: string]: any } {
     return this.toJSON(true);
   }
 
   // deleteRequestQueryString is used by delete(). Subclasses should override this method.
-  deleteRequestQueryString(_params: { [key: string]: any }): any {
+  deleteRequestQueryString(_params: {
+    [key: string]: any;
+  }): { [key: string]: any } {
     return {};
   }
   // deleteRequestBody is used by delete(). Subclasses should override this method.
-  deleteRequestBody(_params: { [key: string]: any }): any {
+  deleteRequestBody(_params: { [key: string]: any }): { [key: string]: any } {
     return {};
   }
 
   // deleteRequestOptions is used by delete(). Subclasses should override this method.
-  deleteRequestOptions(params: { [key: string]: any }): any {
+  deleteRequestOptions(params: { [key: string]: any }): requestOptions {
     return {
       body: this.deleteRequestBody(params),
       qs: this.deleteRequestQueryString(params),
@@ -89,7 +96,7 @@ export default class RestfulModel extends Model {
   protected save(
     params: {} | SaveCallback = {},
     callback?: SaveCallback
-  ): Promise<this> {
+  ): Promise<any> {
     if (typeof params === 'function') {
       callback = params as SaveCallback;
       params = {};
@@ -104,11 +111,11 @@ export default class RestfulModel extends Model {
           : `${this.saveEndpoint()}`,
       })
       .then(json => {
-        this.fromJSON(json as RestfulModelJSON);
+        const newModel = this.fromJSON(json as RestfulModelJSON);
         if (callback) {
           callback(null, this);
         }
-        return Promise.resolve(this);
+        return Promise.resolve(newModel);
       })
       .catch(err => {
         if (callback) {

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -12,8 +12,8 @@ interface RestfulModelJSON {
 }
 
 type requestOptions = {
-  body: Record<string, any>;
-  qs: Record<string, any>;
+  body: Record<string, unknown>;
+  qs: Record<string, unknown>;
 };
 
 export default class RestfulModel extends Model {
@@ -39,7 +39,7 @@ export default class RestfulModel extends Model {
 
   static propsFromJSON(
     json: Partial<RestfulModelJSON> = {},
-    parent: any
+    parent: unknown
   ): Partial<RestfulModelJSON> {
     return super.propsFromJSON(json, parent);
   }
@@ -67,21 +67,23 @@ export default class RestfulModel extends Model {
 
   // saveRequestBody is used by save(). It returns a JSON dict containing only the
   // fields the API allows updating. Subclasses should override this method.
-  saveRequestBody(): Record<string, any> {
+  saveRequestBody(): Record<string, unknown> {
     return this.toJSON(true);
   }
 
   // deleteRequestQueryString is used by delete(). Subclasses should override this method.
-  deleteRequestQueryString(_params: Record<string, any>): Record<string, any> {
+  deleteRequestQueryString(
+    _params: Record<string, unknown>
+  ): Record<string, unknown> {
     return {};
   }
   // deleteRequestBody is used by delete(). Subclasses should override this method.
-  deleteRequestBody(_params: Record<string, any>): Record<string, any> {
+  deleteRequestBody(_params: Record<string, unknown>): Record<string, unknown> {
     return {};
   }
 
   // deleteRequestOptions is used by delete(). Subclasses should override this method.
-  deleteRequestOptions(params: Record<string, any>): requestOptions {
+  deleteRequestOptions(params: Record<string, unknown>): requestOptions {
     return {
       body: this.deleteRequestBody(params),
       qs: this.deleteRequestQueryString(params),
@@ -94,7 +96,7 @@ export default class RestfulModel extends Model {
   protected save(
     params: {} | SaveCallback = {},
     callback?: SaveCallback
-  ): Promise<any> {
+  ): Promise<this> {
     if (typeof params === 'function') {
       callback = params as SaveCallback;
       params = {};

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -51,12 +51,12 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
+  toJSON(enforceReadOnly?: boolean): Record<string, any> {
     return super.toJSON(enforceReadOnly);
   }
 
-  saveRequestBody(): { [key: string]: any } {
-    const json: { [key: string]: any } = {};
+  saveRequestBody(): Record<string, any> {
+    const json: Record<string, any> = {};
     if (this.labels) {
       json['label_ids'] = this.labels.map(label => label.id);
     } else if (this.folders && this.folders.length === 1) {

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -68,7 +68,10 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     return json;
   }
 
-  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Thread> {
+  save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<Thread> {
     return super.save(params, callback);
   }
 }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -51,11 +51,11 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean): ThreadProperties {
+  toJSON(enforceReadOnly?: boolean): { [key: string]: any } {
     return super.toJSON(enforceReadOnly);
   }
 
-  saveRequestBody() {
+  saveRequestBody(): { [key: string]: any } {
     const json: { [key: string]: any } = {};
     if (this.labels) {
       json['label_ids'] = this.labels.map(label => label.id);
@@ -68,7 +68,7 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     return json;
   }
 
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Thread> {
     return super.save(params, callback);
   }
 }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -7,7 +7,7 @@ import EmailParticipant, {
 import { Label, Folder, FolderProperties } from './folder';
 import NylasConnection from '../nylas-connection';
 
-export interface ThreadProperties {
+export type ThreadProperties = {
   subject: string;
   participants: EmailParticipantProperties[];
   lastMessageTimestamp: Date;
@@ -25,7 +25,7 @@ export interface ThreadProperties {
   draftIds?: string[];
   messages?: MessageProperties[];
   drafts?: MessageProperties[];
-}
+};
 
 export default class Thread extends RestfulModel implements ThreadProperties {
   subject = '';
@@ -51,12 +51,8 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     this.initAttributes(props);
   }
 
-  toJSON(enforceReadOnly?: boolean): Record<string, any> {
-    return super.toJSON(enforceReadOnly);
-  }
-
-  saveRequestBody(): Record<string, any> {
-    const json: Record<string, any> = {};
+  saveRequestBody(): Record<string, unknown> {
+    const json: Record<string, unknown> = {};
     if (this.labels) {
       json['label_ids'] = this.labels.map(label => label.id);
     } else if (this.folders && this.folders.length === 1) {
@@ -68,10 +64,7 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     return json;
   }
 
-  save(
-    params: {} | SaveCallback = {},
-    callback?: SaveCallback
-  ): Promise<Thread> {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     return super.save(params, callback);
   }
 }

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -33,8 +33,8 @@ export default class Webhook extends ManagementModel
   pathPrefix(): string {
     return `/a/${this.clientId}`;
   }
-  saveRequestBody(): { [key: string]: any } {
-    const json: { [key: string]: any } = {};
+  saveRequestBody(): Record<string, any> {
+    const json: Record<string, any> = {};
     // We can only update the state of an existing webhook
     if (this.id) {
       json['state'] = this.state;

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -30,10 +30,10 @@ export default class Webhook extends ManagementModel
     this.initAttributes(props);
   }
 
-  pathPrefix() {
+  pathPrefix(): string {
     return `/a/${this.clientId}`;
   }
-  saveRequestBody() {
+  saveRequestBody(): { [key: string]: any } {
     const json: { [key: string]: any } = {};
     // We can only update the state of an existing webhook
     if (this.id) {
@@ -45,7 +45,7 @@ export default class Webhook extends ManagementModel
     }
     return json;
   }
-  protected save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Webhook> {
     return super.save(params, callback);
   }
 }

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -45,7 +45,10 @@ export default class Webhook extends ManagementModel
     }
     return json;
   }
-  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<Webhook> {
+  save(
+    params: {} | SaveCallback = {},
+    callback?: SaveCallback
+  ): Promise<Webhook> {
     return super.save(params, callback);
   }
 }

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -3,14 +3,14 @@ import Attributes from './attributes';
 import { SaveCallback } from './restful-model';
 import NylasConnection from '../nylas-connection';
 
-export interface WebhookProperties {
+export type WebhookProperties = {
   callbackUrl: string;
   state: string;
   triggers: string[];
   id?: string;
   applicationId?: string;
   version?: string;
-}
+};
 
 export default class Webhook extends ManagementModel
   implements WebhookProperties {
@@ -33,8 +33,8 @@ export default class Webhook extends ManagementModel
   pathPrefix(): string {
     return `/a/${this.clientId}`;
   }
-  saveRequestBody(): Record<string, any> {
-    const json: Record<string, any> = {};
+  saveRequestBody(): Record<string, unknown> {
+    const json: Record<string, unknown> = {};
     // We can only update the state of an existing webhook
     if (this.id) {
       json['state'] = this.state;
@@ -45,10 +45,7 @@ export default class Webhook extends ManagementModel
     }
     return json;
   }
-  save(
-    params: {} | SaveCallback = {},
-    callback?: SaveCallback
-  ): Promise<Webhook> {
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
     return super.save(params, callback);
   }
 }

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -24,10 +24,6 @@ export default class When extends Model implements WhenProperties {
     super();
     this.initAttributes(props);
   }
-
-  toJSON(): WhenProperties {
-    return super.toJSON();
-  }
 }
 
 When.attributes = {

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -1,7 +1,7 @@
 import Model from './model';
 import Attributes from './attributes';
 
-export interface WhenProperties {
+export type WhenProperties = {
   startTime?: number;
   endTime?: number;
   time?: number;
@@ -9,7 +9,7 @@ export interface WhenProperties {
   endDate?: string;
   date?: string;
   object?: string;
-}
+};
 
 export default class When extends Model implements WhenProperties {
   startTime?: number;

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -27,18 +27,18 @@ const SUPPORTED_API_VERSION = '2.2';
 export type RequestOptions = {
   path: string;
   method?: string;
-  headers?: { [key: string]: string };
-  qs?: { [key: string]: any };
+  headers?: Record<string, string>;
+  qs?: Record<string, any>;
   downloadRequest?: boolean;
   json?: boolean;
-  formData?: { [key: string]: FormDataType };
+  formData?: Record<string, FormDataType>;
   body?: any;
   url?: URL;
 };
 
 export type FormDataType = {
   value: any;
-  options?: { [key: string]: any } | AppendOptions;
+  options?: Record<string, any> | AppendOptions;
 };
 
 export default class NylasConnection {
@@ -128,7 +128,7 @@ export default class NylasConnection {
     }
     options.url = url;
 
-    const headers = { ...options.headers };
+    const headers: Record<string, string> = { ...options.headers };
     const user =
       options.path.substr(0, 3) === '/a/'
         ? config.clientSecret
@@ -242,7 +242,7 @@ export default class NylasConnection {
                 .buffer()
                 .then(buffer => {
                   // Return an object with the headers and the body as a buffer
-                  const fileDetails: { [key: string]: any } = {};
+                  const fileDetails: Record<string, any> = {};
                   response.headers.forEach((v, k) => {
                     fileDetails[k] = v;
                   });

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -174,7 +174,10 @@ export default class NylasConnection {
     });
   }
 
-  private getWarningForVersion(sdkApiVersion?: string, apiVersion?: string): string {
+  private getWarningForVersion(
+    sdkApiVersion?: string,
+    apiVersion?: string
+  ): string {
     let warning = '';
 
     if (sdkApiVersion != apiVersion) {

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -174,7 +174,7 @@ export default class NylasConnection {
     });
   }
 
-  private getWarningForVersion(sdkApiVersion?: string, apiVersion?: string) {
+  private getWarningForVersion(sdkApiVersion?: string, apiVersion?: string): string {
     let warning = '';
 
     if (sdkApiVersion != apiVersion) {
@@ -197,7 +197,7 @@ export default class NylasConnection {
     return warning;
   }
 
-  request(options: RequestOptions) {
+  request(options: RequestOptions): Promise<any> {
     const req = this.newRequest(options);
     return new Promise<any>((resolve, reject) => {
       return fetch(req)

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -28,7 +28,7 @@ export type RequestOptions = {
   path: string;
   method?: string;
   headers?: Record<string, string>;
-  qs?: Record<string, any>;
+  qs?: Record<string, unknown>;
   downloadRequest?: boolean;
   json?: boolean;
   formData?: Record<string, FormDataType>;
@@ -37,8 +37,8 @@ export type RequestOptions = {
 };
 
 export type FormDataType = {
-  value: any;
-  options?: Record<string, any> | AppendOptions;
+  value: unknown;
+  options?: Record<string, unknown> | AppendOptions;
 };
 
 export default class NylasConnection {
@@ -114,15 +114,18 @@ export default class NylasConnection {
         } else if (key == 'metadata_pair') {
           // The API understands a metadata_pair filter in the form of:
           // <key>:<value>
-          for (const item in value) {
-            url.searchParams.set('metadata_pair', `${item}:${value[item]}`);
+          for (const item in value as Record<string, string>) {
+            url.searchParams.set(
+              'metadata_pair',
+              `${item}:${(value as Record<string, string>)[item]}`
+            );
           }
         } else if (Array.isArray(value)) {
           for (const item of value) {
             url.searchParams.append(key, item);
           }
         } else {
-          url.searchParams.set(key, value);
+          url.searchParams.set(key, value as string);
         }
       }
     }

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -73,7 +73,10 @@ class Nylas {
         this.clientId!
       ) as ManagementModelCollection<ManagementAccount>;
     } else {
-      this.accounts = new RestfulModelCollection(Account, conn);
+      this.accounts = new RestfulModelCollection(
+        Account,
+        conn
+      ) as RestfulModelCollection<Account>;
     }
 
     return this;


### PR DESCRIPTION
# Description
This PR is to address the Node SDK typing issues our customers have been experiencing. The biggest change we've made here is that all of the SDK methods that are meant to be used by the user for Nylas operations all have a non-any return type when possible.

In addition to this, the PR improves on the previous work of the refactor to ensure that we are utilizing the use of models, interfaces, and proper deserialization. With this, our support for Calendar availability has improved with the introduction of classes and types for API objects like free-busy and availability. Our support for Native Authentication and Virtual Calendars have also seen improvements as we have models to represent these objects and introduced enums to provide the user an easier time with providing things like providers and scopes without needing to refer to the API docs to see what scopes/providers are supported and to reduce user typing errors.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.