### PR TITLE
Metadata support for Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Unreleased
 * Add support for Event notifications
 * Add support for remaining Scheduler endpoints
-* Add metadata support for `Calendar` and `ManagementAccount`
+* Add metadata support for `Calendar`, `Message` and `ManagementAccount`
 
 ### 5.9.0 / 2021-09-24
 * Add Component CRUD Support

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -95,6 +95,27 @@ describe('Message', () => {
       });
     });
 
+    test('should do a PUT with metadata if metadata is defined', done => {
+      testContext.message.metadata = {
+        test: 'yes',
+      };
+      return testContext.message.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/messages/4333'
+        );
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          metadata: {
+            test: 'yes',
+          },
+          starred: true,
+          unread: false,
+        });
+        done();
+      });
+    });
+
     test('should resolve with the message object', done => {
       return testContext.message.save().then(message => {
         expect(message.id).toBe('4333');

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -22,6 +22,7 @@ export default class Message extends RestfulModel {
   events?: Event[];
   folder?: Folder;
   labels?: Label[];
+  metadata?: object;
   headers?: { [key: string]: string };
   failures?: any;
 
@@ -80,6 +81,7 @@ export default class Message extends RestfulModel {
 
     json['starred'] = this.starred;
     json['unread'] = this.unread;
+    json['metadata'] = this.metadata;
     return json;
   }
 
@@ -149,6 +151,9 @@ Message.attributes = {
   labels: Attributes.Collection({
     modelKey: 'labels',
     itemClass: Label,
+  }),
+  metadata: Attributes.Object({
+    modelKey: 'metadata',
   }),
   headers: Attributes.Object({
     modelKey: 'headers',


### PR DESCRIPTION
# Description
The Nylas API now supports metadata for existing messages. This is a followup to #286. 

# Usage

### Adding Metadata to a message
```javascript
const message = Nylas.messages.first();

message.metadata = {
  test: "true",
};

message.save();
```

### Query Messages by Metadata
```javascript
const messages = Nylas.messages.list({metadata_key: "test"});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.