### PR TITLE
[78923] Fix `saveRequestBody()` for `Model` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add `comment` and `phoneNumber` fields to `EventParticipant`
+* Fix issue where properties of `Model` type were sending read-only attributes to the API
 
 ### 6.0.0 / 2022-01-12
 * **BREAKING CHANGE**: Refactored `RestfulModel` and `RestfulModelCollection`, introduced `Model` and `ModelCollection` superclass for models that do not directly interact with the Nylas API

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -138,6 +138,7 @@ describe('Event', () => {
       testContext.event.when = new When();
       testContext.event.start = 1408875644;
       testContext.event.end = 1408875644;
+      testContext.event.when.object = "timespan";
       return testContext.event.save().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -4,6 +4,7 @@ import EventConferencing from '../src/models/event-conferencing';
 import Nylas from '../src/nylas';
 import fetch from 'node-fetch';
 import When from '../src/models/when';
+import EventParticipant from '../src/models/event-participant';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -138,7 +139,7 @@ describe('Event', () => {
       testContext.event.when = new When();
       testContext.event.start = 1408875644;
       testContext.event.end = 1408875644;
-      testContext.event.when.object = "timespan";
+      testContext.event.when.object = 'timespan';
       return testContext.event.save().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
@@ -708,6 +709,35 @@ describe('Event', () => {
           expect(err).toBe(null);
           expect(event.id).toBe('id-1234');
           expect(event.title).toBe('test event');
+          done();
+        });
+      });
+
+      test('should not send the status object within the participant object', done => {
+        testContext.event.participants = [
+          new EventParticipant({
+            name: 'foo',
+            email: 'bar',
+            status: 'noreply',
+            comment: 'This is a comment',
+            phoneNumber: '416-000-0000',
+          }),
+        ];
+        return testContext.event.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.body).toEqual({
+            calendar_id: '',
+            when: {},
+            participants: [
+              {
+                name: 'foo',
+                email: 'bar',
+                comment: 'This is a comment',
+                phone_number: '416-000-0000',
+                status: undefined,
+              },
+            ],
+          });
           done();
         });
       });

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -167,9 +167,6 @@ export default class Event extends RestfulModel {
 
   saveRequestBody(): Record<string, unknown> {
     const json = super.saveRequestBody();
-    if (json.when && (json.when as WhenProperties).object) {
-      delete (json.when as WhenProperties).object;
-    }
     if (!this.notifications) {
       delete json.notifications;
     }

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -60,6 +60,12 @@ export default class Model {
     return json;
   }
 
+  // saveRequestBody is used by save(). It returns a JSON dict containing only the
+  // fields the API allows updating. Subclasses should override this method.
+  saveRequestBody(): Record<string, unknown> {
+    return this.toJSON(true);
+  }
+
   toString(): string {
     return JSON.stringify(this.toJSON());
   }

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -66,12 +66,6 @@ export default class RestfulModel extends Model {
     return `${this.pathPrefix()}/${collectionName}`;
   }
 
-  // saveRequestBody is used by save(). It returns a JSON dict containing only the
-  // fields the API allows updating. Subclasses should override this method.
-  saveRequestBody(): Record<string, unknown> {
-    return this.toJSON(true);
-  }
-
   // deleteRequestQueryString is used by delete(). Subclasses should override this method.
   deleteRequestQueryString(
     _params: Record<string, unknown>

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -51,5 +51,6 @@ When.attributes = {
   }),
   object: Attributes.String({
     modelKey: 'object',
+    readOnly: true,
   }),
 };


### PR DESCRIPTION
# Description
`saveRequestBody()` was introduced prior to the v6.0 release to enforce read-only attributes not being serialized for outgoing API calls. With the introduction of the `Model` superclass in v6.0 a lot of objects got refactored from extending `RestfulModel` to `Model`, but `saveRequestBody()` remained on `RestfulModel`. This broke the serialization of `Model` properties. To resolve this, we moved `saveRequestBody()` to the `Model` superclass.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.