### PR TITLE
[66508] Add support consecutive availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add support for consecutive availability
 * Fix issue where JSON.stringify would omit read-only values
 * Fix webhook example throwing error if body is not a raw body
 

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -202,7 +202,7 @@ describe('CalendarRestfulModelCollection', () => {
           free_busy: [],
           open_hours: [
             {
-              emails: ['swag@nylas.com'],
+              emails: [{ name: 'Nylas', email: 'swag@nylas.com' }],
               days: ['0'],
               timezone: 'America/Chicago',
               start: '10:00',

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -173,16 +173,20 @@ describe('CalendarRestfulModelCollection', () => {
       interval: 5,
       duration: 30,
       emails: [['jane@email.com'], ['swag@nylas.com']],
-      free_busy: [{
-        email: 'jane@email.com',
-        object: 'free_busy',
-        time_slots: [{
-          object: "time_slots",
-          status: "busy",
-          start_time: 1590454800,
-          end_time: 1590780800,
-        }]
-      }],
+      free_busy: [
+        {
+          email: 'jane@email.com',
+          object: 'free_busy',
+          time_slots: [
+            {
+              object: 'time_slots',
+              status: 'busy',
+              start_time: 1590454800,
+              end_time: 1590780800,
+            },
+          ],
+        },
+      ],
       open_hours: [
         {
           emails: ['jane@email.com', 'swag@nylas.com'],
@@ -209,16 +213,20 @@ describe('CalendarRestfulModelCollection', () => {
           interval_minutes: 5,
           duration_minutes: 30,
           emails: [['jane@email.com'], ['swag@nylas.com']],
-          free_busy: [{
-            email: 'jane@email.com',
-            object: 'free_busy',
-            time_slots: [{
-              object: "time_slots",
-              status: "busy",
-              start_time: 1590454800,
-              end_time: 1590780800,
-            }]
-          }],
+          free_busy: [
+            {
+              email: 'jane@email.com',
+              object: 'free_busy',
+              time_slots: [
+                {
+                  object: 'time_slots',
+                  status: 'busy',
+                  start_time: 1590454800,
+                  end_time: 1590780800,
+                },
+              ],
+            },
+          ],
           open_hours: [
             {
               emails: ['jane@email.com', 'swag@nylas.com'],
@@ -246,16 +254,20 @@ describe('CalendarRestfulModelCollection', () => {
       interval: 5,
       duration: 30,
       emails: [['jane@email.com']],
-      free_busy: [{
-        email: 'jane@email.com',
-        object: 'free_busy',
-        time_slots: [{
-          object: "time_slots",
-          status: "busy",
-          start_time: 1590454800,
-          end_time: 1590780800,
-        }]
-      }],
+      free_busy: [
+        {
+          email: 'jane@email.com',
+          object: 'free_busy',
+          time_slots: [
+            {
+              object: 'time_slots',
+              status: 'busy',
+              start_time: 1590454800,
+              end_time: 1590780800,
+            },
+          ],
+        },
+      ],
       open_hours: [
         {
           emails: ['jane@email.com', 'swag@nylas.com'],
@@ -268,7 +280,9 @@ describe('CalendarRestfulModelCollection', () => {
       ],
     };
 
-    expect(() => testContext.connection.calendars.consecutiveAvailability(params)).toThrow();
+    expect(() =>
+      testContext.connection.calendars.consecutiveAvailability(params)
+    ).toThrow();
     done();
   });
 

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -175,7 +175,7 @@ describe('CalendarRestfulModelCollection', () => {
       emails: [{ name: 'Jane', email: 'jane@email.com' }],
       open_hours: [
         {
-          emails: ['swag@nylas.com'],
+          emails: [{ name: 'Nylas', email: 'swag@nylas.com' }],
           days: ['0'],
           timezone: 'America/Chicago',
           start: '10:00',

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -168,15 +168,15 @@ describe('CalendarRestfulModelCollection', () => {
 
   test('[CONSECUTIVE AVAILABILITY] should fetch results with params', done => {
     const params = {
-      startTime: '1590454800',
-      endTime: '1590780800',
+      startTime: 1590454800,
+      endTime: 1590780800,
       interval: 5,
       duration: 30,
-      emails: [{ name: 'Jane', email: 'jane@email.com' }],
+      emails: [['jane@email.com'], ['swag@nylas.com']],
       open_hours: [
         {
-          emails: [{ name: 'Nylas', email: 'swag@nylas.com' }],
-          days: ['0'],
+          emails: ['jane@email.com', 'swag@nylas.com'],
+          days: [0],
           timezone: 'America/Chicago',
           start: '10:00',
           end: '14:00',

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -239,6 +239,39 @@ describe('CalendarRestfulModelCollection', () => {
       });
   });
 
+  test('[CONSECUTIVE AVAILABILITY] should throw error if open hour emails dont match free busy emails', done => {
+    const params = {
+      startTime: 1590454800,
+      endTime: 1590780800,
+      interval: 5,
+      duration: 30,
+      emails: [['jane@email.com']],
+      free_busy: [{
+        email: 'jane@email.com',
+        object: 'free_busy',
+        time_slots: [{
+          object: "time_slots",
+          status: "busy",
+          start_time: 1590454800,
+          end_time: 1590780800,
+        }]
+      }],
+      open_hours: [
+        {
+          emails: ['jane@email.com', 'swag@nylas.com'],
+          days: [0],
+          timezone: 'America/Chicago',
+          start: '10:00',
+          end: '14:00',
+          object_type: 'open_hours',
+        },
+      ],
+    };
+
+    expect(() => testContext.connection.calendars.consecutiveAvailability(params)).toThrow();
+    done();
+  });
+
   test('[DELETE] should use correct route, method and auth', done => {
     const calendarId = 'id123';
 

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -166,6 +166,60 @@ describe('CalendarRestfulModelCollection', () => {
     });
   });
 
+  test('[CONSECUTIVE AVAILABILITY] should fetch results with params', done => {
+    const params = {
+      startTime: '1590454800',
+      endTime: '1590780800',
+      interval: 5,
+      duration: 30,
+      emails: [{ name: 'Jane', email: 'jane@email.com' }],
+      open_hours: [
+        {
+          emails: ['swag@nylas.com'],
+          days: ['0'],
+          timezone: 'America/Chicago',
+          start: '10:00',
+          end: '14:00',
+          object_type: 'open_hours',
+        },
+      ],
+    };
+
+    return testContext.connection.calendars
+      .calendarAvailability(params)
+      .then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/calendars/availability/consecutive'
+        );
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          start_time: '1590454800',
+          end_time: '1590780800',
+          interval_minutes: 5,
+          duration_minutes: 30,
+          emails: [{ name: 'Jane', email: 'jane@email.com' }],
+          free_busy: [],
+          open_hours: [
+            {
+              emails: ['swag@nylas.com'],
+              days: ['0'],
+              timezone: 'America/Chicago',
+              start: '10:00',
+              end: '14:00',
+              object_type: 'open_hours',
+            },
+          ],
+        });
+        expect(options.headers['authorization']).toEqual(
+          `Basic ${Buffer.from(`${testAccessToken}:`, 'utf8').toString(
+            'base64'
+          )}`
+        );
+        done();
+      });
+  });
+
   test('[DELETE] should use correct route, method and auth', done => {
     const calendarId = 'id123';
 

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -173,6 +173,16 @@ describe('CalendarRestfulModelCollection', () => {
       interval: 5,
       duration: 30,
       emails: [['jane@email.com'], ['swag@nylas.com']],
+      free_busy: [{
+        email: 'jane@email.com',
+        object: 'free_busy',
+        time_slots: [{
+          object: "time_slots",
+          status: "busy",
+          start_time: 1590454800,
+          end_time: 1590780800,
+        }]
+      }],
       open_hours: [
         {
           emails: ['jane@email.com', 'swag@nylas.com'],
@@ -194,16 +204,25 @@ describe('CalendarRestfulModelCollection', () => {
         );
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
-          start_time: '1590454800',
-          end_time: '1590780800',
+          start_time: 1590454800,
+          end_time: 1590780800,
           interval_minutes: 5,
           duration_minutes: 30,
-          emails: [{ name: 'Jane', email: 'jane@email.com' }],
-          free_busy: [],
+          emails: [['jane@email.com'], ['swag@nylas.com']],
+          free_busy: [{
+            email: 'jane@email.com',
+            object: 'free_busy',
+            time_slots: [{
+              object: "time_slots",
+              status: "busy",
+              start_time: 1590454800,
+              end_time: 1590780800,
+            }]
+          }],
           open_hours: [
             {
-              emails: [{ name: 'Nylas', email: 'swag@nylas.com' }],
-              days: ['0'],
+              emails: ['jane@email.com', 'swag@nylas.com'],
+              days: [0],
               timezone: 'America/Chicago',
               start: '10:00',
               end: '14:00',

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -186,7 +186,7 @@ describe('CalendarRestfulModelCollection', () => {
     };
 
     return testContext.connection.calendars
-      .calendarAvailability(params)
+      .consecutiveAvailability(params)
       .then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual(

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -105,4 +105,65 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
         return Promise.reject(err);
       });
   }
+
+  calendarAvailability(
+    options: {
+      emails: Array<{
+        email: string;
+        name: string;
+      }>;
+      duration: number;
+      interval: number;
+      start_time?: string;
+      startTime?: string;
+      end_time?: string;
+      endTime?: string;
+      free_busy?: Array<{
+        emails: string;
+        object: string;
+        time_slots: Array<{
+          object: string;
+          status: string;
+          start_time: string;
+          end_time: string;
+        }>;
+      }>;
+      open_hours: Array<{
+        emails: string[];
+        days: string[];
+        timezone: string;
+        start: string;
+        end: string;
+        object_type: string;
+      }>;
+    },
+    callback?: (error: Error | null, data?: { [key: string]: any }) => void
+  ) {
+    return this.connection
+      .request({
+        method: 'POST',
+        path: `/calendars/availability/consecutive`,
+        body: {
+          emails: options.emails,
+          duration_minutes: options.duration,
+          interval_minutes: options.interval,
+          start_time: options.startTime || options.start_time,
+          end_time: options.endTime || options.end_time,
+          free_busy: options.free_busy || [],
+          open_hours: options.open_hours,
+        },
+      })
+      .then(json => {
+        if (callback) {
+          callback(null, json);
+        }
+        return Promise.resolve(json);
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        return Promise.reject(err);
+      });
+  }
 }

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -129,7 +129,10 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
         }>;
       }>;
       open_hours: Array<{
-        emails: string[];
+        emails: Array<{
+          email: string;
+          name: string;
+        }>;
         days: string[];
         timezone: string;
         start: string;

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -117,13 +117,13 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       endTime?: number;
       buffer?: number;
       free_busy?: Array<{
-        emails: string;
+        email: string;
         object: string;
         time_slots: Array<{
           object: string;
           status: string;
-          start_time: string;
-          end_time: string;
+          start_time: number;
+          end_time: number;
         }>;
       }>;
       open_hours: Array<{
@@ -138,7 +138,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
   ) {
     const freeBusyEmails = options.free_busy
-      ? options.free_busy.map(freeBusy => freeBusy.emails)
+      ? options.free_busy.map(freeBusy => freeBusy.email)
       : [];
     for (const openHour of options.open_hours) {
       for (const email of openHour.emails) {

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -108,16 +108,13 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
 
   consecutiveAvailability(
     options: {
-      emails: Array<{
-        email: string;
-        name: string;
-      }>;
+      emails: string[][];
       duration: number;
       interval: number;
-      start_time?: string;
-      startTime?: string;
-      end_time?: string;
-      endTime?: string;
+      start_time?: number;
+      startTime?: number;
+      end_time?: number;
+      endTime?: number;
       free_busy?: Array<{
         emails: string;
         object: string;
@@ -129,11 +126,8 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
         }>;
       }>;
       open_hours: Array<{
-        emails: Array<{
-          email: string;
-          name: string;
-        }>;
-        days: string[];
+        emails: string[];
+        days: number[];
         timezone: string;
         start: string;
         end: string;

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -106,7 +106,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       });
   }
 
-  calendarAvailability(
+  consecutiveAvailability(
     options: {
       emails: Array<{
         email: string;

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -136,6 +136,22 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
     },
     callback?: (error: Error | null, data?: { [key: string]: any }) => void
   ) {
+    const freeBusyEmails = options.free_busy
+      ? options.free_busy.map(freeBusy => freeBusy.emails)
+      : [];
+    for (const openHour of options.open_hours) {
+      for (const email of openHour.emails) {
+        if (
+          !options.emails.some(row => row.includes(email)) &&
+          !freeBusyEmails.includes(email)
+        ) {
+          throw new Error(
+            'Open Hours cannot contain an email not present in the main email list or the free busy email list.'
+          );
+        }
+      }
+    }
+
     return this.connection
       .request({
         method: 'POST',

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -108,13 +108,14 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
 
   consecutiveAvailability(
     options: {
-      emails: string[][];
+      emails: Array<string[]>;
       duration: number;
       interval: number;
       start_time?: number;
       startTime?: number;
       end_time?: number;
       endTime?: number;
+      buffer?: number;
       free_busy?: Array<{
         emails: string;
         object: string;
@@ -162,6 +163,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
           interval_minutes: options.interval,
           start_time: options.startTime || options.start_time,
           end_time: options.endTime || options.end_time,
+          buffer: options.buffer,
           free_busy: options.free_busy || [],
           open_hours: options.open_hours,
         },


### PR DESCRIPTION
# Description
This PR enables support for the `/calendars/availability/consecutive` endpoint. 

# Usage
To check for consecutive availability:
```javascript
const params = {
  startTime: 1590454800,
  endTime: 1590780800,
  interval: 5,
  duration: 30,
  buffer: 30,
  emails: [['jane@email.com'], ['swag@nylas.com']],
  open_hours: [
    {
      emails: ['swag@nylas.com', 'jane@email.com'],
      days: [0],
      timezone: 'America/Chicago',
      start: '10:00',
      end: '14:00',
      object_type: 'open_hours',
    },
  ],
};

const consecutiveAvailability = await nylas.calendars.consecutiveAvailability(params);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.