### PR TITLE
Scheduler booking timeslot hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix bug where booking a valid timeslot resulted in an API error
+
 ### 5.10.0 / 2021-10-18
 * Add support for Event notifications
 * Add support for remaining Scheduler endpoints

--- a/__tests__/scheduler-restful-model-collection-spec.js
+++ b/__tests__/scheduler-restful-model-collection-spec.js
@@ -304,6 +304,7 @@ describe('SchedulerRestfulModelCollection', () => {
             );
             expect(options.method).toEqual('POST');
             expect(JSON.parse(options.body)).toEqual({
+              additional_emails: [],
               additional_values: {
                 test: 'yes',
               },

--- a/src/models/scheduler-booking-request.ts
+++ b/src/models/scheduler-booking-request.ts
@@ -90,6 +90,21 @@ export default class SchedulerBookingRequest extends RestfulModel {
   replacesBookingHash?: string;
   slot?: SchedulerTimeSlot;
   timezone?: string;
+
+  /*
+  * The booking endpoint requires additional_values and additional_emails
+    to exist regardless if they are empty or not
+  */
+  toJSON(enforceReadOnly?: boolean): Record<string, any> {
+    const json = super.toJSON(enforceReadOnly);
+    if(!this.additionalEmails) {
+      json["additional_emails"] = [];
+    }
+    if(!this.additionalValues) {
+      json["additional_values"] = {};
+    }
+    return json;
+  }
 }
 SchedulerBookingRequest.collectionName = 'booking_request';
 SchedulerBookingRequest.attributes = {

--- a/src/models/scheduler-booking-request.ts
+++ b/src/models/scheduler-booking-request.ts
@@ -97,11 +97,11 @@ export default class SchedulerBookingRequest extends RestfulModel {
   */
   toJSON(enforceReadOnly?: boolean): Record<string, any> {
     const json = super.toJSON(enforceReadOnly);
-    if(!this.additionalEmails) {
-      json["additional_emails"] = [];
+    if (!this.additionalEmails) {
+      json['additional_emails'] = [];
     }
-    if(!this.additionalValues) {
-      json["additional_values"] = {};
+    if (!this.additionalValues) {
+      json['additional_values'] = {};
     }
     return json;
   }


### PR DESCRIPTION
# Description
The Scheduler booking timeslot endpoint requires the booking request payload to include a value for `additional_emails` and `additional_values` even if they are set to empty or null. This PR sets them to a blank array/object to avoid this error.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.