### PR TITLE
[75824] Job Status improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Job status improvements
+
 ### 5.10.2 / 2021-12-03
 * Fix Scheduler and Component types
 * Fix Component sending unmodifiable fields during update

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -159,4 +159,27 @@ describe('Job Status', () => {
       });
     });
   });
+
+  describe('isSuccessful', () => {
+    beforeEach(() => {
+      const response = {
+        status: 200,
+        json: () => {
+          return Promise.resolve(testContext.getApiResponse);
+        },
+        headers: new Map(),
+      };
+
+      fetch.mockImplementation(() => Promise.resolve(response));
+    });
+
+    test('job status with status = successful should return true, otherwise false', done => {
+      testContext.connection.jobStatuses.find('a1b2c3').then(jobStatus => {
+        expect(jobStatus.isSuccessful()).toBe(true);
+        jobStatus.status = "failure";
+        expect(jobStatus.isSuccessful()).toBe(false);
+        done();
+      });
+    });
+  })
 });

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -176,10 +176,10 @@ describe('Job Status', () => {
     test('job status with status = successful should return true, otherwise false', done => {
       testContext.connection.jobStatuses.find('a1b2c3').then(jobStatus => {
         expect(jobStatus.isSuccessful()).toBe(true);
-        jobStatus.status = "failure";
+        jobStatus.status = 'failure';
         expect(jobStatus.isSuccessful()).toBe(false);
         done();
       });
     });
-  })
+  });
 });

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -65,6 +65,7 @@ Calendar.attributes = {
   jobStatusId: Attributes.String({
     modelKey: 'jobStatusId',
     jsonKey: 'job_status_id',
+    readOnly: true,
   }),
   metadata: Attributes.Object({
     modelKey: 'metadata',

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -189,6 +189,7 @@ export class Contact extends RestfulModel {
   webPages?: WebPage[];
   groups?: Group[];
   source?: string;
+  jobStatusId?: string;
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback) {
     return this._save(params, callback);
@@ -279,5 +280,10 @@ Contact.attributes = {
   }),
   source: Attributes.String({
     modelKey: 'source',
+  }),
+  jobStatusId: Attributes.String({
+    modelKey: 'jobStatusId',
+    jsonKey: 'job_status_id',
+    readOnly: true,
   }),
 };

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -4,6 +4,7 @@ import Attributes from './attributes';
 export class Folder extends RestfulModel {
   displayName?: string;
   name?: string;
+  jobStatusId?: string;
 
   saveRequestBody() {
     const json: { [key: string]: any } = {};
@@ -26,6 +27,11 @@ Folder.attributes = {
   displayName: Attributes.String({
     modelKey: 'displayName',
     jsonKey: 'display_name',
+  }),
+  jobStatusId: Attributes.String({
+    modelKey: 'jobStatusId',
+    jsonKey: 'job_status_id',
+    readOnly: true,
   }),
 };
 

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -1,11 +1,18 @@
 import RestfulModel from './restful-model';
 import Attributes from './attributes';
+import Message from './message';
 
 export default class JobStatus extends RestfulModel {
   action?: string;
   createdAt?: Date;
   jobStatusId?: string;
   status?: string;
+  originalData?: Message;
+
+  // Returns the status of a job as a boolean
+  isSuccessful(): boolean {
+    return this.status === "successful";
+  }
 }
 
 JobStatus.collectionName = 'job-statuses';
@@ -13,16 +20,25 @@ JobStatus.attributes = {
   ...RestfulModel.attributes,
   action: Attributes.String({
     modelKey: 'action',
+    readOnly: true
   }),
   createdAt: Attributes.DateTime({
     modelKey: 'createdAt',
     jsonKey: 'created_at',
+    readOnly: true
   }),
   jobStatusId: Attributes.String({
     modelKey: 'jobStatusId',
     jsonKey: 'job_status_id',
+    readOnly: true
   }),
   status: Attributes.String({
     modelKey: 'status',
+    readOnly: true
+  }),
+  originalData: Attributes.Object({
+    modelKey: 'originalData',
+    jsonKey: 'original_data',
+    readOnly: true
   }),
 };

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -11,7 +11,7 @@ export default class JobStatus extends RestfulModel {
 
   // Returns the status of a job as a boolean
   isSuccessful(): boolean {
-    return this.status === "successful";
+    return this.status === 'successful';
   }
 }
 
@@ -20,25 +20,25 @@ JobStatus.attributes = {
   ...RestfulModel.attributes,
   action: Attributes.String({
     modelKey: 'action',
-    readOnly: true
+    readOnly: true,
   }),
   createdAt: Attributes.DateTime({
     modelKey: 'createdAt',
     jsonKey: 'created_at',
-    readOnly: true
+    readOnly: true,
   }),
   jobStatusId: Attributes.String({
     modelKey: 'jobStatusId',
     jsonKey: 'job_status_id',
-    readOnly: true
+    readOnly: true,
   }),
   status: Attributes.String({
     modelKey: 'status',
-    readOnly: true
+    readOnly: true,
   }),
   originalData: Attributes.Object({
     modelKey: 'originalData',
     jsonKey: 'original_data',
-    readOnly: true
+    readOnly: true,
   }),
 };

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -25,6 +25,7 @@ export default class Message extends RestfulModel {
   metadata?: object;
   headers?: { [key: string]: string };
   failures?: any;
+  jobStatusId?: string;
 
   // We calculate the list of participants instead of grabbing it from
   // a parent because it is a better source of ground truth, and saves us
@@ -157,5 +158,10 @@ Message.attributes = {
   }),
   headers: Attributes.Object({
     modelKey: 'headers',
+  }),
+  jobStatusId: Attributes.String({
+    modelKey: 'jobStatusId',
+    jsonKey: 'job_status_id',
+    readOnly: true,
   }),
 };


### PR DESCRIPTION
# Description
This PR improves the Job Status support on this SDK. Some models are missing a `job_status_id` key, as well as the Job Status model itself was missing an `original_data` key. A new helper method was also introduced to the `JobStatus` object called `isSuccessful()` that returns a boolean value representing a successful job status.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.