### PR TITLE
[64477] Fix readonly Calendar attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Fix issue where JSON.stringify would omit read-only values
 * Fix webhook example throwing error if body is not a raw body
+* Fix readonly calendar attributes being sent for POST and PUT calls
 
 ### 5.7.0 / 2021-08-18
 * Fix minor issues with Neural API implementation

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -163,10 +163,12 @@ Event.attributes = {
   iCalUID: Attributes.String({
     modelKey: 'iCalUID',
     jsonKey: 'ical_uid',
+    readOnly: true,
   }),
   messageId: Attributes.String({
     modelKey: 'messageId',
     jsonKey: 'message_id',
+    readOnly: true,
   }),
   title: Attributes.String({
     modelKey: 'title',
@@ -176,6 +178,7 @@ Event.attributes = {
   }),
   owner: Attributes.String({
     modelKey: 'owner',
+    readOnly: true,
   }),
   participants: Attributes.Collection({
     modelKey: 'participants',
@@ -196,6 +199,7 @@ Event.attributes = {
   }),
   status: Attributes.String({
     modelKey: 'status',
+    readOnly: true,
   }),
   recurrence: Attributes.Object({
     modelKey: 'recurrence',
@@ -220,5 +224,6 @@ Event.attributes = {
   jobStatusId: Attributes.String({
     modelKey: 'jobStatusId',
     jsonKey: 'job_status_id',
+    readOnly: true,
   }),
 };


### PR DESCRIPTION
# Description
This PR addresses an issue that causes some PUT calls for Calendar objects to break. The issue was found when a customer was unable to update an event on API 2.2 with the API rejecting the call because `message_id` was present in the body. The messageId property is supposed to be readonly. We have 5 properties in Calendar that are now marked as readonly: `messageId`, `owner`, `iCalUID`, `status`, and `jobStatusId`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.