### PR TITLE
[67847] Component CRUD Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add Component CRUD Support
+
 ### 5.8.0 / 2021-09-16
 * Add support for consecutive availability
 * Fix issue where JSON.stringify would omit read-only values

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -1,0 +1,153 @@
+import Nylas from '../src/nylas';
+import NylasConnection from '../src/nylas-connection';
+import fetch from 'node-fetch';
+import Component from '../src/models/component';
+
+jest.mock('node-fetch', () => {
+  const { Request, Response } = jest.requireActual('node-fetch');
+  const fetch = jest.fn();
+  fetch.Request = Request;
+  fetch.Response = Response;
+  return fetch;
+});
+
+describe('Component', () => {
+  let testContext;
+
+  beforeEach(() => {
+    Nylas.config({
+      clientId: 'myClientId',
+      clientSecret: 'myClientSecret',
+      apiServer: 'https://api.nylas.com',
+    });
+    testContext = {};
+    testContext.connection = new NylasConnection('123', { clientId: 'myClientId' });
+    jest.spyOn(testContext.connection, 'request');
+
+    const componentJSON = {
+      id: "abc-123",
+      account_id: "account-123",
+      name: "test-component",
+      type: "agenda",
+      action: 0,
+      active: true,
+      settings: {},
+      allowed_domains: [],
+      public_account_id: ["account-123"],
+      public_token_id: ["token-123"],
+      public_application_id: ["application-123"],
+      created_at: "2021-08-24T15:05:48.000Z",
+      updated_at: "2021-08-24T15:05:48.000Z",
+    }
+
+    const response = receivedBody => {
+      return {
+        status: 200,
+        text: () => {
+          return Promise.resolve(receivedBody);
+        },
+        json: () => {
+          if(!receivedBody) {
+            return Promise.resolve([componentJSON]);
+          }
+          return Promise.resolve(receivedBody);
+        },
+        headers: new Map(),
+      };
+    };
+
+    fetch.mockImplementation(req => Promise.resolve(response(req.body)));
+    testContext.component = new Component(testContext.connection);
+  });
+
+  describe('save', () => {
+    test('should do a POST request if the component has no id', done => {
+      testContext.component.id = undefined;
+      return testContext.component.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          id: undefined,
+          account_id: undefined,
+          object: undefined,
+          name: undefined,
+          type: undefined,
+          action: undefined,
+          active: undefined,
+          settings: undefined,
+          allowed_domains: undefined,
+          public_account_id: undefined,
+          public_token_id: undefined,
+          public_application_id: undefined,
+          created_at: undefined,
+          updated_at: undefined,
+        });
+        done();
+      });
+    });
+
+    test('should do a PUT request if the component has an id', done => {
+      testContext.component.id = "abc-123";
+      testContext.component.allowedDomains = ["www.nylas.com"];
+      return testContext.component.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId/abc-123');
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          id: undefined,
+          account_id: undefined,
+          object: undefined,
+          name: undefined,
+          type: undefined,
+          action: undefined,
+          active: undefined,
+          settings: undefined,
+          allowed_domains: ["www.nylas.com"],
+          public_account_id: undefined,
+          public_token_id: undefined,
+          public_application_id: undefined,
+          created_at: undefined,
+          updated_at: undefined,
+        });
+        done();
+      });
+    });
+  });
+
+  describe('fetching', () => {
+    test('should do a GET request to the correct URL when requesting all components', done => {
+      return testContext.connection.conponent.list().then(componentList => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId?offset=0&limit=100');
+        expect(options.method).toEqual('GET');
+        expect(componentList.length).toBe(1);
+        expect(componentList[0].id).toEqual("abc-123");
+        expect(componentList[0].accountId).toEqual("account-123");
+        expect(componentList[0].name).toEqual("test-component");
+        expect(componentList[0].type).toEqual("agenda");
+        expect(componentList[0].action).toBe(0);
+        expect(componentList[0].active).toBe(true);
+        expect(componentList[0].settings).toEqual({});
+        expect(componentList[0].allowedDomains).toEqual([]);
+        expect(componentList[0].publicAccountId).toEqual(["account-123"]);
+        expect(componentList[0].publicTokenId).toEqual(["token-123"]);
+        expect(componentList[0].publicApplicationId).toEqual(["application-123"]);
+        expect(componentList[0].createdAt).toEqual(new Date("2021-08-24T15:05:48.000Z"));
+        expect(componentList[0].updatedAt).toEqual(new Date("2021-08-24T15:05:48.000Z"));
+        done();
+      });
+    });
+  });
+
+  describe('delete', () => {
+    test('should do a DELETE request to the correct URL when deleting a', done => {
+      return testContext.connection.conponent.delete("abc-123").then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId/abc-123');
+        expect(options.method).toEqual('DELETE');
+        done();
+      });
+    });
+  });
+});

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -123,10 +123,9 @@ describe('Component', () => {
       const response = req => {
         return {
           status: 200,
-          text: () => {
-          },
+          text: () => {},
           json: () => {
-            if(!req.url.includes("abc-123")) {
+            if (!req.url.includes('abc-123')) {
               return Promise.resolve([componentJSON]);
             }
             return Promise.resolve(componentJSON);
@@ -170,33 +169,33 @@ describe('Component', () => {
     });
 
     test('should do a GET request to the correct URL when requesting a specific component', done => {
-      return testContext.connection.component.find("abc-123").then(component => {
-        const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.url.toString()).toEqual(
-          'https://api.nylas.com/component/myClientId/abc-123'
-        );
-        expect(options.method).toEqual('GET');
-        expect(component.id).toEqual('abc-123');
-        expect(component.accountId).toEqual('account-123');
-        expect(component.name).toEqual('test-component');
-        expect(component.type).toEqual('agenda');
-        expect(component.action).toBe(0);
-        expect(component.active).toBe(true);
-        expect(component.settings).toEqual({});
-        expect(component.allowedDomains).toEqual([]);
-        expect(component.publicAccountId).toEqual(['account-123']);
-        expect(component.publicTokenId).toEqual(['token-123']);
-        expect(component.publicApplicationId).toEqual([
-          'application-123',
-        ]);
-        expect(component.createdAt).toEqual(
-          new Date('2021-08-24T15:05:48.000Z')
-        );
-        expect(component.updatedAt).toEqual(
-          new Date('2021-08-24T15:05:48.000Z')
-        );
-        done();
-      });
+      return testContext.connection.component
+        .find('abc-123')
+        .then(component => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/component/myClientId/abc-123'
+          );
+          expect(options.method).toEqual('GET');
+          expect(component.id).toEqual('abc-123');
+          expect(component.accountId).toEqual('account-123');
+          expect(component.name).toEqual('test-component');
+          expect(component.type).toEqual('agenda');
+          expect(component.action).toBe(0);
+          expect(component.active).toBe(true);
+          expect(component.settings).toEqual({});
+          expect(component.allowedDomains).toEqual([]);
+          expect(component.publicAccountId).toEqual(['account-123']);
+          expect(component.publicTokenId).toEqual(['token-123']);
+          expect(component.publicApplicationId).toEqual(['application-123']);
+          expect(component.createdAt).toEqual(
+            new Date('2021-08-24T15:05:48.000Z')
+          );
+          expect(component.updatedAt).toEqual(
+            new Date('2021-08-24T15:05:48.000Z')
+          );
+          done();
+        });
     });
   });
 

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -21,24 +21,26 @@ describe('Component', () => {
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'myClientId' });
+    testContext.connection = new NylasConnection('123', {
+      clientId: 'myClientId',
+    });
     jest.spyOn(testContext.connection, 'request');
 
     const componentJSON = {
-      id: "abc-123",
-      account_id: "account-123",
-      name: "test-component",
-      type: "agenda",
+      id: 'abc-123',
+      account_id: 'account-123',
+      name: 'test-component',
+      type: 'agenda',
       action: 0,
       active: true,
       settings: {},
       allowed_domains: [],
-      public_account_id: ["account-123"],
-      public_token_id: ["token-123"],
-      public_application_id: ["application-123"],
-      created_at: "2021-08-24T15:05:48.000Z",
-      updated_at: "2021-08-24T15:05:48.000Z",
-    }
+      public_account_id: ['account-123'],
+      public_token_id: ['token-123'],
+      public_application_id: ['application-123'],
+      created_at: '2021-08-24T15:05:48.000Z',
+      updated_at: '2021-08-24T15:05:48.000Z',
+    };
 
     const response = receivedBody => {
       return {
@@ -47,7 +49,7 @@ describe('Component', () => {
           return Promise.resolve(receivedBody);
         },
         json: () => {
-          if(!receivedBody) {
+          if (!receivedBody) {
             return Promise.resolve([componentJSON]);
           }
           return Promise.resolve(receivedBody);
@@ -65,7 +67,9 @@ describe('Component', () => {
       testContext.component.id = undefined;
       return testContext.component.save().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId');
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/component/myClientId'
+        );
         expect(options.method).toEqual('POST');
         expect(JSON.parse(options.body)).toEqual({
           id: undefined,
@@ -88,11 +92,13 @@ describe('Component', () => {
     });
 
     test('should do a PUT request if the component has an id', done => {
-      testContext.component.id = "abc-123";
-      testContext.component.allowedDomains = ["www.nylas.com"];
+      testContext.component.id = 'abc-123';
+      testContext.component.allowedDomains = ['www.nylas.com'];
       return testContext.component.save().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId/abc-123');
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/component/myClientId/abc-123'
+        );
         expect(options.method).toEqual('PUT');
         expect(JSON.parse(options.body)).toEqual({
           id: undefined,
@@ -103,7 +109,7 @@ describe('Component', () => {
           action: undefined,
           active: undefined,
           settings: undefined,
-          allowed_domains: ["www.nylas.com"],
+          allowed_domains: ['www.nylas.com'],
           public_account_id: undefined,
           public_token_id: undefined,
           public_application_id: undefined,
@@ -119,22 +125,30 @@ describe('Component', () => {
     test('should do a GET request to the correct URL when requesting all components', done => {
       return testContext.connection.conponent.list().then(componentList => {
         const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId?offset=0&limit=100');
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/component/myClientId?offset=0&limit=100'
+        );
         expect(options.method).toEqual('GET');
         expect(componentList.length).toBe(1);
-        expect(componentList[0].id).toEqual("abc-123");
-        expect(componentList[0].accountId).toEqual("account-123");
-        expect(componentList[0].name).toEqual("test-component");
-        expect(componentList[0].type).toEqual("agenda");
+        expect(componentList[0].id).toEqual('abc-123');
+        expect(componentList[0].accountId).toEqual('account-123');
+        expect(componentList[0].name).toEqual('test-component');
+        expect(componentList[0].type).toEqual('agenda');
         expect(componentList[0].action).toBe(0);
         expect(componentList[0].active).toBe(true);
         expect(componentList[0].settings).toEqual({});
         expect(componentList[0].allowedDomains).toEqual([]);
-        expect(componentList[0].publicAccountId).toEqual(["account-123"]);
-        expect(componentList[0].publicTokenId).toEqual(["token-123"]);
-        expect(componentList[0].publicApplicationId).toEqual(["application-123"]);
-        expect(componentList[0].createdAt).toEqual(new Date("2021-08-24T15:05:48.000Z"));
-        expect(componentList[0].updatedAt).toEqual(new Date("2021-08-24T15:05:48.000Z"));
+        expect(componentList[0].publicAccountId).toEqual(['account-123']);
+        expect(componentList[0].publicTokenId).toEqual(['token-123']);
+        expect(componentList[0].publicApplicationId).toEqual([
+          'application-123',
+        ]);
+        expect(componentList[0].createdAt).toEqual(
+          new Date('2021-08-24T15:05:48.000Z')
+        );
+        expect(componentList[0].updatedAt).toEqual(
+          new Date('2021-08-24T15:05:48.000Z')
+        );
         done();
       });
     });
@@ -142,9 +156,11 @@ describe('Component', () => {
 
   describe('delete', () => {
     test('should do a DELETE request to the correct URL when deleting a', done => {
-      return testContext.connection.conponent.delete("abc-123").then(() => {
+      return testContext.connection.conponent.delete('abc-123').then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.url.toString()).toEqual('https://api.nylas.com/component/myClientId/abc-123');
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/component/myClientId/abc-123'
+        );
         expect(options.method).toEqual('DELETE');
         done();
       });

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -123,7 +123,7 @@ describe('Component', () => {
 
   describe('fetching', () => {
     test('should do a GET request to the correct URL when requesting all components', done => {
-      return testContext.connection.conponent.list().then(componentList => {
+      return testContext.connection.component.list().then(componentList => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual(
           'https://api.nylas.com/component/myClientId?offset=0&limit=100'
@@ -156,7 +156,7 @@ describe('Component', () => {
 
   describe('delete', () => {
     test('should do a DELETE request to the correct URL when deleting a', done => {
-      return testContext.connection.conponent.delete('abc-123').then(() => {
+      return testContext.connection.component.delete('abc-123').then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual(
           'https://api.nylas.com/component/myClientId/abc-123'

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -26,22 +26,6 @@ describe('Component', () => {
     });
     jest.spyOn(testContext.connection, 'request');
 
-    const componentJSON = {
-      id: 'abc-123',
-      account_id: 'account-123',
-      name: 'test-component',
-      type: 'agenda',
-      action: 0,
-      active: true,
-      settings: {},
-      allowed_domains: [],
-      public_account_id: ['account-123'],
-      public_token_id: ['token-123'],
-      public_application_id: ['application-123'],
-      created_at: '2021-08-24T15:05:48.000Z',
-      updated_at: '2021-08-24T15:05:48.000Z',
-    };
-
     const response = receivedBody => {
       return {
         status: 200,
@@ -49,9 +33,6 @@ describe('Component', () => {
           return Promise.resolve(receivedBody);
         },
         json: () => {
-          if (!receivedBody) {
-            return Promise.resolve([componentJSON]);
-          }
           return Promise.resolve(receivedBody);
         },
         headers: new Map(),
@@ -122,6 +103,41 @@ describe('Component', () => {
   });
 
   describe('fetching', () => {
+    beforeEach(() => {
+      const componentJSON = {
+        id: 'abc-123',
+        account_id: 'account-123',
+        name: 'test-component',
+        type: 'agenda',
+        action: 0,
+        active: true,
+        settings: {},
+        allowed_domains: [],
+        public_account_id: ['account-123'],
+        public_token_id: ['token-123'],
+        public_application_id: ['application-123'],
+        created_at: '2021-08-24T15:05:48.000Z',
+        updated_at: '2021-08-24T15:05:48.000Z',
+      };
+
+      const response = req => {
+        return {
+          status: 200,
+          text: () => {
+          },
+          json: () => {
+            if(!req.url.includes("abc-123")) {
+              return Promise.resolve([componentJSON]);
+            }
+            return Promise.resolve(componentJSON);
+          },
+          headers: new Map(),
+        };
+      };
+
+      fetch.mockImplementation(req => Promise.resolve(response(req)));
+    });
+
     test('should do a GET request to the correct URL when requesting all components', done => {
       return testContext.connection.component.list().then(componentList => {
         const options = testContext.connection.request.mock.calls[0][0];
@@ -147,6 +163,36 @@ describe('Component', () => {
           new Date('2021-08-24T15:05:48.000Z')
         );
         expect(componentList[0].updatedAt).toEqual(
+          new Date('2021-08-24T15:05:48.000Z')
+        );
+        done();
+      });
+    });
+
+    test('should do a GET request to the correct URL when requesting a specific component', done => {
+      return testContext.connection.component.find("abc-123").then(component => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/component/myClientId/abc-123'
+        );
+        expect(options.method).toEqual('GET');
+        expect(component.id).toEqual('abc-123');
+        expect(component.accountId).toEqual('account-123');
+        expect(component.name).toEqual('test-component');
+        expect(component.type).toEqual('agenda');
+        expect(component.action).toBe(0);
+        expect(component.active).toBe(true);
+        expect(component.settings).toEqual({});
+        expect(component.allowedDomains).toEqual([]);
+        expect(component.publicAccountId).toEqual(['account-123']);
+        expect(component.publicTokenId).toEqual(['token-123']);
+        expect(component.publicApplicationId).toEqual([
+          'application-123',
+        ]);
+        expect(component.createdAt).toEqual(
+          new Date('2021-08-24T15:05:48.000Z')
+        );
+        expect(component.updatedAt).toEqual(
           new Date('2021-08-24T15:05:48.000Z')
         );
         done();

--- a/src/models/component-restful-model-collection.ts
+++ b/src/models/component-restful-model-collection.ts
@@ -1,0 +1,20 @@
+import RestfulModelCollection from './restful-model-collection';
+import NylasConnection from '../nylas-connection';
+import Component from './component';
+
+export default class ComponentRestfulModelCollection extends RestfulModelCollection<
+  Component
+  > {
+  connection: NylasConnection;
+  modelClass: typeof Component;
+
+  constructor(connection: NylasConnection) {
+    super(Component, connection);
+    this.connection = connection;
+    this.modelClass = Component;
+  }
+
+  path(): string {
+    return `/component/${this.connection.clientId}`;
+  }
+}

--- a/src/models/component-restful-model-collection.ts
+++ b/src/models/component-restful-model-collection.ts
@@ -4,7 +4,7 @@ import Component from './component';
 
 export default class ComponentRestfulModelCollection extends RestfulModelCollection<
   Component
-  > {
+> {
   connection: NylasConnection;
   modelClass: typeof Component;
 

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -15,7 +15,7 @@ export default class Component extends RestfulModel {
   updatedAt?: Date;
 
   saveEndpoint(): string {
-    return `/component/${this.connection.clientId}`
+    return `/component/${this.connection.clientId}`;
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
@@ -64,4 +64,4 @@ Component.attributes = {
     modelKey: 'updatedAt',
     jsonKey: 'updated_at',
   }),
-}
+};

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -1,0 +1,67 @@
+import RestfulModel, { SaveCallback } from './restful-model';
+import Attributes from './attributes';
+
+export default class Component extends RestfulModel {
+  name?: string;
+  type?: string;
+  action?: number;
+  active?: boolean;
+  settings?: object;
+  allowedDomains?: string[];
+  publicAccountId?: string;
+  publicTokenId?: string;
+  publicApplicationId?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+
+  saveEndpoint(): string {
+    return `/component/${this.connection.clientId}`
+  }
+
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+    return this._save(params, callback);
+  }
+}
+Component.collectionName = 'component';
+Component.attributes = {
+  ...RestfulModel.attributes,
+  name: Attributes.String({
+    modelKey: 'name',
+  }),
+  type: Attributes.String({
+    modelKey: 'type',
+  }),
+  action: Attributes.Number({
+    modelKey: 'action',
+  }),
+  active: Attributes.Boolean({
+    modelKey: 'active',
+  }),
+  settings: Attributes.Object({
+    modelKey: 'settings',
+  }),
+  allowedDomains: Attributes.StringList({
+    modelKey: 'allowedDomains',
+    jsonKey: 'allowed_domains',
+  }),
+  publicAccountId: Attributes.String({
+    modelKey: 'publicAccountId',
+    jsonKey: 'public_account_id',
+  }),
+  publicTokenId: Attributes.String({
+    modelKey: 'publicTokenId',
+    jsonKey: 'public_token_id',
+  }),
+  publicApplicationId: Attributes.String({
+    modelKey: 'publicApplicationId',
+    jsonKey: 'public_application_id',
+  }),
+  createdAt: Attributes.Date({
+    modelKey: 'createdAt',
+    jsonKey: 'created_at',
+  }),
+  updatedAt: Attributes.Date({
+    modelKey: 'updatedAt',
+    jsonKey: 'updated_at',
+  }),
+}

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -19,6 +19,7 @@ import { Folder, Label } from './models/folder';
 import FormData, { AppendOptions } from 'form-data';
 import Neural from './models/neural';
 import NylasApiError from './models/nylas-api-error';
+import ComponentRestfulModelCollection from './models/component-restful-model-collection';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -87,6 +88,9 @@ export default class NylasConnection {
   );
   account: RestfulModelInstance<Account> = new RestfulModelInstance(
     Account,
+    this
+  );
+  conponent: ComponentRestfulModelCollection = new ComponentRestfulModelCollection(
     this
   );
 

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -90,7 +90,7 @@ export default class NylasConnection {
     Account,
     this
   );
-  conponent: ComponentRestfulModelCollection = new ComponentRestfulModelCollection(
+  component: ComponentRestfulModelCollection = new ComponentRestfulModelCollection(
     this
   );
 

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -134,7 +134,7 @@ export default class NylasConnection {
 
     const headers = { ...options.headers };
     const user =
-      options.path.substr(0, 3) === '/a/'
+      options.path.substr(0, 3) === '/a/' || options.path.includes('/component')
         ? config.clientSecret
         : this.accessToken;
     if (user) {


### PR DESCRIPTION
# Description
This PR enables SDK support for the Nylas `/component` endpoints.

# Usage
To create a new component:
```javascript
const component = nylas.component.create({
  name: "New Component",
  type: "agenda",
  public_account_id: "{ACCOUNT_ID}",
  access_token: "{ACCESS_TOKEN}",
});
```

To get all components:
```javascript
const componentList = await nylas.component.list();
```

To get a specific component:
```javascript
const component = await nylas.component.find("{COMPONENT_ID}");
```

To update a component:
```javascript
const component = await nylas.component.find("{COMPONENT_ID}");
component.allowedDomains = ["www.nylas.com"];
component.save();
```

To delete a component:
```javascript
await nylas.component.delete("{COMPONENT_ID}");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.