### PR TITLE
[72428] Support Event notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for Event notifications
+
 ### 5.9.0 / 2021-09-24
 * Add Component CRUD Support
 * Add Scheduler support

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -2,7 +2,6 @@ import NylasConnection from '../src/nylas-connection';
 import Event from '../src/models/event';
 import Nylas from '../src/nylas';
 import fetch from 'node-fetch';
-import { EventNotification } from '../src/models/event-notification';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -57,6 +57,7 @@ describe('Event', () => {
           location: undefined,
           when: undefined,
           participants: [],
+          notifications: [],
         });
         done();
       });
@@ -78,6 +79,7 @@ describe('Event', () => {
           location: undefined,
           when: undefined,
           participants: [],
+          notifications: [],
         });
         done();
       });
@@ -99,6 +101,7 @@ describe('Event', () => {
           location: undefined,
           when: undefined,
           participants: [],
+          notifications: [],
         });
         done();
       });
@@ -122,6 +125,7 @@ describe('Event', () => {
           location: undefined,
           when: undefined,
           participants: [],
+          notifications: [],
           recurrence: recurrence,
         });
         done();
@@ -148,6 +152,7 @@ describe('Event', () => {
             time: 1408875644,
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -176,6 +181,7 @@ describe('Event', () => {
             end_time: 1409598000,
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -203,6 +209,7 @@ describe('Event', () => {
             date: '1912-06-23',
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -231,6 +238,7 @@ describe('Event', () => {
             end_date: '1852-11-27',
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
         });
         done();
@@ -255,6 +263,7 @@ describe('Event', () => {
             time: 1408875644,
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -283,6 +292,7 @@ describe('Event', () => {
             end_time: 1409598000,
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -310,6 +320,7 @@ describe('Event', () => {
             date: '1912-06-23',
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -341,6 +352,7 @@ describe('Event', () => {
             end_date: '1852-11-27',
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -375,6 +387,7 @@ describe('Event', () => {
             end_date: '1852-11-27',
           },
           participants: [],
+          notifications: [],
           read_only: undefined,
           status: undefined,
         });
@@ -398,6 +411,7 @@ describe('Event', () => {
           _start: undefined,
           _end: undefined,
           participants: [],
+          notifications: [],
           metadata: { hello: 'world' },
         });
         done();
@@ -433,6 +447,7 @@ describe('Event', () => {
             _start: undefined,
             _end: undefined,
             participants: [],
+            notifications: [],
             conferencing: {
               provider: 'Zoom Meeting',
               details: {
@@ -474,6 +489,7 @@ describe('Event', () => {
             _start: undefined,
             _end: undefined,
             participants: [],
+            notifications: [],
             conferencing: {
               provider: 'Zoom Meeting',
               autocreate: {

--- a/src/models/event-notification.ts
+++ b/src/models/event-notification.ts
@@ -1,0 +1,49 @@
+import RestfulModel from './restful-model';
+import Attributes from './attributes';
+
+export class EventNotification extends RestfulModel {
+  type?: string;
+  minutesBeforeEvent?: number;
+  url?: string;
+  payload?: string;
+  subject?: string;
+  body?: string;
+  message?: string;
+
+  toJSON(): any {
+    return {
+      type: this.type,
+      minutes_before_event: this.minutesBeforeEvent,
+      url: this.url,
+      payload: this.payload,
+      subject: this.subject,
+      body: this.body,
+      message: this.message,
+    };
+  }
+}
+EventNotification.collectionName = 'event_notification';
+EventNotification.attributes = {
+  type: Attributes.String({
+    modelKey: 'type',
+  }),
+  minutesBeforeEvent: Attributes.Number({
+    modelKey: 'minutesBeforeEvent',
+    jsonKey: 'minutes_before_event',
+  }),
+  url: Attributes.String({
+    modelKey: 'url',
+  }),
+  payload: Attributes.String({
+    modelKey: 'payload',
+  }),
+  subject: Attributes.String({
+    modelKey: 'subject',
+  }),
+  body: Attributes.String({
+    modelKey: 'body',
+  }),
+  message: Attributes.String({
+    modelKey: 'message',
+  }),
+};

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -2,6 +2,7 @@ import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes from './attributes';
 import EventParticipant from './event-participant';
 import { EventConferencing } from './event-conferencing';
+import { EventNotification } from './event-notification';
 
 export default class Event extends RestfulModel {
   calendarId?: string;
@@ -31,6 +32,7 @@ export default class Event extends RestfulModel {
   masterEventId?: string;
   originalStartTime?: number;
   conferencing?: EventConferencing;
+  notifications?: EventNotification[];
   metadata?: object;
   jobStatusId?: string;
 
@@ -217,6 +219,10 @@ Event.attributes = {
   conferencing: Attributes.Object({
     modelKey: 'conferencing',
     itemClass: EventConferencing,
+  }),
+  notifications: Attributes.Collection({
+    modelKey: 'notifications',
+    itemClass: EventNotification,
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',


### PR DESCRIPTION
# Description
Add support for [Event notifications](https://developer.nylas.com/docs/connectivity/calendar/event-notifications).

# Usage
To add notifications to an event:
```python
const notificationEvent = nylas.events.build({
  ...
  notifications: [
  {
    body: 'Reminding you about our meeting.',
    minutes_before_event: 600,
    subject: 'Test Event Notification',
    type: 'email',
  },
  {
    type: 'webhook',
    minutes_before_event: 600,
    url: 'https://hooks.service.com/services/T01A03EEXDE/B01TBNH532R/HubIZu1zog4oYdFqQ8VUcuiW',
    payload: JSON.stringify({
      text: 'Your reminder goes here!',
    }),
  },
  {
    type: 'sms',
    minutes_before_event: 60,
    message: 'Test Event Notification',
  },
  ],
});
```

To retrieve event notification details of an event:
```python
const event = await nylas.events.find("id");

const minutesBeforeEvent = event.notifications[0].minutesBeforeEvent
const type = event.notifications[0].type
const body = event.notifications[0].body
const url = event.notifications[0].url
const subject = event.notifications[0].subject
const payload = event.notifications[0].payload
const message = event.notifications[0].message
```

To update an event with a notification:
```python
const event = await nylas.events.find("id");

event.notifications = [
  {
    body: 'Reminding you about our meeting.',
    minutes_before_event: 600,
    subject: 'Test Event Notification',
    type: 'email',
  }
];
event.save();
```

To delete a notification from an event:
```python
const event = await nylas.events.find("id");

event.notifications = [];
event.save();
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.