### PR TITLE
v5.10.4 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.10.3 / 2022-01-04
 * Prevent `Event` objects from sending an empty list of notifications when not set, causing errors for recurring events 
 
 ### 5.10.3 / 2021-12-16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "5.10.3",
+  "version": "5.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "5.10.3",
+      "version": "5.10.4",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "5.10.3",
+  "version": "5.10.4",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v5.10.4 patch release provides the following fix:
* Prevent `Event` objects from sending an empty list of notifications when not set, causing errors for recurring events (#298)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.