### PR TITLE
[78166] Add `comment` and `phoneNumber` fields to `EventParticipant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Unreleased
-* Add `comment` and `phoneNumber` fields in `EventParticipant`
+* Add `comment` and `phoneNumber` fields to `EventParticipant`
 
 ### 6.0.0 / 2022-01-12
 * **BREAKING CHANGE**: Refactored `RestfulModel` and `RestfulModelCollection`, introduced `Model` and `ModelCollection` superclass for models that do not directly interact with the Nylas API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add `comment` and `phoneNumber` fields in `EventParticipant`
+
 ### 6.0.0 / 2022-01-12
 * **BREAKING CHANGE**: Refactored `RestfulModel` and `RestfulModelCollection`, introduced `Model` and `ModelCollection` superclass for models that do not directly interact with the Nylas API
 * **BREAKING CHANGE**: Introduction of interfaces that accompany models to improve experience when instantiating API models and provides better insight on "required" fields

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -664,7 +664,15 @@ describe('Event', () => {
             id: 'id-1234',
             title: 'test event',
             when: { time: 1409594400, object: 'time' },
-            participants: [{ name: 'foo', email: 'bar', status: 'noreply' }],
+            participants: [
+              {
+                name: 'foo',
+                email: 'bar',
+                status: 'noreply',
+                comment: 'This is a comment',
+                phone_number: '416-000-0000',
+              },
+            ],
             ical_uid: 'id-5678',
             master_event_id: 'master-1234',
             original_start_time: 1409592400,
@@ -685,11 +693,11 @@ describe('Event', () => {
             new Date(1409592400 * 1000).toString()
           );
           const participant = event.participants[0];
-          expect(participant.toJSON()).toEqual({
-            name: 'foo',
-            email: 'bar',
-            status: 'noreply',
-          });
+          expect(participant.name).toEqual('foo');
+          expect(participant.email).toEqual('bar');
+          expect(participant.status).toEqual('noreply');
+          expect(participant.comment).toEqual('This is a comment');
+          expect(participant.phoneNumber).toEqual('416-000-0000');
           done();
         });
       });

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -4,6 +4,8 @@ import Model from './model';
 export type EventParticipantProperties = {
   email: string;
   name?: string;
+  comment?: string;
+  phoneNumber?: string;
   status?: string;
 };
 
@@ -11,6 +13,8 @@ export default class EventParticipant extends Model
   implements EventParticipantProperties {
   email = '';
   name?: string;
+  comment?: string;
+  phoneNumber?: string;
   status?: string;
 
   constructor(props?: EventParticipantProperties) {
@@ -33,6 +37,13 @@ EventParticipant.attributes = {
   }),
   email: Attributes.String({
     modelKey: 'email',
+  }),
+  comment: Attributes.String({
+    modelKey: 'comment',
+  }),
+  phoneNumber: Attributes.String({
+    modelKey: 'phoneNumber',
+    jsonKey: 'phone_number',
   }),
   status: Attributes.String({
     modelKey: 'status',


### PR DESCRIPTION
# Description
This PR enables two new fields in `EventParticipant`, `comment` and `phoneNumber`. More detail can be found in the [API reference](https://developer.nylas.com/docs/api/#post/events).

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.