### PR TITLE
[73526] Metadata support for Calendar and Accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for Event notifications
+* Add metadata support for `Calendar` and `ManagementAccount`
 
 ### 5.9.0 / 2021-09-24
 * Add Component CRUD Support

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -96,6 +96,9 @@ describe('Calendar', () => {
     expect.assertions(13);
     testContext.calendar.id = '8e570s302fdazx9zqwiuk9jqn';
     testContext.calendar.description = 'Updated description';
+    testContext.calendar.metadata = {
+      key: 'value',
+    };
     testContext.calendar.save().then(calendar => {
       const options = testContext.connection.request.mock.calls[0][0];
       expect(options.url.toString()).toEqual(
@@ -107,6 +110,9 @@ describe('Calendar', () => {
         description: 'Updated description',
         location: 'Santa Monica, CA',
         timezone: 'America/Los_Angeles',
+        metadata: {
+          key: 'value',
+        },
       });
       sharedCalendarEvaluation(calendar);
       expect(calendar.description).toEqual('Updated description');

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -1,4 +1,6 @@
 import Nylas from '../src/nylas';
+import NylasConnection from '../src/nylas-connection';
+import ManagementAccount from '../src/models/management-account';
 
 describe('ManagementAccount', () => {
   const CLIENT_ID = 'abc';
@@ -23,6 +25,9 @@ describe('ManagementAccount', () => {
             provider: 'gmail',
             sync_state: 'running',
             trial: false,
+            metadata: {
+              test: 'true',
+            },
           },
         ])
       );
@@ -32,6 +37,9 @@ describe('ManagementAccount', () => {
         expect(accounts[0].billingState).toEqual('paid');
         expect(accounts[0].emailAddress).toEqual('margaret@hamilton.com');
         expect(accounts[0].provider).toEqual('gmail');
+        expect(accounts[0].metadata).toEqual({
+          test: 'true',
+        });
         expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
           method: 'GET',
           qs: { limit: 100, offset: 0 },
@@ -154,43 +162,43 @@ describe('ManagementAccount', () => {
           expect(resp.success).toBe('true');
           done();
         });
-    }),
-      test('should POST to revoke all tokens of an account except one token', done => {
-        expect.assertions(4);
-        const requestMock = jest.fn();
-        requestMock
-          .mockReturnValueOnce(
-            Promise.resolve([
-              {
-                account_id: '8rilmlwuo4zmpjedz8bcplclk',
-                billing_state: 'free',
-                id: ACCOUNT_ID,
-                sync_state: 'running',
-                trial: false,
-              },
-            ])
-          )
-          .mockReturnValueOnce(Promise.resolve({ success: 'true' }));
-        Nylas.accounts.connection.request = requestMock;
-        Nylas.accounts
-          .first()
-          .then(account => account.revokeAll('abc123'))
-          .then(resp => {
-            expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-            expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
-              method: 'GET',
-              qs: { limit: 1, offset: 0 },
-              path: `/a/${CLIENT_ID}/accounts`,
-            });
-            expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
-              method: 'POST',
-              path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
-              body: { keep_access_token: 'abc123' },
-            });
-            expect(resp.success).toBe('true');
-            done();
+    });
+    test('should POST to revoke all tokens of an account except one token', done => {
+      expect.assertions(4);
+      const requestMock = jest.fn();
+      requestMock
+        .mockReturnValueOnce(
+          Promise.resolve([
+            {
+              account_id: '8rilmlwuo4zmpjedz8bcplclk',
+              billing_state: 'free',
+              id: ACCOUNT_ID,
+              sync_state: 'running',
+              trial: false,
+            },
+          ])
+        )
+        .mockReturnValueOnce(Promise.resolve({ success: 'true' }));
+      Nylas.accounts.connection.request = requestMock;
+      Nylas.accounts
+        .first()
+        .then(account => account.revokeAll('abc123'))
+        .then(resp => {
+          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
+          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+            method: 'GET',
+            qs: { limit: 1, offset: 0 },
+            path: `/a/${CLIENT_ID}/accounts`,
           });
-      });
+          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+            method: 'POST',
+            path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
+            body: { keep_access_token: 'abc123' },
+          });
+          expect(resp.success).toBe('true');
+          done();
+        });
+    });
   });
 
   describe('ip_addresses', () => {
@@ -322,6 +330,46 @@ describe('ManagementAccount', () => {
           expect(resp).toBe('Error: No access_token passed.');
           done();
         });
+    });
+  });
+
+  describe('save', () => {
+    test('Should update only metadata when saving', async done => {
+      Nylas.accounts.connection = new NylasConnection('123', {
+        clientId: CLIENT_ID,
+      });
+      Nylas.accounts.connection.request = jest.fn(() => Promise.resolve({}));
+      const accJson = {
+        account_id: '8rilmlwuo4zmpjedz8bcplclk',
+        billing_state: 'paid',
+        email: 'margaret@hamilton.com',
+        id: ACCOUNT_ID,
+        provider: 'gmail',
+        sync_state: 'running',
+        trial: false,
+      };
+      const account = new ManagementAccount(
+        Nylas.accounts.connection,
+        CLIENT_ID,
+        accJson
+      );
+      account.metadata = {
+        test: 'true',
+      };
+
+      account.save().then(() => {
+        expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          method: 'PUT',
+          path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}`,
+          qs: {},
+          body: {
+            metadata: {
+              test: 'true',
+            },
+          },
+        });
+        done();
+      });
     });
   });
 });

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -14,7 +14,6 @@ describe('ManagementAccount', () => {
 
   describe('list', () => {
     test('should do a GET request to get the account list', done => {
-      expect.assertions(6);
       Nylas.accounts.connection.request = jest.fn(() =>
         Promise.resolve([
           {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -10,6 +10,7 @@ export default class Calendar extends RestfulModel {
   timezone?: string;
   isPrimary?: boolean;
   jobStatusId?: string;
+  metadata?: object;
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
     return this._save(params, callback);
@@ -22,6 +23,7 @@ export default class Calendar extends RestfulModel {
       description: calendarJSON.description,
       location: calendarJSON.location,
       timezone: calendarJSON.timezone,
+      metadata: calendarJSON.metadata,
     };
   }
 
@@ -63,5 +65,8 @@ Calendar.attributes = {
   jobStatusId: Attributes.String({
     modelKey: 'jobStatusId',
     jsonKey: 'job_status_id',
+  }),
+  metadata: Attributes.Object({
+    modelKey: 'metadata',
   }),
 };

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -1,5 +1,6 @@
 import ManagementModel from './management-model';
 import Attributes from './attributes';
+import { SaveCallback } from './restful-model';
 
 export default class ManagementAccount extends ManagementModel {
   billingState?: string;
@@ -8,6 +9,7 @@ export default class ManagementAccount extends ManagementModel {
   provider?: string;
   syncState?: string;
   trial?: boolean;
+  metadata?: object;
 
   upgrade() {
     return this.connection
@@ -42,6 +44,7 @@ export default class ManagementAccount extends ManagementModel {
       })
       .catch(err => Promise.reject(err));
   }
+
   ipAddresses() {
     return this.connection
       .request({
@@ -50,6 +53,7 @@ export default class ManagementAccount extends ManagementModel {
       })
       .catch(err => Promise.reject(err));
   }
+
   tokenInfo(accessToken?: string) {
     return this.connection
       .request({
@@ -62,6 +66,20 @@ export default class ManagementAccount extends ManagementModel {
         },
       })
       .catch(err => Promise.reject(err));
+  }
+
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
+    return this._save(params, callback);
+  }
+
+  saveRequestBody() {
+    return {
+      metadata: this.metadata,
+    };
+  }
+
+  saveEndpoint(): string {
+    return `/a/${this.connection.clientId}/accounts`;
   }
 }
 ManagementAccount.collectionName = 'accounts';
@@ -88,5 +106,8 @@ ManagementAccount.attributes = {
   }),
   trial: Attributes.Boolean({
     modelKey: 'trial',
+  }),
+  metadata: Attributes.Object({
+    modelKey: 'metadata',
   }),
 };


### PR DESCRIPTION
# Description
The metadata feature first introduced for events has expended to `Calendar` and `Account`. This PR adds support for this change. More information on the expansion of the metadata can be found here: https://developer.nylas.com/docs/developer-tools/api/metadata

# Usage

### Adding Metadata to Calendar
```javascript
const calendar = nylas.calendars.create();
calendar.name = "My New Calendar";
calendar.description = "Description of my new calendar";
calendar.location = "Location description";
calendar.timezone = "America/Los_Angeles";
calendar.metadata = {
  test: "true",
};

calendar.save();

// Or you can update a calendar with metadata

const calendar = nylas.calendars.first();

calendar.metadata = {
  test: "true",
};

calendar.save();
```

### Query Calendars by Metadata
```javascript
const calendar = nylas.calendars.list({metadata_key: "test"});
```

### Adding Metadata to Account
```javascript
const account = Nylas.accounts.list();

account.metadata = {
  test: "true",
};

account.save();
```

### Query Account by Metadata
```javascript
const account = Nylas.accounts.list({metadata_key: "test"});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.