### PR TITLE
[76422] Add missing `provider` option for `urlForAuthentication`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add missing `provider` option for `urlForAuthentication`
+
 ### 5.10.2 / 2021-12-03
 * Fix Scheduler and Component types
 * Fix Component sending unmodifiable fields during update

--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -211,6 +211,17 @@ describe('Nylas', () => {
       );
     });
 
+    test('should use a provider when provided in the options', () => {
+      const options = {
+        loginHint: 'ben@nylas.com',
+        redirectURI: 'https://localhost/callback',
+        provider: 'icloud',
+      };
+      expect(Nylas.urlForAuthentication(options)).toEqual(
+        'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback&provider=icloud'
+      );
+    });
+
     test('should add scopes when provided in the options', () => {
       const options = {
         loginHint: 'test@nylas.com',

--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -211,8 +211,9 @@ describe('Nylas', () => {
         redirectURI,
       };
 
-      expect(Nylas.urlForAuthentication(options))
-        .toEqual(`https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}`);
+      expect(Nylas.urlForAuthentication(options)).toEqual(
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}`
+      );
     });
 
     test('should use a provider when provided in the options', () => {
@@ -225,8 +226,9 @@ describe('Nylas', () => {
         provider,
       };
 
-      expect(Nylas.urlForAuthentication(options))
-        .toEqual(`https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&provider=${provider}`);
+      expect(Nylas.urlForAuthentication(options)).toEqual(
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&provider=${provider}`
+      );
     });
 
     test('should add scopes when provided in the options', () => {
@@ -239,8 +241,9 @@ describe('Nylas', () => {
         scopes,
       };
 
-      expect(Nylas.urlForAuthentication(options))
-        .toEqual(`https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&scopes=${scopes[0]},${scopes[1]}`);
+      expect(Nylas.urlForAuthentication(options)).toEqual(
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&scopes=${scopes[0]},${scopes[1]}`
+      );
     });
   });
 

--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -170,6 +170,8 @@ describe('Nylas', () => {
   });
 
   describe('urlForAuthentication', () => {
+    const redirectURI = 'https://localhost/callback';
+
     beforeEach(() =>
       Nylas.config({
         clientId: 'newId',
@@ -182,55 +184,63 @@ describe('Nylas', () => {
 
     test('should throw an exception if the client id has not been configured', () => {
       Nylas.clientId = undefined;
-      const options = { redirectURI: 'https://localhost/callback' };
+      const options = { redirectURI: redirectURI };
       expect(() => Nylas.urlForAuthentication(options)).toThrow();
     });
 
     test('should not throw an exception if the client secret has not been configured', () => {
       Nylas.clientSecret = undefined;
-      const options = { redirectURI: 'https://localhost/callback' };
+      const options = { redirectURI: redirectURI };
       expect(Nylas.urlForAuthentication(options)).toEqual(
-        'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=&redirect_uri=https://localhost/callback'
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=&redirect_uri=${redirectURI}`
       );
     });
 
     test('should generate the correct authentication URL', () => {
       const options = { redirectURI: 'https://localhost/callback' };
       expect(Nylas.urlForAuthentication(options)).toEqual(
-        'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=&redirect_uri=https://localhost/callback'
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=&redirect_uri=${redirectURI}`
       );
     });
 
     test('should use a login hint when provided in the options', () => {
+      const loginHint = 'ben@nylas.com';
+
       const options = {
-        loginHint: 'ben@nylas.com',
-        redirectURI: 'https://localhost/callback',
+        loginHint,
+        redirectURI,
       };
-      expect(Nylas.urlForAuthentication(options)).toEqual(
-        'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback'
-      );
+
+      expect(Nylas.urlForAuthentication(options))
+        .toEqual(`https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}`);
     });
 
     test('should use a provider when provided in the options', () => {
+      const loginHint = 'ben@nylas.com',
+        provider = 'icloud';
+
       const options = {
-        loginHint: 'ben@nylas.com',
-        redirectURI: 'https://localhost/callback',
-        provider: 'icloud',
+        loginHint,
+        redirectURI,
+        provider,
       };
-      expect(Nylas.urlForAuthentication(options)).toEqual(
-        'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=ben@nylas.com&redirect_uri=https://localhost/callback&provider=icloud'
-      );
+
+      expect(Nylas.urlForAuthentication(options))
+        .toEqual(`https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&provider=${provider}`);
     });
 
     test('should add scopes when provided in the options', () => {
+      const loginHint = 'ben@nylas.com',
+        scopes = ['calendar', 'contacts'];
+
       const options = {
-        loginHint: 'test@nylas.com',
-        redirectURI: 'https://localhost/callback',
-        scopes: ['calendar', 'contacts'],
+        loginHint,
+        redirectURI,
+        scopes,
       };
-      expect(Nylas.urlForAuthentication(options)).toEqual(
-        'https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=test@nylas.com&redirect_uri=https://localhost/callback&scopes=calendar,contacts'
-      );
+
+      expect(Nylas.urlForAuthentication(options))
+        .toEqual(`https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&scopes=${scopes[0]},${scopes[1]}`);
     });
   });
 

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -171,6 +171,7 @@ class Nylas {
       redirectURI?: string;
       loginHint?: string;
       state?: string;
+      provider?: string;
       scopes?: string[];
     } = {}
   ) {
@@ -191,6 +192,9 @@ class Nylas {
     }
     if (options.scopes != null) {
       url += `&scopes=${options.scopes.join(',')}`;
+    }
+    if (options.provider != null) {
+      url += `&provider=${options.provider}`;
     }
     return url;
   }


### PR DESCRIPTION
# Description
The `oauth/authorize` endpoint supports a `provider` option for forcing authentication against a different provider, this PR adds it in.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.