### PR TITLE
[69572] Scheduler API Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add Scheduler support
+
 ### 5.8.0 / 2021-09-16
 * Add support for consecutive availability
 * Fix issue where JSON.stringify would omit read-only values

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -1,0 +1,195 @@
+import Nylas from '../src/nylas';
+import NylasConnection from '../src/nylas-connection';
+import fetch from 'node-fetch';
+import Message from '../src/models/message';
+import Scheduler from '../src/models/scheduler';
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
+
+describe('Scheduler', () => {
+  let testContext;
+
+  beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
+    testContext = {};
+    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    jest.spyOn(testContext.connection, 'request');
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        buffer: () => {
+          return Promise.resolve('body');
+        },
+        json: () => {
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map(),
+      };
+    };
+
+    fetch.mockImplementation(req => Promise.resolve(response(req.body)));
+
+    testContext.scheduler = new Scheduler(testContext.connection);
+  });
+
+  describe('json', () => {
+    test('Should deserialize the object properly', done => {
+      const schedulerJSON = {
+        app_client_id: 'test-client-id',
+        app_organization_id: 0,
+        config: {
+          timezone: 'America/Los_Angeles',
+        },
+        edit_token: 'token',
+        name: 'Test',
+        slug: 'test-slug',
+        created_at: new Date('2021-06-24T21:28:09Z'),
+        modified_at: new Date('2021-06-24T21:28:09Z'),
+      };
+      const scheduler = new Scheduler(testContext.connection, schedulerJSON);
+
+      expect(scheduler.appClientId).toEqual('test-client-id');
+      expect(scheduler.appOrganizationId).toBe(0);
+      expect(scheduler.config.timezone).toEqual('America/Los_Angeles');
+      expect(scheduler.editToken).toEqual('token');
+      expect(scheduler.name).toEqual('Test');
+      expect(scheduler.slug).toEqual('test-slug');
+      expect(scheduler.createdAt).toEqual(new Date('2021-06-24T21:28:09Z'));
+      expect(scheduler.modifiedAt).toEqual(new Date('2021-06-24T21:28:09Z'));
+      done();
+    });
+
+    test('Should serialize the object properly', done => {
+      testContext.scheduler.id = 'abc-123';
+      testContext.scheduler.appClientId = 'test-client-id';
+      testContext.scheduler.appOrganizationId = 0;
+      testContext.scheduler.config = {
+        timezone: 'America/Los_Angeles',
+      };
+      testContext.scheduler.editToken = 'token';
+      testContext.scheduler.name = 'Test';
+      testContext.scheduler.slug = 'test-slug';
+      testContext.scheduler.createdAt = new Date('2021-06-24T21:28:09Z');
+      testContext.scheduler.modifiedAt = new Date('2021-06-24T21:28:09Z');
+      testContext.scheduler.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.schedule.nylas.com/manage/pages/abc-123'
+        );
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          config: {
+            timezone: 'America/Los_Angeles',
+          },
+          name: 'Test',
+          slug: 'test-slug',
+        });
+        done();
+      });
+    });
+  });
+
+  describe('save', () => {
+    test('Should do a POST request if the scheduler has no id', done => {
+      testContext.scheduler.id = undefined;
+      testContext.scheduler.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.schedule.nylas.com/manage/pages'
+        );
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          app_client_id: undefined,
+          app_organization_id: undefined,
+          config: undefined,
+          edit_token: undefined,
+          name: undefined,
+          slug: undefined,
+          created_at: undefined,
+          modified_at: undefined,
+        });
+        done();
+      });
+    });
+
+    test('Should do a PUT request if the scheduler an id', done => {
+      testContext.scheduler.id = 'abc-123';
+      testContext.scheduler.name = 'test';
+      testContext.scheduler.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.schedule.nylas.com/manage/pages/abc-123'
+        );
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          app_client_id: undefined,
+          app_organization_id: undefined,
+          config: undefined,
+          edit_token: undefined,
+          name: 'test',
+          slug: undefined,
+          created_at: undefined,
+          modified_at: undefined,
+        });
+        done();
+      });
+    });
+  });
+
+  describe('getAvailableCalendars', () => {
+    test('Should do a GET request if the scheduler has an id', done => {
+      testContext.scheduler.id = 'abc-123';
+      testContext.scheduler.getAvailableCalendars().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.schedule.nylas.com/manage/pages/abc-123/calendars'
+        );
+        expect(options.method).toEqual('GET');
+        done();
+      });
+    });
+
+    test('Should throw an error if scheduler has no id', done => {
+      testContext.scheduler.id = undefined;
+      expect(() => testContext.scheduler.getAvailableCalendars()).toThrow();
+      done();
+    });
+  });
+
+  describe('uploadImage', () => {
+    test('Should do a PUT request if the scheduler has an id', done => {
+      testContext.scheduler.id = 'abc-123';
+      testContext.scheduler.uploadImage('image', 'logo.png').then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.schedule.nylas.com/manage/pages/abc-123/upload-image'
+        );
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          contentType: 'image',
+          objectName: 'logo.png',
+        });
+        done();
+      });
+    });
+
+    test('Should throw an error if scheduler has no id', done => {
+      testContext.scheduler.id = undefined;
+      expect(() =>
+        testContext.scheduler.uploadImage('image', 'logo.png')
+      ).toThrow();
+      done();
+    });
+  });
+});

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -1,7 +1,6 @@
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
-import Message from '../src/models/message';
 import Scheduler from '../src/models/scheduler';
 
 jest.mock('node-fetch', () => {

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -1,5 +1,6 @@
-import RestfulModel from './restful-model';
+import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
+import NylasConnection from '../nylas-connection';
 
 export default class Scheduler extends RestfulModel {
   accessTokens?: string[];
@@ -79,6 +80,15 @@ export default class Scheduler extends RestfulModel {
   slug?: string;
   createdAt?: Date;
   modifiedAt?: Date;
+
+  constructor(connection: NylasConnection, json?: Record<string, any>) {
+    super(connection, json);
+    connection.baseUrl = "https://api.schedule.nylas.com";
+  }
+
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+    return this._save(params, callback);
+  }
 
   getAvailableCalendars(): Record<string, any> {
     if (!this.id) {

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -81,8 +81,8 @@ export default class Scheduler extends RestfulModel {
   modifiedAt?: Date;
 
   getAvailableCalendars(): Record<string, any> {
-    if(!this.id) {
-      throw new Error("Cannot get calendars for a page without an ID.");
+    if (!this.id) {
+      throw new Error('Cannot get calendars for a page without an ID.');
     }
     return this.connection.request({
       method: 'GET',
@@ -94,8 +94,8 @@ export default class Scheduler extends RestfulModel {
   }
 
   uploadImage(contentType: string, objectName: string): Record<string, any> {
-    if(!this.id) {
-      throw new Error("Cannot upload an image to a page without an ID.");
+    if (!this.id) {
+      throw new Error('Cannot upload an image to a page without an ID.');
     }
     return this.connection.request({
       method: 'PUT',
@@ -151,4 +151,4 @@ Scheduler.attributes = {
     jsonKey: 'modified_at',
     readOnly: true,
   }),
-}
+};

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -1,0 +1,124 @@
+import RestfulModel from './restful-model';
+import Attributes from './attributes';
+
+export default class Scheduler extends RestfulModel {
+  accessTokens?: string[];
+  appClientId?: string;
+  appOrganizationId?: number;
+  config?: {
+    appearance?: {
+      color?: string;
+      company_name?: string;
+      logo?: string;
+      privacy_policy_redirect?: string;
+      show_autoschedule?: boolean;
+      show_nylas_branding?: boolean;
+      show_timezone_options?: boolean;
+      submit_text?: string;
+      thank_you_redirect?: string;
+      thank_you_text?: string;
+      thank_you_text_secondary?: string;
+    };
+    booking?: {
+      additional_fields: Array<{
+        dropdown_options?: string[];
+        label?: string;
+        multi_select_options?: string[];
+        name?: string;
+        order?: number;
+        pattern?: string;
+        required?: boolean;
+        type?: string;
+      }>;
+      available_days_in_future: number;
+      calendar_invite_to_guests: boolean;
+      cancellation_policy: string;
+      confirmation_emails_to_guests: boolean;
+      confirmation_emails_to_host: boolean;
+      confirmation_method: string;
+      min_booking_notice: number;
+      min_buffer: number;
+      min_cancellation_notice: number;
+      name_field_hidden: boolean;
+      opening_hours: Array<{
+        account_id?: string;
+        days?: string;
+        end?: string;
+        start?: string;
+      }>;
+      scheduling_method: string;
+    };
+    calendar_ids?: {
+      [accountId: string]: {
+        availability?: string[];
+        booking?: string;
+      };
+    };
+    event?: {
+      duration?: number;
+      location?: string;
+      title?: string;
+    };
+    expire_after?: {
+      date?: number;
+      uses?: number;
+    };
+    locale?: string;
+    locale_for_guests?: string;
+    reminders?: Array<{
+      delivery_method?: string;
+      delivery_recipient?: string;
+      email_subject?: string;
+      time_before_event?: number;
+      webhook_url?: string;
+    }>;
+    timezone?: string;
+  };
+  editToken?: string;
+  name?: string;
+  slug?: string;
+  createdAt?: Date;
+  modifiedAt?: Date;
+}
+Scheduler.collectionName = 'manage/pages';
+Scheduler.attributes = {
+  ...RestfulModel.attributes,
+  accessTokens: Attributes.StringList({
+    modelKey: 'accessTokens',
+    jsonKey: 'access_tokens',
+  }),
+  appClientId: Attributes.String({
+    modelKey: 'appClientId',
+    jsonKey: 'app_client_id',
+    readOnly: true,
+  }),
+  appOrganizationId: Attributes.Number({
+    modelKey: 'appOrganizationId',
+    jsonKey: 'app_organization_id',
+    readOnly: true,
+  }),
+  config: Attributes.Object({
+    modelKey: 'config',
+  }),
+  editToken: Attributes.String({
+    modelKey: 'editToken',
+    jsonKey: 'edit_token',
+    readOnly: true,
+  }),
+  name: Attributes.String({
+    modelKey: 'name',
+  }),
+  slug: Attributes.String({
+    modelKey: 'slug',
+  }),
+  createdAt: Attributes.Date({
+    modelKey: 'createdAt',
+    jsonKey: 'created_at',
+    readOnly: true,
+  }),
+  modifiedAt: Attributes.Date({
+    modelKey: 'modifiedAt',
+    jsonKey: 'modified_at',
+    readOnly: true,
+  }),
+}

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -83,7 +83,7 @@ export default class Scheduler extends RestfulModel {
 
   constructor(connection: NylasConnection, json?: Record<string, any>) {
     super(connection, json);
-    connection.baseUrl = "https://api.schedule.nylas.com";
+    connection.baseUrl = 'https://api.schedule.nylas.com';
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -79,6 +79,36 @@ export default class Scheduler extends RestfulModel {
   slug?: string;
   createdAt?: Date;
   modifiedAt?: Date;
+
+  getAvailableCalendars(): Record<string, any> {
+    if(!this.id) {
+      throw new Error("Cannot get calendars for a page without an ID.");
+    }
+    return this.connection.request({
+      method: 'GET',
+      path: `/manage/pages/${this.id}/calendars`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  uploadImage(contentType: string, objectName: string): Record<string, any> {
+    if(!this.id) {
+      throw new Error("Cannot upload an image to a page without an ID.");
+    }
+    return this.connection.request({
+      method: 'PUT',
+      path: `/manage/pages/${this.id}/upload-image`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: {
+        contentType: contentType,
+        objectName: objectName,
+      },
+    });
+  }
 }
 Scheduler.collectionName = 'manage/pages';
 Scheduler.attributes = {

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -33,6 +33,7 @@ export type RequestOptions = {
   json?: boolean;
   formData?: { [key: string]: FormDataType };
   body?: any;
+  baseUrl?: string;
   url?: URL;
 };
 
@@ -44,6 +45,7 @@ export type FormDataType = {
 export default class NylasConnection {
   accessToken: string | null | undefined;
   clientId: string | null | undefined;
+  baseUrl: string | null | undefined;
 
   threads: RestfulModelCollection<Thread> = new RestfulModelCollection(
     Thread,
@@ -101,7 +103,8 @@ export default class NylasConnection {
   }
 
   requestOptions(options: RequestOptions): RequestOptions {
-    const url = new URL(`${config.apiServer}${options.path}`);
+    const baseUrl = this.baseUrl ? this.baseUrl : config.apiServer;
+    const url = new URL(`${baseUrl}${options.path}`);
     // map querystring to search params
     if (options.qs) {
       for (const [key, value] of Object.entries(options.qs)) {

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -19,6 +19,7 @@ import { Folder, Label } from './models/folder';
 import FormData, { AppendOptions } from 'form-data';
 import Neural from './models/neural';
 import NylasApiError from './models/nylas-api-error';
+import Scheduler from './models/scheduler';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -89,6 +90,10 @@ export default class NylasConnection {
   );
   account: RestfulModelInstance<Account> = new RestfulModelInstance(
     Account,
+    this
+  );
+  scheduler: RestfulModelCollection<Scheduler> = new RestfulModelCollection(
+    Scheduler,
     this
   );
 


### PR DESCRIPTION
# Description
This PR enables SDK support for the [Scheduler API](https://developer.nylas.com/docs/api/scheduler/#overview).

# Usage
To create a new Scheduler page:
```javascript
const scheduler = nylas.scheduler.create({
  access_tokens: ['test-access-tokens'],
  config: {
    timezone: 'America/Los_Angeles',
  },
  name: 'Test',
  slug: 'test-slug',
});
```

To return all Scheduler pages:
```javascript
const schedulerList = await nylas.scheduler.list();
```

To return a single Scheduler page:
```javascript
const scheduler = await nylas.scheduler.find('SCHEDULER_ID');
```

To update a Scheduler page:
```javascript
const scheduler = await nylas.scheduler.find('SCHEDULER_ID');
scheduler.name = "Updated page name";
scheduler.save();
```

To delete a Scheduler page:
```javascript
await nylas.scheduler.delete('SCHEDULER_ID');
```

To get available calendars for a Scheduler page:
```javascript
const scheduler = await nylas.scheduler.find('SCHEDULER_ID');
const calendars = scheduler.getAvailableCalendars();
```

To upload an image:
```javascript
const scheduler = await nylas.scheduler.find('SCHEDULER_ID');
await scheduler.uploadImage('CONTENT_TYPE', 'OBJECT_NAME');
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.