### PR TITLE
V5.8.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.8.0 / 2021-09-16
 * Add support for consecutive availability
 * Fix issue where JSON.stringify would omit read-only values
 * Fix webhook example throwing error if body is not a raw body

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -22,7 +22,7 @@ import NylasApiError from './models/nylas-api-error';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
-const SUPPORTED_API_VERSION = '2.2';
+const SUPPORTED_API_VERSION = '2.3';
 
 export type RequestOptions = {
   path: string;


### PR DESCRIPTION
# Description

New `nylas` v5.8.0 release bringing in the following new features:
* Add support for Calendar consecutive availability (#275)
* Enabled Nylas API 2.3 support

The new release also fixes the following:
* Fix issue where JSON.stringify would omit read-only values (#268, #266)
* Fix webhook example throwing error if body is not a raw body (#272)
* Fix readonly calendar attributes being sent for POST and PUT calls (#276)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.