### PR TITLE
[74829] Fix bug where updating an Event results in an API error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix bug where updating an event resulted in an API error
+
 ### 5.10.1 / 2021-10-22
 * Fix bug where booking a valid timeslot resulted in an API error
 

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -30,6 +30,12 @@ export class Attribute {
   fromJSON(val: any, _parent: any) {
     return val || null;
   }
+  saveRequestBody(val: any) {
+    if(this.readOnly) {
+      return undefined;
+    }
+    return this.toJSON(val);
+  }
 }
 
 class AttributeObject extends Attribute {
@@ -50,11 +56,13 @@ class AttributeObject extends Attribute {
     this.itemClass = itemClass;
   }
 
-  toJSON(val: any) {
+  toJSON(val: any, saveRequestBody?: boolean) {
     if (!val) {
       return val;
     }
-    if (val.toJSON != null) {
+    if (saveRequestBody === true && val.saveRequestBody != null) {
+      return val.saveRequestBody();
+    } else if (val.toJSON != null) {
       return val.toJSON();
     }
     return val;
@@ -65,6 +73,13 @@ class AttributeObject extends Attribute {
       return val;
     }
     return new this.itemClass(_parent.connection, val);
+  }
+
+  saveRequestBody(val: any) {
+    if(this.readOnly) {
+      return undefined;
+    }
+    return this.toJSON(val, true);
   }
 }
 
@@ -172,13 +187,15 @@ class AttributeCollection extends Attribute {
     this.itemClass = itemClass;
   }
 
-  toJSON(vals: any) {
+  toJSON(vals: any, saveRequestBody?: boolean) {
     if (!vals) {
       return [];
     }
     const json = [];
     for (const val of vals) {
-      if (val.toJSON != null) {
+      if (saveRequestBody === true && val.saveRequestBody != null) {
+        json.push(val.saveRequestBody());
+      } else if (val.toJSON != null) {
         json.push(val.toJSON());
       } else {
         json.push(val);
@@ -197,6 +214,13 @@ class AttributeCollection extends Attribute {
       objs.push(obj);
     }
     return objs;
+  }
+
+  saveRequestBody(val: any) {
+    if(this.readOnly) {
+      return undefined;
+    }
+    return this.toJSON(val, true);
   }
 }
 

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -32,7 +32,7 @@ export class Attribute {
   }
   saveRequestBody(val: any) {
     if (this.readOnly) {
-      return undefined;
+      return;
     }
     return this.toJSON(val);
   }
@@ -77,7 +77,7 @@ class AttributeObject extends Attribute {
 
   saveRequestBody(val: any) {
     if (this.readOnly) {
-      return undefined;
+      return;
     }
     return this.toJSON(val, true);
   }
@@ -218,7 +218,7 @@ class AttributeCollection extends Attribute {
 
   saveRequestBody(val: any) {
     if (this.readOnly) {
-      return undefined;
+      return;
     }
     return this.toJSON(val, true);
   }

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -31,7 +31,7 @@ export class Attribute {
     return val || null;
   }
   saveRequestBody(val: any) {
-    if(this.readOnly) {
+    if (this.readOnly) {
       return undefined;
     }
     return this.toJSON(val);
@@ -76,7 +76,7 @@ class AttributeObject extends Attribute {
   }
 
   saveRequestBody(val: any) {
-    if(this.readOnly) {
+    if (this.readOnly) {
       return undefined;
     }
     return this.toJSON(val, true);
@@ -217,7 +217,7 @@ class AttributeCollection extends Attribute {
   }
 
   saveRequestBody(val: any) {
-    if(this.readOnly) {
+    if (this.readOnly) {
       return undefined;
     }
     return this.toJSON(val, true);

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -24,6 +24,6 @@ EventParticipant.attributes = {
   }),
   status: Attributes.String({
     modelKey: 'status',
-    readOnly: true
+    readOnly: true,
   }),
 };

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -24,5 +24,6 @@ EventParticipant.attributes = {
   }),
   status: Attributes.String({
     modelKey: 'status',
+    readOnly: true
   }),
 };

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -129,6 +129,15 @@ export default class Event extends RestfulModel {
     return this._save(params, callback);
   }
 
+  saveRequestBody(): any {
+    const json = super.saveRequestBody();
+    if(json.when && json.when.object) {
+      delete(json.when.object);
+    }
+
+    return json;
+  }
+
   rsvp(
     status: string,
     comment: string,

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -131,8 +131,8 @@ export default class Event extends RestfulModel {
 
   saveRequestBody(): any {
     const json = super.saveRequestBody();
-    if(json.when && json.when.object) {
-      delete(json.when.object);
+    if (json.when && json.when.object) {
+      delete json.when.object;
     }
 
     return json;

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -57,8 +57,10 @@ export default class RestfulModel {
     const json: any = {};
     const attributes = this.attributes();
     for (const attrName in attributes) {
-      if (!attributes[attrName].readOnly || enforceReadOnly !== true) {
-        const attr = attributes[attrName];
+      const attr = attributes[attrName];
+      if (enforceReadOnly === true) {
+        json[attr.jsonKey] = attr.saveRequestBody((this as any)[attrName]);
+      } else {
         json[attr.jsonKey] = attr.toJSON((this as any)[attrName]);
       }
     }


### PR DESCRIPTION
# Description
A recent API update caused updating an event using the SDK to return an error because the SDK sends a Participant's status as well as an object key within the Event.when object. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.