### PR TITLE
v5.10.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
-### Unreleased
+### 5.10.2 / 2021-12-03
 * Fix Scheduler and Component types
 * Fix Component sending unmodifiable fields during update
 * Fix bug where updating an event resulted in an API error
 
-### 5.10.1 / 2021-10-22
+### 5.10.1 / 2021-11-22
 * Fix bug where booking a valid timeslot resulted in an API error
 
-### 5.10.0 / 2021-10-18
+### 5.10.0 / 2021-11-18
 * Add support for Event notifications
 * Add support for remaining Scheduler endpoints
 * Add metadata support for `Calendar`, `Message` and `ManagementAccount`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "5.10.1",
+  "version": "5.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "5.10.1",
+      "version": "5.10.2",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.10.1",
+  "version": "5.10.2",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v5.10.2 patch release fixes the following issues:
* Fix Scheduler and Component types (#293)
* Fix Component sending unmodifiable fields during update (#293)
* Fix bug where updating an event resulted in an API error (#292)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.