### PR TITLE
[79531] Move `attributes` and `collectionName` into classes as a static variables

### DIFF
--- a/src/models/access-token.ts
+++ b/src/models/access-token.ts
@@ -1,5 +1,5 @@
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 
 export type AccessTokenProperties = {
   accessToken: string;
@@ -16,31 +16,30 @@ export default class AccessToken extends Model
   emailAddress = '';
   provider = '';
   tokenType = 'bearer';
+  static attributes: Record<string, Attribute> = {
+    accessToken: Attributes.String({
+      modelKey: 'accessToken',
+      jsonKey: 'access_token',
+    }),
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+    }),
+    emailAddress: Attributes.String({
+      modelKey: 'emailAddress',
+      jsonKey: 'email_address',
+    }),
+    provider: Attributes.String({
+      modelKey: 'provider',
+    }),
+    tokenType: Attributes.String({
+      modelKey: 'tokenType',
+      jsonKey: 'token_type',
+    }),
+  };
 
   constructor(props?: AccessTokenProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-AccessToken.attributes = {
-  accessToken: Attributes.String({
-    modelKey: 'accessToken',
-    jsonKey: 'access_token',
-  }),
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-  }),
-  emailAddress: Attributes.String({
-    modelKey: 'emailAddress',
-    jsonKey: 'email_address',
-  }),
-  provider: Attributes.String({
-    modelKey: 'provider',
-  }),
-  tokenType: Attributes.String({
-    modelKey: 'tokenType',
-    jsonKey: 'token_type',
-  }),
-};

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,5 +1,5 @@
 import RestfulModel from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 
 export type AccountProperties = {
@@ -22,51 +22,51 @@ export default class Account extends RestfulModel implements AccountProperties {
   linkedAt = new Date();
   accessToken = '';
   billingState?: string;
+  static collectionName = 'accounts';
+  static endpointName = 'account';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+
+    emailAddress: Attributes.String({
+      modelKey: 'emailAddress',
+      jsonKey: 'email_address',
+    }),
+
+    provider: Attributes.String({
+      modelKey: 'provider',
+    }),
+
+    organizationUnit: Attributes.String({
+      modelKey: 'organizationUnit',
+      jsonKey: 'organization_unit',
+    }),
+
+    syncState: Attributes.String({
+      modelKey: 'syncState',
+      jsonKey: 'sync_state',
+    }),
+
+    billingState: Attributes.String({
+      modelKey: 'billingState',
+      jsonKey: 'billing_state',
+    }),
+
+    linkedAt: Attributes.DateTime({
+      modelKey: 'linkedAt',
+      jsonKey: 'linked_at',
+    }),
+
+    accessToken: Attributes.String({
+      modelKey: 'accessToken',
+      jsonKey: 'access_token',
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: AccountProperties) {
     super(connection, props);
     this.initAttributes(props);
   }
 }
-Account.collectionName = 'accounts';
-Account.endpointName = 'account';
-Account.attributes = {
-  ...RestfulModel.attributes,
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-
-  emailAddress: Attributes.String({
-    modelKey: 'emailAddress',
-    jsonKey: 'email_address',
-  }),
-
-  provider: Attributes.String({
-    modelKey: 'provider',
-  }),
-
-  organizationUnit: Attributes.String({
-    modelKey: 'organizationUnit',
-    jsonKey: 'organization_unit',
-  }),
-
-  syncState: Attributes.String({
-    modelKey: 'syncState',
-    jsonKey: 'sync_state',
-  }),
-
-  billingState: Attributes.String({
-    modelKey: 'billingState',
-    jsonKey: 'billing_state',
-  }),
-
-  linkedAt: Attributes.DateTime({
-    modelKey: 'linkedAt',
-    jsonKey: 'linked_at',
-  }),
-
-  accessToken: Attributes.String({
-    modelKey: 'accessToken',
-    jsonKey: 'access_token',
-  }),
-};

--- a/src/models/application-details.ts
+++ b/src/models/application-details.ts
@@ -1,5 +1,5 @@
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 
 export type ApplicationDetailsProperties = {
   applicationName?: string;
@@ -12,24 +12,23 @@ export default class ApplicationDetails extends Model
   applicationName = '';
   iconUrl = '';
   redirectUris: string[] = [];
+  static attributes: Record<string, Attribute> = {
+    applicationName: Attributes.String({
+      modelKey: 'applicationName',
+      jsonKey: 'application_name',
+    }),
+    iconUrl: Attributes.String({
+      modelKey: 'iconUrl',
+      jsonKey: 'icon_url',
+    }),
+    redirectUris: Attributes.StringList({
+      modelKey: 'redirectUris',
+      jsonKey: 'redirect_uris',
+    }),
+  };
 
   constructor(props?: ApplicationDetailsProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-ApplicationDetails.attributes = {
-  applicationName: Attributes.String({
-    modelKey: 'applicationName',
-    jsonKey: 'application_name',
-  }),
-  iconUrl: Attributes.String({
-    modelKey: 'iconUrl',
-    jsonKey: 'icon_url',
-  }),
-  redirectUris: Attributes.StringList({
-    modelKey: 'redirectUris',
-    jsonKey: 'redirect_uris',
-  }),
-};

--- a/src/models/calendar-availability.ts
+++ b/src/models/calendar-availability.ts
@@ -1,5 +1,5 @@
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import { FreeBusyProperties, TimeSlot, TimeSlotProperties } from './free-busy';
 
 export enum RoundRobin {
@@ -52,33 +52,33 @@ export class OpenHours extends Model implements OpenHoursProperties {
   timezone = '';
   start = '';
   end = '';
+  static attributes: Record<string, Attribute> = {
+    objectType: Attributes.String({
+      modelKey: 'objectType',
+      jsonKey: 'object_type',
+    }),
+    emails: Attributes.StringList({
+      modelKey: 'emails',
+    }),
+    days: Attributes.NumberList({
+      modelKey: 'days',
+    }),
+    timezone: Attributes.String({
+      modelKey: 'timezone',
+    }),
+    start: Attributes.String({
+      modelKey: 'start',
+    }),
+    end: Attributes.String({
+      modelKey: 'end',
+    }),
+  };
 
   constructor(props?: OpenHoursProperties) {
     super();
     this.initAttributes(props);
   }
 }
-OpenHours.attributes = {
-  objectType: Attributes.String({
-    modelKey: 'objectType',
-    jsonKey: 'object_type',
-  }),
-  emails: Attributes.StringList({
-    modelKey: 'emails',
-  }),
-  days: Attributes.NumberList({
-    modelKey: 'days',
-  }),
-  timezone: Attributes.String({
-    modelKey: 'timezone',
-  }),
-  start: Attributes.String({
-    modelKey: 'start',
-  }),
-  end: Attributes.String({
-    modelKey: 'end',
-  }),
-};
 
 export type CalendarConsecutiveAvailabilityProperties = {
   emails: string[];
@@ -91,25 +91,25 @@ export class CalendarConsecutiveAvailability extends Model
   emails: string[] = [];
   startTime = 0;
   endTime = 0;
+  static attributes: Record<string, Attribute> = {
+    emails: Attributes.StringList({
+      modelKey: 'emails',
+    }),
+    startTime: Attributes.Number({
+      modelKey: 'startTime',
+      jsonKey: 'start_time',
+    }),
+    endTime: Attributes.Number({
+      modelKey: 'endTime',
+      jsonKey: 'end_time',
+    }),
+  };
 
   constructor(props?: CalendarConsecutiveAvailabilityProperties) {
     super();
     this.initAttributes(props);
   }
 }
-CalendarConsecutiveAvailability.attributes = {
-  emails: Attributes.StringList({
-    modelKey: 'emails',
-  }),
-  startTime: Attributes.Number({
-    modelKey: 'startTime',
-    jsonKey: 'start_time',
-  }),
-  endTime: Attributes.Number({
-    modelKey: 'endTime',
-    jsonKey: 'end_time',
-  }),
-};
 
 export type CalendarAvailabilityProperties = {
   timeSlots: TimeSlotProperties[];
@@ -119,16 +119,16 @@ export default class CalendarAvailability extends Model
   implements CalendarAvailabilityProperties {
   object = 'availability';
   timeSlots: TimeSlot[] = [];
+  static attributes: Record<string, Attribute> = {
+    timeSlots: Attributes.Collection({
+      modelKey: 'timeSlots',
+      jsonKey: 'time_slots',
+      itemClass: TimeSlot,
+    }),
+  };
 
   constructor(props?: CalendarAvailabilityProperties) {
     super();
     this.initAttributes(props);
   }
 }
-CalendarAvailability.attributes = {
-  timeSlots: Attributes.Collection({
-    modelKey: 'timeSlots',
-    jsonKey: 'time_slots',
-    itemClass: TimeSlot,
-  }),
-};

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -1,6 +1,6 @@
 import RestfulModel, { SaveCallback } from './restful-model';
 import { GetCallback } from './model-collection';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 import JobStatus from './job-status';
 
@@ -25,6 +25,40 @@ export default class Calendar extends RestfulModel
   isPrimary?: boolean;
   jobStatusId?: string;
   metadata?: object;
+  static collectionName = 'calendars';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    description: Attributes.String({
+      modelKey: 'description',
+    }),
+    readOnly: Attributes.Boolean({
+      modelKey: 'readOnly',
+      jsonKey: 'read_only',
+      readOnly: true,
+    }),
+    location: Attributes.String({
+      modelKey: 'location',
+    }),
+    timezone: Attributes.String({
+      modelKey: 'timezone',
+    }),
+    isPrimary: Attributes.Boolean({
+      modelKey: 'isPrimary',
+      jsonKey: 'is_primary',
+      readOnly: true,
+    }),
+    jobStatusId: Attributes.String({
+      modelKey: 'jobStatusId',
+      jsonKey: 'job_status_id',
+      readOnly: true,
+    }),
+    metadata: Attributes.Object({
+      modelKey: 'metadata',
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: CalendarProperties) {
     super(connection, props);
@@ -57,38 +91,3 @@ export default class Calendar extends RestfulModel
     return this.connection.jobStatuses.find(this.jobStatusId, callback);
   }
 }
-
-Calendar.collectionName = 'calendars';
-Calendar.attributes = {
-  ...RestfulModel.attributes,
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  description: Attributes.String({
-    modelKey: 'description',
-  }),
-  readOnly: Attributes.Boolean({
-    modelKey: 'readOnly',
-    jsonKey: 'read_only',
-    readOnly: true,
-  }),
-  location: Attributes.String({
-    modelKey: 'location',
-  }),
-  timezone: Attributes.String({
-    modelKey: 'timezone',
-  }),
-  isPrimary: Attributes.Boolean({
-    modelKey: 'isPrimary',
-    jsonKey: 'is_primary',
-    readOnly: true,
-  }),
-  jobStatusId: Attributes.String({
-    modelKey: 'jobStatusId',
-    jsonKey: 'job_status_id',
-    readOnly: true,
-  }),
-  metadata: Attributes.Object({
-    modelKey: 'metadata',
-  }),
-};

--- a/src/models/component.ts
+++ b/src/models/component.ts
@@ -1,5 +1,5 @@
 import RestfulModel, { SaveCallback } from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 
 export type ComponentProperties = {
@@ -31,6 +31,53 @@ export default class Component extends RestfulModel
   accessToken?: string;
   createdAt?: Date;
   updatedAt?: Date;
+  static collectionName = 'component';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    action: Attributes.Number({
+      modelKey: 'action',
+    }),
+    active: Attributes.Boolean({
+      modelKey: 'active',
+    }),
+    settings: Attributes.Object({
+      modelKey: 'settings',
+    }),
+    allowedDomains: Attributes.StringList({
+      modelKey: 'allowedDomains',
+      jsonKey: 'allowed_domains',
+    }),
+    publicAccountId: Attributes.String({
+      modelKey: 'publicAccountId',
+      jsonKey: 'public_account_id',
+    }),
+    publicTokenId: Attributes.String({
+      modelKey: 'publicTokenId',
+      jsonKey: 'public_token_id',
+    }),
+    publicApplicationId: Attributes.String({
+      modelKey: 'publicApplicationId',
+      jsonKey: 'public_application_id',
+    }),
+    accessToken: Attributes.String({
+      modelKey: 'accessToken',
+      jsonKey: 'access_token',
+    }),
+    createdAt: Attributes.Date({
+      modelKey: 'createdAt',
+      jsonKey: 'created_at',
+    }),
+    updatedAt: Attributes.Date({
+      modelKey: 'updatedAt',
+      jsonKey: 'updated_at',
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: ComponentProperties) {
     super(connection, props);
@@ -56,50 +103,3 @@ export default class Component extends RestfulModel
     return json;
   }
 }
-Component.collectionName = 'component';
-Component.attributes = {
-  ...RestfulModel.attributes,
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  action: Attributes.Number({
-    modelKey: 'action',
-  }),
-  active: Attributes.Boolean({
-    modelKey: 'active',
-  }),
-  settings: Attributes.Object({
-    modelKey: 'settings',
-  }),
-  allowedDomains: Attributes.StringList({
-    modelKey: 'allowedDomains',
-    jsonKey: 'allowed_domains',
-  }),
-  publicAccountId: Attributes.String({
-    modelKey: 'publicAccountId',
-    jsonKey: 'public_account_id',
-  }),
-  publicTokenId: Attributes.String({
-    modelKey: 'publicTokenId',
-    jsonKey: 'public_token_id',
-  }),
-  publicApplicationId: Attributes.String({
-    modelKey: 'publicApplicationId',
-    jsonKey: 'public_application_id',
-  }),
-  accessToken: Attributes.String({
-    modelKey: 'accessToken',
-    jsonKey: 'access_token',
-  }),
-  createdAt: Attributes.Date({
-    modelKey: 'createdAt',
-    jsonKey: 'created_at',
-  }),
-  updatedAt: Attributes.Date({
-    modelKey: 'updatedAt',
-    jsonKey: 'updated_at',
-  }),
-};

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -1,6 +1,6 @@
 import NylasConnection from '../nylas-connection';
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Account from './account';
 
 export enum Scope {
@@ -34,35 +34,35 @@ export class VirtualCalendar extends Model
   scopes: Scope[] = [];
   settings = {};
   clientId?: string;
+  static attributes: Record<string, Attribute> = {
+    provider: Attributes.String({
+      modelKey: 'provider',
+    }),
+    clientId: Attributes.String({
+      modelKey: 'clientId',
+      jsonKey: 'client_id',
+    }),
+    emailAddress: Attributes.String({
+      modelKey: 'emailAddress',
+      jsonKey: 'email',
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    scopes: Attributes.EnumList({
+      modelKey: 'scopes',
+      itemClass: Scope,
+    }),
+    settings: Attributes.Object({
+      modelKey: 'settings',
+    }),
+  };
 
   constructor(props?: VirtualCalendarProperties) {
     super();
     this.initAttributes(props);
   }
 }
-VirtualCalendar.attributes = {
-  provider: Attributes.String({
-    modelKey: 'provider',
-  }),
-  clientId: Attributes.String({
-    modelKey: 'clientId',
-    jsonKey: 'client_id',
-  }),
-  emailAddress: Attributes.String({
-    modelKey: 'emailAddress',
-    jsonKey: 'email',
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  scopes: Attributes.EnumList({
-    modelKey: 'scopes',
-    itemClass: Scope,
-  }),
-  settings: Attributes.Object({
-    modelKey: 'settings',
-  }),
-};
 
 export enum NativeAuthenticationProvider {
   Gmail = 'gmail',
@@ -93,6 +93,30 @@ export class NativeAuthentication extends Model
   settings = {};
   scopes: Scope[] = [];
   clientId?: string;
+  static attributes: Record<string, Attribute> = {
+    clientId: Attributes.String({
+      modelKey: 'clientId',
+      jsonKey: 'client_id',
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    emailAddress: Attributes.String({
+      modelKey: 'emailAddress',
+      jsonKey: 'email_address',
+    }),
+    provider: Attributes.Enum({
+      modelKey: 'provider',
+      itemClass: NativeAuthenticationProvider,
+    }),
+    scopes: Attributes.EnumList({
+      modelKey: 'scopes',
+      itemClass: Scope,
+    }),
+    settings: Attributes.Object({
+      modelKey: 'settings',
+    }),
+  };
 
   constructor(props?: NativeAuthenticationProperties) {
     super();
@@ -112,30 +136,6 @@ export class NativeAuthentication extends Model
     return super.fromJSON(json);
   }
 }
-NativeAuthentication.attributes = {
-  clientId: Attributes.String({
-    modelKey: 'clientId',
-    jsonKey: 'client_id',
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  emailAddress: Attributes.String({
-    modelKey: 'emailAddress',
-    jsonKey: 'email_address',
-  }),
-  provider: Attributes.Enum({
-    modelKey: 'provider',
-    itemClass: NativeAuthenticationProvider,
-  }),
-  scopes: Attributes.EnumList({
-    modelKey: 'scopes',
-    itemClass: Scope,
-  }),
-  settings: Attributes.Object({
-    modelKey: 'settings',
-  }),
-};
 
 export default class Connect {
   connection: NylasConnection;

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,5 +1,5 @@
 import RestfulModel, { SaveCallback } from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
 
@@ -11,21 +11,20 @@ export type EmailAddressProperties = {
 export class EmailAddress extends Model implements EmailAddressProperties {
   type = '';
   email = '';
+  static attributes: Record<string, Attribute> = {
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+  };
 
   constructor(props?: EmailAddressProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-EmailAddress.attributes = {
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-};
 
 export type IMAddressProperties = {
   type: string;
@@ -35,22 +34,21 @@ export type IMAddressProperties = {
 export class IMAddress extends Model implements IMAddressProperties {
   type = '';
   imAddress = '';
+  static attributes: Record<string, Attribute> = {
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    imAddress: Attributes.String({
+      modelKey: 'imAddress',
+      jsonKey: 'im_address',
+    }),
+  };
 
   constructor(props?: IMAddressProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-IMAddress.attributes = {
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  imAddress: Attributes.String({
-    modelKey: 'imAddress',
-    jsonKey: 'im_address',
-  }),
-};
 
 export type PhysicalAddressProperties = {
   type: string;
@@ -73,6 +71,34 @@ export class PhysicalAddress extends Model
   state = '';
   country = '';
   address = '';
+  static attributes: Record<string, Attribute> = {
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    format: Attributes.String({
+      modelKey: 'format',
+    }),
+    address: Attributes.String({
+      modelKey: 'address',
+    }),
+    streetAddress: Attributes.String({
+      modelKey: 'streetAddress',
+      jsonKey: 'street_address',
+    }),
+    city: Attributes.String({
+      modelKey: 'city',
+    }),
+    postalCode: Attributes.String({
+      modelKey: 'postalCode',
+      jsonKey: 'postal_code',
+    }),
+    state: Attributes.String({
+      modelKey: 'state',
+    }),
+    country: Attributes.String({
+      modelKey: 'country',
+    }),
+  };
 
   constructor(props?: PhysicalAddressProperties) {
     super();
@@ -97,35 +123,6 @@ export class PhysicalAddress extends Model
   }
 }
 
-PhysicalAddress.attributes = {
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  format: Attributes.String({
-    modelKey: 'format',
-  }),
-  address: Attributes.String({
-    modelKey: 'address',
-  }),
-  streetAddress: Attributes.String({
-    modelKey: 'streetAddress',
-    jsonKey: 'street_address',
-  }),
-  city: Attributes.String({
-    modelKey: 'city',
-  }),
-  postalCode: Attributes.String({
-    modelKey: 'postalCode',
-    jsonKey: 'postal_code',
-  }),
-  state: Attributes.String({
-    modelKey: 'state',
-  }),
-  country: Attributes.String({
-    modelKey: 'country',
-  }),
-};
-
 export type PhoneNumberProperties = {
   type: string;
   number: string;
@@ -134,21 +131,20 @@ export type PhoneNumberProperties = {
 export class PhoneNumber extends Model implements PhoneNumberProperties {
   type = '';
   number = '';
+  static attributes: Record<string, Attribute> = {
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    number: Attributes.String({
+      modelKey: 'number',
+    }),
+  };
 
   constructor(props?: PhoneNumberProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-PhoneNumber.attributes = {
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  number: Attributes.String({
-    modelKey: 'number',
-  }),
-};
 
 export type WebPageProperties = {
   type: string;
@@ -158,21 +154,20 @@ export type WebPageProperties = {
 export class WebPage extends Model implements WebPageProperties {
   type = '';
   url = '';
+  static attributes: Record<string, Attribute> = {
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    url: Attributes.String({
+      modelKey: 'url',
+    }),
+  };
 
   constructor(props?: WebPageProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-WebPage.attributes = {
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  url: Attributes.String({
-    modelKey: 'url',
-  }),
-};
 
 export type GroupProperties = {
   name: string;
@@ -188,34 +183,33 @@ export class Group extends Model implements GroupProperties {
   id?: string;
   accountId?: string;
   object?: string;
+  static attributes: Record<string, Attribute> = {
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    path: Attributes.String({
+      modelKey: 'path',
+    }),
+    id: Attributes.String({
+      modelKey: 'id',
+      readOnly: true,
+    }),
+    object: Attributes.String({
+      modelKey: 'object',
+      readOnly: true,
+    }),
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+      readOnly: true,
+    }),
+  };
 
   constructor(props?: GroupProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-Group.attributes = {
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  path: Attributes.String({
-    modelKey: 'path',
-  }),
-  id: Attributes.String({
-    modelKey: 'id',
-    readOnly: true,
-  }),
-  object: Attributes.String({
-    modelKey: 'object',
-    readOnly: true,
-  }),
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-    readOnly: true,
-  }),
-};
 
 export type ContactProperties = {
   givenName?: string;
@@ -258,6 +252,90 @@ export default class Contact extends RestfulModel implements ContactProperties {
   groups?: Group[];
   source?: string;
   jobStatusId?: string;
+  static collectionName = 'contacts';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    givenName: Attributes.String({
+      modelKey: 'givenName',
+      jsonKey: 'given_name',
+    }),
+    middleName: Attributes.String({
+      modelKey: 'middleName',
+      jsonKey: 'middle_name',
+    }),
+    surname: Attributes.String({
+      modelKey: 'surname',
+    }),
+    suffix: Attributes.String({
+      modelKey: 'suffix',
+    }),
+    nickname: Attributes.String({
+      modelKey: 'nickname',
+    }),
+    birthday: Attributes.String({
+      modelKey: 'birthday',
+    }),
+    companyName: Attributes.String({
+      modelKey: 'companyName',
+      jsonKey: 'company_name',
+    }),
+    jobTitle: Attributes.String({
+      modelKey: 'jobTitle',
+      jsonKey: 'job_title',
+    }),
+    managerName: Attributes.String({
+      modelKey: 'managerName',
+      jsonKey: 'manager_name',
+    }),
+    officeLocation: Attributes.String({
+      modelKey: 'officeLocation',
+      jsonKey: 'office_location',
+    }),
+    notes: Attributes.String({
+      modelKey: 'notes',
+    }),
+    pictureUrl: Attributes.String({
+      modelKey: 'pictureUrl',
+      jsonKey: 'picture_url',
+    }),
+    emailAddresses: Attributes.Collection({
+      modelKey: 'emailAddresses',
+      jsonKey: 'emails',
+      itemClass: EmailAddress,
+    }),
+    imAddresses: Attributes.Collection({
+      modelKey: 'imAddresses',
+      jsonKey: 'im_addresses',
+      itemClass: IMAddress,
+    }),
+    physicalAddresses: Attributes.Collection({
+      modelKey: 'physicalAddresses',
+      jsonKey: 'physical_addresses',
+      itemClass: PhysicalAddress,
+    }),
+    phoneNumbers: Attributes.Collection({
+      modelKey: 'phoneNumbers',
+      jsonKey: 'phone_numbers',
+      itemClass: PhoneNumber,
+    }),
+    webPages: Attributes.Collection({
+      modelKey: 'webPages',
+      jsonKey: 'web_pages',
+      itemClass: WebPage,
+    }),
+    groups: Attributes.Collection({
+      modelKey: 'groups',
+      itemClass: Group,
+    }),
+    source: Attributes.String({
+      modelKey: 'source',
+    }),
+    jobStatusId: Attributes.String({
+      modelKey: 'jobStatusId',
+      jsonKey: 'job_status_id',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: ContactProperties) {
     super(connection);
@@ -275,88 +353,3 @@ export default class Contact extends RestfulModel implements ContactProperties {
     return super.save(params, callback);
   }
 }
-
-Contact.collectionName = 'contacts';
-Contact.attributes = {
-  ...RestfulModel.attributes,
-  givenName: Attributes.String({
-    modelKey: 'givenName',
-    jsonKey: 'given_name',
-  }),
-  middleName: Attributes.String({
-    modelKey: 'middleName',
-    jsonKey: 'middle_name',
-  }),
-  surname: Attributes.String({
-    modelKey: 'surname',
-  }),
-  suffix: Attributes.String({
-    modelKey: 'suffix',
-  }),
-  nickname: Attributes.String({
-    modelKey: 'nickname',
-  }),
-  birthday: Attributes.String({
-    modelKey: 'birthday',
-  }),
-  companyName: Attributes.String({
-    modelKey: 'companyName',
-    jsonKey: 'company_name',
-  }),
-  jobTitle: Attributes.String({
-    modelKey: 'jobTitle',
-    jsonKey: 'job_title',
-  }),
-  managerName: Attributes.String({
-    modelKey: 'managerName',
-    jsonKey: 'manager_name',
-  }),
-  officeLocation: Attributes.String({
-    modelKey: 'officeLocation',
-    jsonKey: 'office_location',
-  }),
-  notes: Attributes.String({
-    modelKey: 'notes',
-  }),
-  pictureUrl: Attributes.String({
-    modelKey: 'pictureUrl',
-    jsonKey: 'picture_url',
-  }),
-  emailAddresses: Attributes.Collection({
-    modelKey: 'emailAddresses',
-    jsonKey: 'emails',
-    itemClass: EmailAddress,
-  }),
-  imAddresses: Attributes.Collection({
-    modelKey: 'imAddresses',
-    jsonKey: 'im_addresses',
-    itemClass: IMAddress,
-  }),
-  physicalAddresses: Attributes.Collection({
-    modelKey: 'physicalAddresses',
-    jsonKey: 'physical_addresses',
-    itemClass: PhysicalAddress,
-  }),
-  phoneNumbers: Attributes.Collection({
-    modelKey: 'phoneNumbers',
-    jsonKey: 'phone_numbers',
-    itemClass: PhoneNumber,
-  }),
-  webPages: Attributes.Collection({
-    modelKey: 'webPages',
-    jsonKey: 'web_pages',
-    itemClass: WebPage,
-  }),
-  groups: Attributes.Collection({
-    modelKey: 'groups',
-    itemClass: Group,
-  }),
-  source: Attributes.String({
-    modelKey: 'source',
-  }),
-  jobStatusId: Attributes.String({
-    modelKey: 'jobStatusId',
-    jsonKey: 'job_status_id',
-    readOnly: true,
-  }),
-};

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -1,5 +1,5 @@
 import Message, { MessageProperties } from './message';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import { SaveCallback } from './restful-model';
 import NylasConnection from '../nylas-connection';
 
@@ -18,6 +18,21 @@ export default class Draft extends Message implements DraftProperties {
   rawMime?: string;
   replyToMessageId?: string;
   version?: number;
+  static collectionName = 'drafts';
+  static attributes: Record<string, Attribute> = {
+    ...Message.attributes,
+    version: Attributes.Number({
+      modelKey: 'version',
+    }),
+    replyToMessageId: Attributes.String({
+      modelKey: 'replyToMessageId',
+      jsonKey: 'reply_to_message_id',
+    }),
+    rawMime: Attributes.String({
+      modelKey: 'rawMime',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: DraftProperties) {
     super(connection, props);
@@ -131,18 +146,3 @@ export default class Draft extends Message implements DraftProperties {
       });
   }
 }
-Draft.collectionName = 'drafts';
-Draft.attributes = {
-  ...Message.attributes,
-  version: Attributes.Number({
-    modelKey: 'version',
-  }),
-  replyToMessageId: Attributes.String({
-    modelKey: 'replyToMessageId',
-    jsonKey: 'reply_to_message_id',
-  }),
-  rawMime: Attributes.String({
-    modelKey: 'rawMime',
-    readOnly: true,
-  }),
-};

--- a/src/models/email-participant.ts
+++ b/src/models/email-participant.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Model from './model';
 
 export type EmailParticipantProperties = {
@@ -10,6 +10,14 @@ export default class EmailParticipant extends Model
   implements EmailParticipantProperties {
   email = '';
   name?: string;
+  static attributes: Record<string, Attribute> = {
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+  };
 
   constructor(props?: EmailParticipantProperties) {
     super();
@@ -24,11 +32,3 @@ export default class EmailParticipant extends Model
     return json;
   }
 }
-EmailParticipant.attributes = {
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-};

--- a/src/models/event-conferencing.ts
+++ b/src/models/event-conferencing.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Model from './model';
 
 export type EventConferencingDetailsProperties = {
@@ -16,31 +16,30 @@ export class EventConferencingDetails extends Model
   password?: string;
   pin?: string;
   url?: string;
+  static attributes: Record<string, Attribute> = {
+    meetingCode: Attributes.String({
+      modelKey: 'meetingCode',
+      jsonKey: 'meeting_code',
+    }),
+    phone: Attributes.StringList({
+      modelKey: 'phone',
+    }),
+    password: Attributes.String({
+      modelKey: 'password',
+    }),
+    pin: Attributes.String({
+      modelKey: 'pin',
+    }),
+    url: Attributes.String({
+      modelKey: 'url',
+    }),
+  };
 
   constructor(props?: EventConferencingProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-EventConferencingDetails.attributes = {
-  meetingCode: Attributes.String({
-    modelKey: 'meetingCode',
-    jsonKey: 'meeting_code',
-  }),
-  phone: Attributes.StringList({
-    modelKey: 'phone',
-  }),
-  password: Attributes.String({
-    modelKey: 'password',
-  }),
-  pin: Attributes.String({
-    modelKey: 'pin',
-  }),
-  url: Attributes.String({
-    modelKey: 'url',
-  }),
-};
 
 export type EventConferencingProperties = {
   provider: string;
@@ -57,22 +56,21 @@ export default class EventConferencing extends Model
   autocreate?: {
     settings?: Record<string, string>;
   };
+  static attributes: Record<string, Attribute> = {
+    details: Attributes.Object({
+      modelKey: 'details',
+      itemClass: EventConferencingDetails,
+    }),
+    provider: Attributes.String({
+      modelKey: 'provider',
+    }),
+    autocreate: Attributes.Object({
+      modelKey: 'autocreate',
+    }),
+  };
 
   constructor(props?: EventConferencingProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-EventConferencing.attributes = {
-  details: Attributes.Object({
-    modelKey: 'details',
-    itemClass: EventConferencingDetails,
-  }),
-  provider: Attributes.String({
-    modelKey: 'provider',
-  }),
-  autocreate: Attributes.Object({
-    modelKey: 'autocreate',
-  }),
-};

--- a/src/models/event-notification.ts
+++ b/src/models/event-notification.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Model from './model';
 
 export enum EventNotificationType {
@@ -26,33 +26,33 @@ export default class EventNotification extends Model
   subject?: string;
   body?: string;
   message?: string;
+  static attributes: Record<string, Attribute> = {
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+    minutesBeforeEvent: Attributes.Number({
+      modelKey: 'minutesBeforeEvent',
+      jsonKey: 'minutes_before_event',
+    }),
+    url: Attributes.String({
+      modelKey: 'url',
+    }),
+    payload: Attributes.String({
+      modelKey: 'payload',
+    }),
+    subject: Attributes.String({
+      modelKey: 'subject',
+    }),
+    body: Attributes.String({
+      modelKey: 'body',
+    }),
+    message: Attributes.String({
+      modelKey: 'message',
+    }),
+  };
 
   constructor(props?: EventNotificationProperties) {
     super();
     this.initAttributes(props);
   }
 }
-EventNotification.attributes = {
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-  minutesBeforeEvent: Attributes.Number({
-    modelKey: 'minutesBeforeEvent',
-    jsonKey: 'minutes_before_event',
-  }),
-  url: Attributes.String({
-    modelKey: 'url',
-  }),
-  payload: Attributes.String({
-    modelKey: 'payload',
-  }),
-  subject: Attributes.String({
-    modelKey: 'subject',
-  }),
-  body: Attributes.String({
-    modelKey: 'body',
-  }),
-  message: Attributes.String({
-    modelKey: 'message',
-  }),
-};

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Model from './model';
 
 export type EventParticipantProperties = {
@@ -16,6 +16,25 @@ export default class EventParticipant extends Model
   comment?: string;
   phoneNumber?: string;
   status?: string;
+  static attributes: Record<string, Attribute> = {
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+    comment: Attributes.String({
+      modelKey: 'comment',
+    }),
+    phoneNumber: Attributes.String({
+      modelKey: 'phoneNumber',
+      jsonKey: 'phone_number',
+    }),
+    status: Attributes.String({
+      modelKey: 'status',
+      readOnly: true,
+    }),
+  };
 
   constructor(props?: EventParticipantProperties) {
     super();
@@ -30,23 +49,3 @@ export default class EventParticipant extends Model
     return json;
   }
 }
-
-EventParticipant.attributes = {
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-  comment: Attributes.String({
-    modelKey: 'comment',
-  }),
-  phoneNumber: Attributes.String({
-    modelKey: 'phoneNumber',
-    jsonKey: 'phone_number',
-  }),
-  status: Attributes.String({
-    modelKey: 'status',
-    readOnly: true,
-  }),
-};

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,5 +1,5 @@
 import RestfulModel, { SaveCallback } from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import EventParticipant, {
   EventParticipantProperties,
 } from './event-participant';
@@ -60,6 +60,85 @@ export default class Event extends RestfulModel {
   notifications?: EventNotification[];
   metadata?: object;
   jobStatusId?: string;
+  static collectionName = 'events';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    calendarId: Attributes.String({
+      modelKey: 'calendarId',
+      jsonKey: 'calendar_id',
+    }),
+    iCalUID: Attributes.String({
+      modelKey: 'iCalUID',
+      jsonKey: 'ical_uid',
+      readOnly: true,
+    }),
+    messageId: Attributes.String({
+      modelKey: 'messageId',
+      jsonKey: 'message_id',
+      readOnly: true,
+    }),
+    title: Attributes.String({
+      modelKey: 'title',
+    }),
+    description: Attributes.String({
+      modelKey: 'description',
+    }),
+    owner: Attributes.String({
+      modelKey: 'owner',
+      readOnly: true,
+    }),
+    participants: Attributes.Collection({
+      modelKey: 'participants',
+      itemClass: EventParticipant,
+    }),
+    readOnly: Attributes.Boolean({
+      modelKey: 'readOnly',
+      jsonKey: 'read_only',
+    }),
+    location: Attributes.String({
+      modelKey: 'location',
+    }),
+    when: Attributes.Object({
+      modelKey: 'when',
+      itemClass: When,
+    }),
+    busy: Attributes.Boolean({
+      modelKey: 'busy',
+    }),
+    status: Attributes.String({
+      modelKey: 'status',
+      readOnly: true,
+    }),
+    recurrence: Attributes.Object({
+      modelKey: 'recurrence',
+    }),
+    masterEventId: Attributes.String({
+      modelKey: 'masterEventId',
+      jsonKey: 'master_event_id',
+      readOnly: true,
+    }),
+    originalStartTime: Attributes.DateTime({
+      modelKey: 'originalStartTime',
+      jsonKey: 'original_start_time',
+      readOnly: true,
+    }),
+    conferencing: Attributes.Object({
+      modelKey: 'conferencing',
+      itemClass: EventConferencing,
+    }),
+    notifications: Attributes.Collection({
+      modelKey: 'notifications',
+      itemClass: EventNotification,
+    }),
+    metadata: Attributes.Object({
+      modelKey: 'metadata',
+    }),
+    jobStatusId: Attributes.String({
+      modelKey: 'jobStatusId',
+      jsonKey: 'job_status_id',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: EventProperties) {
     super(connection, props);
@@ -200,82 +279,3 @@ export default class Event extends RestfulModel {
       });
   }
 }
-Event.collectionName = 'events';
-Event.attributes = {
-  ...RestfulModel.attributes,
-  calendarId: Attributes.String({
-    modelKey: 'calendarId',
-    jsonKey: 'calendar_id',
-  }),
-  iCalUID: Attributes.String({
-    modelKey: 'iCalUID',
-    jsonKey: 'ical_uid',
-    readOnly: true,
-  }),
-  messageId: Attributes.String({
-    modelKey: 'messageId',
-    jsonKey: 'message_id',
-    readOnly: true,
-  }),
-  title: Attributes.String({
-    modelKey: 'title',
-  }),
-  description: Attributes.String({
-    modelKey: 'description',
-  }),
-  owner: Attributes.String({
-    modelKey: 'owner',
-    readOnly: true,
-  }),
-  participants: Attributes.Collection({
-    modelKey: 'participants',
-    itemClass: EventParticipant,
-  }),
-  readOnly: Attributes.Boolean({
-    modelKey: 'readOnly',
-    jsonKey: 'read_only',
-  }),
-  location: Attributes.String({
-    modelKey: 'location',
-  }),
-  when: Attributes.Object({
-    modelKey: 'when',
-    itemClass: When,
-  }),
-  busy: Attributes.Boolean({
-    modelKey: 'busy',
-  }),
-  status: Attributes.String({
-    modelKey: 'status',
-    readOnly: true,
-  }),
-  recurrence: Attributes.Object({
-    modelKey: 'recurrence',
-  }),
-  masterEventId: Attributes.String({
-    modelKey: 'masterEventId',
-    jsonKey: 'master_event_id',
-    readOnly: true,
-  }),
-  originalStartTime: Attributes.DateTime({
-    modelKey: 'originalStartTime',
-    jsonKey: 'original_start_time',
-    readOnly: true,
-  }),
-  conferencing: Attributes.Object({
-    modelKey: 'conferencing',
-    itemClass: EventConferencing,
-  }),
-  notifications: Attributes.Collection({
-    modelKey: 'notifications',
-    itemClass: EventNotification,
-  }),
-  metadata: Attributes.Object({
-    modelKey: 'metadata',
-  }),
-  jobStatusId: Attributes.String({
-    modelKey: 'jobStatusId',
-    jsonKey: 'job_status_id',
-    readOnly: true,
-  }),
-};

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import RestfulModel from './restful-model';
 import NylasConnection from '../nylas-connection';
 
@@ -20,6 +20,36 @@ export default class File extends RestfulModel implements FileProperties {
   contentId?: string;
   contentDisposition?: string;
   data?: unknown;
+  static collectionName = 'files';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    contentType: Attributes.String({
+      modelKey: 'contentType',
+      jsonKey: 'content_type',
+    }),
+    size: Attributes.Number({
+      modelKey: 'size',
+    }),
+    filename: Attributes.String({
+      modelKey: 'filename',
+    }),
+    messageIds: Attributes.StringList({
+      modelKey: 'messageIds',
+      jsonKey: 'message_ids',
+    }),
+    contentId: Attributes.String({
+      modelKey: 'contentId',
+      jsonKey: 'content_id',
+    }),
+    contentDisposition: Attributes.String({
+      modelKey: 'contentDisposition',
+      jsonKey: 'content_disposition',
+    }),
+    data: Attributes.Object({
+      modelKey: 'data',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: FileProperties) {
     super(connection, props);
@@ -111,33 +141,3 @@ export default class File extends RestfulModel implements FileProperties {
       });
   }
 }
-File.collectionName = 'files';
-File.attributes = {
-  ...RestfulModel.attributes,
-  contentType: Attributes.String({
-    modelKey: 'contentType',
-    jsonKey: 'content_type',
-  }),
-  size: Attributes.Number({
-    modelKey: 'size',
-  }),
-  filename: Attributes.String({
-    modelKey: 'filename',
-  }),
-  messageIds: Attributes.StringList({
-    modelKey: 'messageIds',
-    jsonKey: 'message_ids',
-  }),
-  contentId: Attributes.String({
-    modelKey: 'contentId',
-    jsonKey: 'content_id',
-  }),
-  contentDisposition: Attributes.String({
-    modelKey: 'contentDisposition',
-    jsonKey: 'content_disposition',
-  }),
-  data: Attributes.Object({
-    modelKey: 'data',
-    readOnly: true,
-  }),
-};

--- a/src/models/folder.ts
+++ b/src/models/folder.ts
@@ -1,5 +1,5 @@
 import RestfulModel, { SaveCallback } from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 
 export type FolderProperties = {
@@ -11,6 +11,23 @@ export default class Folder extends RestfulModel implements FolderProperties {
   displayName?: string;
   name?: string;
   jobStatusId?: string;
+  static collectionName = 'folders';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    name: Attributes.String({
+      modelKey: 'name',
+      jsonKey: 'name',
+    }),
+    displayName: Attributes.String({
+      modelKey: 'displayName',
+      jsonKey: 'display_name',
+    }),
+    jobStatusId: Attributes.String({
+      modelKey: 'jobStatusId',
+      jsonKey: 'job_status_id',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: FolderProperties) {
     super(connection, props);
@@ -21,25 +38,9 @@ export default class Folder extends RestfulModel implements FolderProperties {
     return super.save(params, callback);
   }
 }
-Folder.collectionName = 'folders';
-Folder.attributes = {
-  ...RestfulModel.attributes,
-  name: Attributes.String({
-    modelKey: 'name',
-    jsonKey: 'name',
-  }),
-  displayName: Attributes.String({
-    modelKey: 'displayName',
-    jsonKey: 'display_name',
-  }),
-  jobStatusId: Attributes.String({
-    modelKey: 'jobStatusId',
-    jsonKey: 'job_status_id',
-    readOnly: true,
-  }),
-};
 
 export class Label extends Folder {
+  static collectionName = 'labels';
   constructor(connection: NylasConnection, props?: FolderProperties) {
     super(connection, props);
   }
@@ -48,4 +49,3 @@ export class Label extends Folder {
     return { display_name: this.displayName };
   }
 }
-Label.collectionName = 'labels';

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -1,5 +1,5 @@
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 
 export type FreeBusyQuery = {
   startTime: number;
@@ -18,28 +18,28 @@ export class TimeSlot extends Model implements TimeSlotProperties {
   status = '';
   startTime = 0;
   endTime = 0;
+  static attributes: Record<string, Attribute> = {
+    object: Attributes.String({
+      modelKey: 'object',
+    }),
+    status: Attributes.String({
+      modelKey: 'status',
+    }),
+    startTime: Attributes.Number({
+      modelKey: 'startTime',
+      jsonKey: 'start_time',
+    }),
+    endTime: Attributes.Number({
+      modelKey: 'endTime',
+      jsonKey: 'end_time',
+    }),
+  };
 
   constructor(props?: TimeSlotProperties) {
     super();
     this.initAttributes(props);
   }
 }
-TimeSlot.attributes = {
-  object: Attributes.String({
-    modelKey: 'object',
-  }),
-  status: Attributes.String({
-    modelKey: 'status',
-  }),
-  startTime: Attributes.Number({
-    modelKey: 'startTime',
-    jsonKey: 'start_time',
-  }),
-  endTime: Attributes.Number({
-    modelKey: 'endTime',
-    jsonKey: 'end_time',
-  }),
-};
 
 export type FreeBusyProperties = {
   email: string;
@@ -50,22 +50,22 @@ export default class FreeBusy extends Model implements FreeBusyProperties {
   object = 'free_busy';
   email = '';
   timeSlots: TimeSlot[] = [];
+  static attributes: Record<string, Attribute> = {
+    object: Attributes.String({
+      modelKey: 'object',
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+    timeSlots: Attributes.Collection({
+      modelKey: 'timeSlots',
+      jsonKey: 'time_slots',
+      itemClass: TimeSlot,
+    }),
+  };
 
   constructor(props?: FreeBusyProperties) {
     super();
     this.initAttributes(props);
   }
 }
-FreeBusy.attributes = {
-  object: Attributes.String({
-    modelKey: 'object',
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-  timeSlots: Attributes.Collection({
-    modelKey: 'timeSlots',
-    jsonKey: 'time_slots',
-    itemClass: TimeSlot,
-  }),
-};

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -1,5 +1,5 @@
 import RestfulModel from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 import Message from './message';
 
@@ -18,6 +18,33 @@ export default class JobStatus extends RestfulModel
   jobStatusId?: string;
   status?: string;
   originalData?: Message;
+  static collectionName = 'job-statuses';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    action: Attributes.String({
+      modelKey: 'action',
+      readOnly: true,
+    }),
+    createdAt: Attributes.DateTime({
+      modelKey: 'createdAt',
+      jsonKey: 'created_at',
+      readOnly: true,
+    }),
+    jobStatusId: Attributes.String({
+      modelKey: 'jobStatusId',
+      jsonKey: 'job_status_id',
+      readOnly: true,
+    }),
+    status: Attributes.String({
+      modelKey: 'status',
+      readOnly: true,
+    }),
+    originalData: Attributes.Object({
+      modelKey: 'originalData',
+      jsonKey: 'original_data',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: JobStatusProperties) {
     super(connection, props);
@@ -29,31 +56,3 @@ export default class JobStatus extends RestfulModel
     return this.status === 'successful';
   }
 }
-
-JobStatus.collectionName = 'job-statuses';
-JobStatus.attributes = {
-  ...RestfulModel.attributes,
-  action: Attributes.String({
-    modelKey: 'action',
-    readOnly: true,
-  }),
-  createdAt: Attributes.DateTime({
-    modelKey: 'createdAt',
-    jsonKey: 'created_at',
-    readOnly: true,
-  }),
-  jobStatusId: Attributes.String({
-    modelKey: 'jobStatusId',
-    jsonKey: 'job_status_id',
-    readOnly: true,
-  }),
-  status: Attributes.String({
-    modelKey: 'status',
-    readOnly: true,
-  }),
-  originalData: Attributes.Object({
-    modelKey: 'originalData',
-    jsonKey: 'original_data',
-    readOnly: true,
-  }),
-};

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -1,5 +1,5 @@
 import ManagementModel from './management-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 import Model from './model';
 import { SaveCallback } from './restful-model';
@@ -13,22 +13,22 @@ export class ApplicationIPAddresses extends Model
   implements ApplicationIPAddressesProperties {
   ipAddresses: string[] = [];
   updatedAt = 0;
+  static attributes: Record<string, Attribute> = {
+    ipAddresses: Attributes.StringList({
+      modelKey: 'ipAddresses',
+      jsonKey: 'ip_addresses',
+    }),
+    updatedAt: Attributes.Number({
+      modelKey: 'updatedAt',
+      jsonKey: 'updated_at',
+    }),
+  };
 
   constructor(props?: ApplicationIPAddressesProperties) {
     super();
     this.initAttributes(props);
   }
 }
-ApplicationIPAddresses.attributes = {
-  ipAddresses: Attributes.StringList({
-    modelKey: 'ipAddresses',
-    jsonKey: 'ip_addresses',
-  }),
-  updatedAt: Attributes.Number({
-    modelKey: 'updatedAt',
-    jsonKey: 'updated_at',
-  }),
-};
 
 export type AccountTokenInfoProperties = {
   scopes: string;
@@ -43,28 +43,28 @@ export class AccountTokenInfo extends Model
   state = '';
   createdAt = 0;
   updatedAt = 0;
+  static attributes: Record<string, Attribute> = {
+    scopes: Attributes.String({
+      modelKey: 'scopes',
+    }),
+    state: Attributes.String({
+      modelKey: 'state',
+    }),
+    createdAt: Attributes.Number({
+      modelKey: 'createdAt',
+      jsonKey: 'created_at',
+    }),
+    updatedAt: Attributes.Number({
+      modelKey: 'updatedAt',
+      jsonKey: 'updated_at',
+    }),
+  };
 
   constructor(props?: AccountTokenInfoProperties) {
     super();
     this.initAttributes(props);
   }
 }
-AccountTokenInfo.attributes = {
-  scopes: Attributes.String({
-    modelKey: 'scopes',
-  }),
-  state: Attributes.String({
-    modelKey: 'state',
-  }),
-  createdAt: Attributes.Number({
-    modelKey: 'createdAt',
-    jsonKey: 'created_at',
-  }),
-  updatedAt: Attributes.Number({
-    modelKey: 'updatedAt',
-    jsonKey: 'updated_at',
-  }),
-};
 
 export type ManagementAccountProperties = {
   billingState: string;
@@ -89,6 +89,35 @@ export default class ManagementAccount extends ManagementModel
   syncState = '';
   trial = false;
   metadata?: object;
+  static collectionName = 'accounts';
+  static attributes: Record<string, Attribute> = {
+    ...ManagementModel.attributes,
+    billingState: Attributes.String({
+      modelKey: 'billingState',
+      jsonKey: 'billing_state',
+    }),
+    emailAddress: Attributes.String({
+      modelKey: 'emailAddress',
+      jsonKey: 'email',
+    }),
+    namespaceId: Attributes.String({
+      modelKey: 'namespaceId',
+      jsonKey: 'namespace_id',
+    }),
+    provider: Attributes.String({
+      modelKey: 'provider',
+    }),
+    syncState: Attributes.String({
+      modelKey: 'syncState',
+      jsonKey: 'sync_state',
+    }),
+    trial: Attributes.Boolean({
+      modelKey: 'trial',
+    }),
+    metadata: Attributes.Object({
+      modelKey: 'metadata',
+    }),
+  };
 
   constructor(
     connection: NylasConnection,
@@ -177,32 +206,3 @@ export default class ManagementAccount extends ManagementModel
     return `/a/${this.connection.clientId}/accounts`;
   }
 }
-ManagementAccount.collectionName = 'accounts';
-ManagementAccount.attributes = {
-  ...ManagementModel.attributes,
-  billingState: Attributes.String({
-    modelKey: 'billingState',
-    jsonKey: 'billing_state',
-  }),
-  emailAddress: Attributes.String({
-    modelKey: 'emailAddress',
-    jsonKey: 'email',
-  }),
-  namespaceId: Attributes.String({
-    modelKey: 'namespaceId',
-    jsonKey: 'namespace_id',
-  }),
-  provider: Attributes.String({
-    modelKey: 'provider',
-  }),
-  syncState: Attributes.String({
-    modelKey: 'syncState',
-    jsonKey: 'sync_state',
-  }),
-  trial: Attributes.Boolean({
-    modelKey: 'trial',
-  }),
-  metadata: Attributes.Object({
-    modelKey: 'metadata',
-  }),
-};

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -1,5 +1,5 @@
 import RestfulModel from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import File, { FileProperties } from './file';
 import Event, { EventProperties } from './event';
 import EmailParticipant, {
@@ -50,6 +50,81 @@ export default class Message extends RestfulModel implements MessageProperties {
   headers?: Record<string, string>;
   metadata?: object;
   jobStatusId?: string;
+  static collectionName = 'messages';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    subject: Attributes.String({
+      modelKey: 'subject',
+    }),
+    from: Attributes.Collection({
+      modelKey: 'from',
+      itemClass: EmailParticipant,
+    }),
+    replyTo: Attributes.Collection({
+      modelKey: 'replyTo',
+      jsonKey: 'reply_to',
+      itemClass: EmailParticipant,
+    }),
+    to: Attributes.Collection({
+      modelKey: 'to',
+      itemClass: EmailParticipant,
+    }),
+    cc: Attributes.Collection({
+      modelKey: 'cc',
+      itemClass: EmailParticipant,
+    }),
+    bcc: Attributes.Collection({
+      modelKey: 'bcc',
+      itemClass: EmailParticipant,
+    }),
+    date: Attributes.DateTime({
+      modelKey: 'date',
+    }),
+    threadId: Attributes.String({
+      modelKey: 'threadId',
+      jsonKey: 'thread_id',
+    }),
+    snippet: Attributes.String({
+      modelKey: 'snippet',
+    }),
+    body: Attributes.String({
+      modelKey: 'body',
+    }),
+    unread: Attributes.Boolean({
+      modelKey: 'unread',
+    }),
+    starred: Attributes.Boolean({
+      modelKey: 'starred',
+    }),
+    files: Attributes.Collection({
+      modelKey: 'files',
+      itemClass: File,
+      readOnly: true,
+    }),
+    events: Attributes.Collection({
+      modelKey: 'events',
+      itemClass: Event,
+    }),
+    folder: Attributes.Object({
+      modelKey: 'folder',
+      itemClass: Folder,
+    }),
+    labels: Attributes.Collection({
+      modelKey: 'labels',
+      itemClass: Label,
+    }),
+    metadata: Attributes.Object({
+      modelKey: 'metadata',
+    }),
+    headers: Attributes.Object({
+      modelKey: 'headers',
+    }),
+    jobStatusId: Attributes.String({
+      modelKey: 'jobStatusId',
+      jsonKey: 'job_status_id',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: MessageProperties) {
     super(connection, props);
@@ -113,78 +188,3 @@ export default class Message extends RestfulModel implements MessageProperties {
     return json;
   }
 }
-Message.collectionName = 'messages';
-Message.attributes = {
-  ...RestfulModel.attributes,
-  subject: Attributes.String({
-    modelKey: 'subject',
-  }),
-  from: Attributes.Collection({
-    modelKey: 'from',
-    itemClass: EmailParticipant,
-  }),
-  replyTo: Attributes.Collection({
-    modelKey: 'replyTo',
-    jsonKey: 'reply_to',
-    itemClass: EmailParticipant,
-  }),
-  to: Attributes.Collection({
-    modelKey: 'to',
-    itemClass: EmailParticipant,
-  }),
-  cc: Attributes.Collection({
-    modelKey: 'cc',
-    itemClass: EmailParticipant,
-  }),
-  bcc: Attributes.Collection({
-    modelKey: 'bcc',
-    itemClass: EmailParticipant,
-  }),
-  date: Attributes.DateTime({
-    modelKey: 'date',
-  }),
-  threadId: Attributes.String({
-    modelKey: 'threadId',
-    jsonKey: 'thread_id',
-  }),
-  snippet: Attributes.String({
-    modelKey: 'snippet',
-  }),
-  body: Attributes.String({
-    modelKey: 'body',
-  }),
-  unread: Attributes.Boolean({
-    modelKey: 'unread',
-  }),
-  starred: Attributes.Boolean({
-    modelKey: 'starred',
-  }),
-  files: Attributes.Collection({
-    modelKey: 'files',
-    itemClass: File,
-    readOnly: true,
-  }),
-  events: Attributes.Collection({
-    modelKey: 'events',
-    itemClass: Event,
-  }),
-  folder: Attributes.Object({
-    modelKey: 'folder',
-    itemClass: Folder,
-  }),
-  labels: Attributes.Collection({
-    modelKey: 'labels',
-    itemClass: Label,
-  }),
-  metadata: Attributes.Object({
-    modelKey: 'metadata',
-  }),
-  headers: Attributes.Object({
-    modelKey: 'headers',
-  }),
-  jobStatusId: Attributes.String({
-    modelKey: 'jobStatusId',
-    jsonKey: 'job_status_id',
-    readOnly: true,
-  }),
-};

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Message, { MessageProperties } from './message';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
@@ -15,29 +15,28 @@ export class Categorize extends Model implements CategorizeProperties {
   categorizedAt: Date = new Date();
   modelVersion = '';
   subcategories: string[] = [];
+  static attributes: Record<string, Attribute> = {
+    category: Attributes.String({
+      modelKey: 'category',
+    }),
+    categorizedAt: Attributes.DateTime({
+      modelKey: 'categorizedAt',
+      jsonKey: 'categorized_at',
+    }),
+    modelVersion: Attributes.String({
+      modelKey: 'modelVersion',
+      jsonKey: 'model_version',
+    }),
+    subcategories: Attributes.StringList({
+      modelKey: 'subcategories',
+    }),
+  };
 
   constructor(props?: CategorizeProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-Categorize.attributes = {
-  category: Attributes.String({
-    modelKey: 'category',
-  }),
-  categorizedAt: Attributes.DateTime({
-    modelKey: 'categorizedAt',
-    jsonKey: 'categorized_at',
-  }),
-  modelVersion: Attributes.String({
-    modelKey: 'modelVersion',
-    jsonKey: 'model_version',
-  }),
-  subcategories: Attributes.StringList({
-    modelKey: 'subcategories',
-  }),
-};
 
 export type NeuralCategorizerProperties = MessageProperties & {
   categorizer: Categorize;
@@ -46,6 +45,14 @@ export type NeuralCategorizerProperties = MessageProperties & {
 export default class NeuralCategorizer extends Message
   implements NeuralCategorizerProperties {
   categorizer = new Categorize();
+  static collectionName = 'categorizer';
+  static attributes: Record<string, Attribute> = {
+    ...Message.attributes,
+    categorizer: Attributes.Object({
+      modelKey: 'categorizer',
+      itemClass: Categorize,
+    }),
+  };
 
   constructor(
     connection: NylasConnection,
@@ -73,12 +80,3 @@ export default class NeuralCategorizer extends Message
       });
   }
 }
-
-NeuralCategorizer.collectionName = 'categorizer';
-NeuralCategorizer.attributes = {
-  ...Message.attributes,
-  categorizer: Attributes.Object({
-    modelKey: 'categorizer',
-    itemClass: Categorize,
-  }),
-};

--- a/src/models/neural-clean-conversation.ts
+++ b/src/models/neural-clean-conversation.ts
@@ -1,5 +1,5 @@
 import Message, { MessageProperties } from './message';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import File from './file';
 import NylasConnection from '../nylas-connection';
 
@@ -14,6 +14,17 @@ export default class NeuralCleanConversation extends Message
   implements NeuralCleanConversationProperties {
   conversation = '';
   modelVersion = '';
+  static collectionName = 'conversation';
+  static attributes: Record<string, Attribute> = {
+    ...Message.attributes,
+    conversation: Attributes.String({
+      modelKey: 'conversation',
+    }),
+    modelVersion: Attributes.String({
+      modelKey: 'modelVersion',
+      jsonKey: 'model_version',
+    }),
+  };
 
   constructor(
     connection: NylasConnection,
@@ -41,15 +52,3 @@ export default class NeuralCleanConversation extends Message
     return Promise.resolve(f);
   }
 }
-
-NeuralCleanConversation.collectionName = 'conversation';
-NeuralCleanConversation.attributes = {
-  ...Message.attributes,
-  conversation: Attributes.String({
-    modelKey: 'conversation',
-  }),
-  modelVersion: Attributes.String({
-    modelKey: 'modelVersion',
-    jsonKey: 'model_version',
-  }),
-};

--- a/src/models/neural-ocr.ts
+++ b/src/models/neural-ocr.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import File, { FileProperties } from './file';
 import NylasConnection from '../nylas-connection';
 
@@ -10,21 +10,20 @@ export type NeuralOcrProperties = FileProperties & {
 export default class NeuralOcr extends File implements NeuralOcrProperties {
   ocr: string[] = [];
   processedPages = 0;
+  static collectionName = 'ocr';
+  static attributes: Record<string, Attribute> = {
+    ...File.attributes,
+    ocr: Attributes.StringList({
+      modelKey: 'ocr',
+    }),
+    processedPages: Attributes.Number({
+      modelKey: 'processedPages',
+      jsonKey: 'processed_pages',
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: NeuralOcrProperties) {
     super(connection, props);
     this.initAttributes(props);
   }
 }
-
-NeuralOcr.collectionName = 'ocr';
-NeuralOcr.attributes = {
-  ...File.attributes,
-  ocr: Attributes.StringList({
-    modelKey: 'ocr',
-  }),
-  processedPages: Attributes.Number({
-    modelKey: 'processedPages',
-    jsonKey: 'processed_pages',
-  }),
-};

--- a/src/models/neural-sentiment-analysis.ts
+++ b/src/models/neural-sentiment-analysis.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import RestfulModel from './restful-model';
 import NylasConnection from '../nylas-connection';
 
@@ -17,6 +17,27 @@ export default class NeuralSentimentAnalysis extends RestfulModel
   sentimentScore = 0;
   processedLength = 0;
   text = '';
+  static collectionName = 'sentiment';
+  static attributes: Record<string, Attribute> = {
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+    }),
+    sentiment: Attributes.String({
+      modelKey: 'sentiment',
+    }),
+    sentimentScore: Attributes.Number({
+      modelKey: 'sentimentScore',
+      jsonKey: 'sentiment_score',
+    }),
+    processedLength: Attributes.Number({
+      modelKey: 'processedLength',
+      jsonKey: 'processed_length',
+    }),
+    text: Attributes.String({
+      modelKey: 'text',
+    }),
+  };
 
   constructor(
     connection: NylasConnection,
@@ -26,25 +47,3 @@ export default class NeuralSentimentAnalysis extends RestfulModel
     this.initAttributes(props);
   }
 }
-
-NeuralSentimentAnalysis.collectionName = 'sentiment';
-NeuralSentimentAnalysis.attributes = {
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-  }),
-  sentiment: Attributes.String({
-    modelKey: 'sentiment',
-  }),
-  sentimentScore: Attributes.Number({
-    modelKey: 'sentimentScore',
-    jsonKey: 'sentiment_score',
-  }),
-  processedLength: Attributes.Number({
-    modelKey: 'processedLength',
-    jsonKey: 'processed_length',
-  }),
-  text: Attributes.String({
-    modelKey: 'text',
-  }),
-};

--- a/src/models/neural-signature-contact.ts
+++ b/src/models/neural-signature-contact.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Contact, { EmailAddress, PhoneNumber, WebPage } from './contact';
 import Model from './model';
 import NylasConnection from '../nylas-connection';
@@ -11,21 +11,20 @@ type LinkProperties = {
 class Link extends Model implements LinkProperties {
   description = '';
   url = '';
+  static attributes: Record<string, Attribute> = {
+    description: Attributes.String({
+      modelKey: 'description',
+    }),
+    url: Attributes.String({
+      modelKey: 'url',
+    }),
+  };
 
   constructor(props?: LinkProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-Link.attributes = {
-  description: Attributes.String({
-    modelKey: 'description',
-  }),
-  url: Attributes.String({
-    modelKey: 'url',
-  }),
-};
 
 type NameProperties = {
   firstName?: string;
@@ -35,23 +34,22 @@ type NameProperties = {
 class Name extends Model implements NameProperties {
   firstName = '';
   lastName = '';
+  static attributes: Record<string, Attribute> = {
+    firstName: Attributes.String({
+      modelKey: 'firstName',
+      jsonKey: 'first_name',
+    }),
+    lastName: Attributes.String({
+      modelKey: 'lastName',
+      jsonKey: 'last_name',
+    }),
+  };
 
   constructor(props?: NameProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-Name.attributes = {
-  firstName: Attributes.String({
-    modelKey: 'firstName',
-    jsonKey: 'first_name',
-  }),
-  lastName: Attributes.String({
-    modelKey: 'lastName',
-    jsonKey: 'last_name',
-  }),
-};
 
 export type NeuralSignatureContactProperties = {
   jobTitles?: string[];
@@ -68,6 +66,27 @@ export default class NeuralSignatureContact extends Model
   phoneNumbers?: string[];
   emails?: string[];
   names?: Name[];
+  static attributes: Record<string, Attribute> = {
+    jobTitles: Attributes.StringList({
+      modelKey: 'jobTitles',
+      jsonKey: 'job_titles',
+    }),
+    links: Attributes.Collection({
+      modelKey: 'links',
+      itemClass: Link,
+    }),
+    phoneNumbers: Attributes.StringList({
+      modelKey: 'phoneNumbers',
+      jsonKey: 'phone_numbers',
+    }),
+    emails: Attributes.StringList({
+      modelKey: 'emails',
+    }),
+    names: Attributes.Collection({
+      modelKey: 'names',
+      itemClass: Name,
+    }),
+  };
 
   constructor(props?: NeuralSignatureContactProperties) {
     super();
@@ -121,25 +140,3 @@ export default class NeuralSignatureContact extends Model
     return contact;
   }
 }
-
-NeuralSignatureContact.attributes = {
-  jobTitles: Attributes.StringList({
-    modelKey: 'jobTitles',
-    jsonKey: 'job_titles',
-  }),
-  links: Attributes.Collection({
-    modelKey: 'links',
-    itemClass: Link,
-  }),
-  phoneNumbers: Attributes.StringList({
-    modelKey: 'phoneNumbers',
-    jsonKey: 'phone_numbers',
-  }),
-  emails: Attributes.StringList({
-    modelKey: 'emails',
-  }),
-  names: Attributes.Collection({
-    modelKey: 'names',
-    itemClass: Name,
-  }),
-};

--- a/src/models/neural-signature-extraction.ts
+++ b/src/models/neural-signature-extraction.ts
@@ -1,5 +1,5 @@
 import NeuralSignatureContact from './neural-signature-contact';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Message, { MessageProperties } from './message';
 import NylasConnection from '../nylas-connection';
 
@@ -14,6 +14,21 @@ export default class NeuralSignatureExtraction extends Message
   signature = '';
   modelVersion = '';
   contacts?: NeuralSignatureContact;
+  static collectionName = 'signature';
+  static attributes: Record<string, Attribute> = {
+    ...Message.attributes,
+    signature: Attributes.String({
+      modelKey: 'signature',
+    }),
+    modelVersion: Attributes.String({
+      modelKey: 'modelVersion',
+      jsonKey: 'model_version',
+    }),
+    contacts: Attributes.Object({
+      modelKey: 'contacts',
+      itemClass: NeuralSignatureContact,
+    }),
+  };
 
   constructor(
     connection: NylasConnection,
@@ -23,19 +38,3 @@ export default class NeuralSignatureExtraction extends Message
     this.initAttributes(props);
   }
 }
-
-NeuralSignatureExtraction.collectionName = 'signature';
-NeuralSignatureExtraction.attributes = {
-  ...Message.attributes,
-  signature: Attributes.String({
-    modelKey: 'signature',
-  }),
-  modelVersion: Attributes.String({
-    modelKey: 'modelVersion',
-    jsonKey: 'model_version',
-  }),
-  contacts: Attributes.Object({
-    modelKey: 'contacts',
-    itemClass: NeuralSignatureContact,
-  }),
-};

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -5,7 +5,7 @@ import NeuralOcr from './neural-ocr';
 import NeuralCategorizer from './neural-categorizer';
 import NeuralCleanConversation from './neural-clean-conversation';
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 
 export type NeuralMessageOptionsProperties = {
   ignoreLinks?: boolean;
@@ -24,6 +24,32 @@ export class NeuralMessageOptions extends Model
   removeConclusionPhrases?: boolean;
   imagesAsMarkdown?: boolean;
   parseContacts?: boolean;
+  static attributes: Record<string, Attribute> = {
+    ignoreLinks: Attributes.Boolean({
+      modelKey: 'ignoreLinks',
+      jsonKey: 'ignore_links',
+    }),
+    ignoreImages: Attributes.Boolean({
+      modelKey: 'ignoreImages',
+      jsonKey: 'ignore_images',
+    }),
+    ignoreTables: Attributes.Boolean({
+      modelKey: 'ignoreTables',
+      jsonKey: 'ignore_tables',
+    }),
+    removeConclusionPhrases: Attributes.Boolean({
+      modelKey: 'removeConclusionPhrases',
+      jsonKey: 'remove_conclusion_phrases',
+    }),
+    imagesAsMarkdown: Attributes.Boolean({
+      modelKey: 'imagesAsMarkdown',
+      jsonKey: 'images_as_markdown',
+    }),
+    parseContacts: Attributes.Boolean({
+      modelKey: 'parseContacts',
+      jsonKey: 'parse_contacts',
+    }),
+  };
 
   constructor(props?: NeuralMessageOptionsProperties) {
     super();
@@ -38,32 +64,6 @@ export class NeuralMessageOptions extends Model
     return body;
   }
 }
-NeuralMessageOptions.attributes = {
-  ignoreLinks: Attributes.Boolean({
-    modelKey: 'ignoreLinks',
-    jsonKey: 'ignore_links',
-  }),
-  ignoreImages: Attributes.Boolean({
-    modelKey: 'ignoreImages',
-    jsonKey: 'ignore_images',
-  }),
-  ignoreTables: Attributes.Boolean({
-    modelKey: 'ignoreTables',
-    jsonKey: 'ignore_tables',
-  }),
-  removeConclusionPhrases: Attributes.Boolean({
-    modelKey: 'removeConclusionPhrases',
-    jsonKey: 'remove_conclusion_phrases',
-  }),
-  imagesAsMarkdown: Attributes.Boolean({
-    modelKey: 'imagesAsMarkdown',
-    jsonKey: 'images_as_markdown',
-  }),
-  parseContacts: Attributes.Boolean({
-    modelKey: 'parseContacts',
-    jsonKey: 'parse_contacts',
-  }),
-};
 
 export default class Neural extends RestfulModel {
   sentimentAnalysisMessage(

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -1,5 +1,5 @@
 import RestfulModel from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 
 export type ResourceProperties = {
@@ -18,41 +18,40 @@ export default class Resource extends RestfulModel {
   building = '';
   floorNumber = '';
   floorName?: string;
+  static collectionName = 'resources';
+  static attributes: Record<string, Attribute> = {
+    object: Attributes.String({
+      modelKey: 'object',
+      readOnly: true,
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    capacity: Attributes.String({
+      modelKey: 'capacity',
+      readOnly: true,
+    }),
+    building: Attributes.String({
+      modelKey: 'building',
+      readOnly: true,
+    }),
+    floorName: Attributes.String({
+      modelKey: 'floorName',
+      jsonKey: 'floor_name',
+      readOnly: true,
+    }),
+    floorNumber: Attributes.String({
+      modelKey: 'floorNumber',
+      jsonKey: 'floor_number',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: ResourceProperties) {
     super(connection, props);
     this.initAttributes(props);
   }
 }
-
-Resource.collectionName = 'resources';
-Resource.attributes = {
-  object: Attributes.String({
-    modelKey: 'object',
-    readOnly: true,
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  capacity: Attributes.String({
-    modelKey: 'capacity',
-    readOnly: true,
-  }),
-  building: Attributes.String({
-    modelKey: 'building',
-    readOnly: true,
-  }),
-  floorName: Attributes.String({
-    modelKey: 'floorName',
-    jsonKey: 'floor_name',
-    readOnly: true,
-  }),
-  floorNumber: Attributes.String({
-    modelKey: 'floorNumber',
-    jsonKey: 'floor_number',
-    readOnly: true,
-  }),
-};

--- a/src/models/restful-model.ts
+++ b/src/models/restful-model.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 import Model from './model';
 
@@ -25,6 +25,21 @@ export default class RestfulModel extends Model {
   id?: string;
   object?: string;
   baseUrl?: string;
+  static attributes: Record<string, Attribute> = {
+    id: Attributes.String({
+      modelKey: 'id',
+      readOnly: true,
+    }),
+    object: Attributes.String({
+      modelKey: 'object',
+      readOnly: true,
+    }),
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: Partial<RestfulModelJSON>) {
     super();
@@ -148,18 +163,3 @@ export default class RestfulModel extends Model {
       });
   }
 }
-(RestfulModel as any).attributes = {
-  id: Attributes.String({
-    modelKey: 'id',
-    readOnly: true,
-  }),
-  object: Attributes.String({
-    modelKey: 'object',
-    readOnly: true,
-  }),
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-    readOnly: true,
-  }),
-};

--- a/src/models/scheduler-booking-request.ts
+++ b/src/models/scheduler-booking-request.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import SchedulerTimeSlot from './scheduler-time-slot';
 import Model from './model';
 
@@ -37,71 +37,71 @@ export class SchedulerBookingConfirmation extends Model
   recipientName?: string;
   recipientTz?: string;
   title?: string;
+  static attributes: Record<string, Attribute> = {
+    id: Attributes.Number({
+      modelKey: 'id',
+    }),
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+    }),
+    additionalFieldValues: Attributes.Object({
+      modelKey: 'additionalFieldValues',
+      jsonKey: 'additional_field_values',
+    }),
+    calendarEventId: Attributes.String({
+      modelKey: 'calendarEventId',
+      jsonKey: 'calendar_event_id',
+    }),
+    calendarId: Attributes.String({
+      modelKey: 'calendarId',
+      jsonKey: 'calendar_id',
+    }),
+    editHash: Attributes.String({
+      modelKey: 'editHash',
+      jsonKey: 'edit_hash',
+    }),
+    startTime: Attributes.DateTime({
+      modelKey: 'startTime',
+      jsonKey: 'start_time',
+    }),
+    endTime: Attributes.DateTime({
+      modelKey: 'endTime',
+      jsonKey: 'end_time',
+    }),
+    isConfirmed: Attributes.Boolean({
+      modelKey: 'isConfirmed',
+      jsonKey: 'is_confirmed',
+    }),
+    location: Attributes.String({
+      modelKey: 'location',
+    }),
+    recipientEmail: Attributes.String({
+      modelKey: 'recipientEmail',
+      jsonKey: 'recipient_email',
+    }),
+    recipientLocale: Attributes.String({
+      modelKey: 'recipientLocale',
+      jsonKey: 'recipient_locale',
+    }),
+    recipientName: Attributes.String({
+      modelKey: 'recipientName',
+      jsonKey: 'recipient_name',
+    }),
+    recipientTz: Attributes.String({
+      modelKey: 'recipientTz',
+      jsonKey: 'recipient_tz',
+    }),
+    title: Attributes.String({
+      modelKey: 'title',
+    }),
+  };
 
   constructor(props?: SchedulerBookingConfirmationProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerBookingConfirmation.attributes = {
-  id: Attributes.Number({
-    modelKey: 'id',
-  }),
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-  }),
-  additionalFieldValues: Attributes.Object({
-    modelKey: 'additionalFieldValues',
-    jsonKey: 'additional_field_values',
-  }),
-  calendarEventId: Attributes.String({
-    modelKey: 'calendarEventId',
-    jsonKey: 'calendar_event_id',
-  }),
-  calendarId: Attributes.String({
-    modelKey: 'calendarId',
-    jsonKey: 'calendar_id',
-  }),
-  editHash: Attributes.String({
-    modelKey: 'editHash',
-    jsonKey: 'edit_hash',
-  }),
-  startTime: Attributes.DateTime({
-    modelKey: 'startTime',
-    jsonKey: 'start_time',
-  }),
-  endTime: Attributes.DateTime({
-    modelKey: 'endTime',
-    jsonKey: 'end_time',
-  }),
-  isConfirmed: Attributes.Boolean({
-    modelKey: 'isConfirmed',
-    jsonKey: 'is_confirmed',
-  }),
-  location: Attributes.String({
-    modelKey: 'location',
-  }),
-  recipientEmail: Attributes.String({
-    modelKey: 'recipientEmail',
-    jsonKey: 'recipient_email',
-  }),
-  recipientLocale: Attributes.String({
-    modelKey: 'recipientLocale',
-    jsonKey: 'recipient_locale',
-  }),
-  recipientName: Attributes.String({
-    modelKey: 'recipientName',
-    jsonKey: 'recipient_name',
-  }),
-  recipientTz: Attributes.String({
-    modelKey: 'recipientTz',
-    jsonKey: 'recipient_tz',
-  }),
-  title: Attributes.String({
-    modelKey: 'title',
-  }),
-};
 
 export type SchedulerBookingRequestProperties = {
   additionalEmails?: string[];
@@ -126,6 +126,40 @@ export default class SchedulerBookingRequest extends Model
   replacesBookingHash?: string;
   slot?: SchedulerTimeSlot;
   timezone?: string;
+  static attributes: Record<string, Attribute> = {
+    additionalEmails: Attributes.StringList({
+      modelKey: 'additionalEmails',
+      jsonKey: 'additional_emails',
+    }),
+    additionalValues: Attributes.Object({
+      modelKey: 'additionalValues',
+      jsonKey: 'additional_values',
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+    locale: Attributes.String({
+      modelKey: 'locale',
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    pageHostname: Attributes.String({
+      modelKey: 'pageHostname',
+      jsonKey: 'page_hostname',
+    }),
+    replacesBookingHash: Attributes.String({
+      modelKey: 'replacesBookingHash',
+      jsonKey: 'replaces_booking_hash',
+    }),
+    slot: Attributes.Object({
+      modelKey: 'slot',
+      itemClass: SchedulerTimeSlot,
+    }),
+    timezone: Attributes.String({
+      modelKey: 'timezone',
+    }),
+  };
 
   constructor(props?: SchedulerBookingRequestProperties) {
     super();
@@ -147,37 +181,3 @@ export default class SchedulerBookingRequest extends Model
     return json;
   }
 }
-SchedulerBookingRequest.attributes = {
-  additionalEmails: Attributes.StringList({
-    modelKey: 'additionalEmails',
-    jsonKey: 'additional_emails',
-  }),
-  additionalValues: Attributes.Object({
-    modelKey: 'additionalValues',
-    jsonKey: 'additional_values',
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-  locale: Attributes.String({
-    modelKey: 'locale',
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  pageHostname: Attributes.String({
-    modelKey: 'pageHostname',
-    jsonKey: 'page_hostname',
-  }),
-  replacesBookingHash: Attributes.String({
-    modelKey: 'replacesBookingHash',
-    jsonKey: 'replaces_booking_hash',
-  }),
-  slot: Attributes.Object({
-    modelKey: 'slot',
-    itemClass: SchedulerTimeSlot,
-  }),
-  timezone: Attributes.String({
-    modelKey: 'timezone',
-  }),
-};

--- a/src/models/scheduler-time-slot.ts
+++ b/src/models/scheduler-time-slot.ts
@@ -1,4 +1,4 @@
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import Model from './model';
 
 export type SchedulerTimeSlotProperties = {
@@ -18,32 +18,32 @@ export default class SchedulerTimeSlot extends Model
   emails?: string[];
   start?: Date;
   end?: Date;
+  static attributes: Record<string, Attribute> = {
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+    }),
+    calendarId: Attributes.String({
+      modelKey: 'calendarId',
+      jsonKey: 'calendar_id',
+    }),
+    hostName: Attributes.String({
+      modelKey: 'hostName',
+      jsonKey: 'host_name',
+    }),
+    emails: Attributes.StringList({
+      modelKey: 'emails',
+    }),
+    start: Attributes.DateTime({
+      modelKey: 'start',
+    }),
+    end: Attributes.DateTime({
+      modelKey: 'end',
+    }),
+  };
 
   constructor(props?: SchedulerTimeSlotProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerTimeSlot.attributes = {
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-  }),
-  calendarId: Attributes.String({
-    modelKey: 'calendarId',
-    jsonKey: 'calendar_id',
-  }),
-  hostName: Attributes.String({
-    modelKey: 'hostName',
-    jsonKey: 'host_name',
-  }),
-  emails: Attributes.StringList({
-    modelKey: 'emails',
-  }),
-  start: Attributes.DateTime({
-    modelKey: 'start',
-  }),
-  end: Attributes.DateTime({
-    modelKey: 'end',
-  }),
-};

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -1,5 +1,5 @@
 import RestfulModel, { SaveCallback } from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 import Model from './model';
 import Calendar from './calendar';
@@ -24,6 +24,21 @@ export class SchedulerAvailableCalendars extends Model
   name = '';
   email = '';
   calendars: Calendar[] = [];
+  static attributes: Record<string, Attribute> = {
+    calendars: Attributes.Collection({
+      modelKey: 'calendars',
+      itemClass: Calendar,
+    }),
+    email: Attributes.String({
+      modelKey: 'email',
+    }),
+    id: Attributes.String({
+      modelKey: 'id',
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+  };
   private _connection?: NylasConnection;
 
   constructor(props?: SchedulerAvailableCalendarsProperties) {
@@ -43,21 +58,6 @@ export class SchedulerAvailableCalendars extends Model
     return super.fromJSON(json);
   }
 }
-SchedulerAvailableCalendars.attributes = {
-  calendars: Attributes.Collection({
-    modelKey: 'calendars',
-    itemClass: Calendar,
-  }),
-  email: Attributes.String({
-    modelKey: 'email',
-  }),
-  id: Attributes.String({
-    modelKey: 'id',
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-};
 
 export type SchedulerAppearanceProperties = {
   color?: string;
@@ -86,56 +86,56 @@ export class SchedulerAppearance extends Model
   thankYouRedirect?: string;
   thankYouText?: string;
   thankYouTextSecondary?: string;
+  static attributes: Record<string, Attribute> = {
+    color: Attributes.String({
+      modelKey: 'color',
+    }),
+    companyName: Attributes.String({
+      modelKey: 'companyName',
+      jsonKey: 'company_name',
+    }),
+    logo: Attributes.String({
+      modelKey: 'logo',
+    }),
+    privacyPolicyRedirect: Attributes.String({
+      modelKey: 'privacyPolicyRedirect',
+      jsonKey: 'privacy_policy_redirect',
+    }),
+    showAutoschedule: Attributes.Boolean({
+      modelKey: 'showAutoschedule',
+      jsonKey: 'show_autoschedule',
+    }),
+    showNylasBranding: Attributes.Boolean({
+      modelKey: 'showNylasBranding',
+      jsonKey: 'show_nylas_branding',
+    }),
+    showTimezoneOptions: Attributes.Boolean({
+      modelKey: 'showTimezoneOptions',
+      jsonKey: 'show_timezone_options',
+    }),
+    submitText: Attributes.String({
+      modelKey: 'submitText',
+      jsonKey: 'submit_text',
+    }),
+    thankYouRedirect: Attributes.String({
+      modelKey: 'thankYouRedirect',
+      jsonKey: 'thank_you_redirect',
+    }),
+    thankYouText: Attributes.String({
+      modelKey: 'thankYouText',
+      jsonKey: 'thank_you_text',
+    }),
+    thankYouTextSecondary: Attributes.String({
+      modelKey: 'thankYouTextSecondary',
+      jsonKey: 'thank_you_text_secondary',
+    }),
+  };
 
   constructor(props?: SchedulerAppearanceProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerAppearance.attributes = {
-  color: Attributes.String({
-    modelKey: 'color',
-  }),
-  companyName: Attributes.String({
-    modelKey: 'companyName',
-    jsonKey: 'company_name',
-  }),
-  logo: Attributes.String({
-    modelKey: 'logo',
-  }),
-  privacyPolicyRedirect: Attributes.String({
-    modelKey: 'privacyPolicyRedirect',
-    jsonKey: 'privacy_policy_redirect',
-  }),
-  showAutoschedule: Attributes.Boolean({
-    modelKey: 'showAutoschedule',
-    jsonKey: 'show_autoschedule',
-  }),
-  showNylasBranding: Attributes.Boolean({
-    modelKey: 'showNylasBranding',
-    jsonKey: 'show_nylas_branding',
-  }),
-  showTimezoneOptions: Attributes.Boolean({
-    modelKey: 'showTimezoneOptions',
-    jsonKey: 'show_timezone_options',
-  }),
-  submitText: Attributes.String({
-    modelKey: 'submitText',
-    jsonKey: 'submit_text',
-  }),
-  thankYouRedirect: Attributes.String({
-    modelKey: 'thankYouRedirect',
-    jsonKey: 'thank_you_redirect',
-  }),
-  thankYouText: Attributes.String({
-    modelKey: 'thankYouText',
-    jsonKey: 'thank_you_text',
-  }),
-  thankYouTextSecondary: Attributes.String({
-    modelKey: 'thankYouTextSecondary',
-    jsonKey: 'thank_you_text_secondary',
-  }),
-};
 
 export type SchedulerBookingAdditionalFieldsProperties = {
   dropdownOptions?: string[];
@@ -158,40 +158,40 @@ export class SchedulerBookingAdditionalFields extends Model
   pattern?: string;
   required?: boolean;
   type?: string;
+  static attributes: Record<string, Attribute> = {
+    dropdownOptions: Attributes.StringList({
+      modelKey: 'dropdownOptions',
+      jsonKey: 'dropdown_options',
+    }),
+    label: Attributes.String({
+      modelKey: 'label',
+    }),
+    multiSelectOptions: Attributes.StringList({
+      modelKey: 'multiSelectOptions',
+      jsonKey: 'multi_select_options',
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    order: Attributes.Number({
+      modelKey: 'order',
+    }),
+    pattern: Attributes.String({
+      modelKey: 'pattern',
+    }),
+    required: Attributes.Boolean({
+      modelKey: 'required',
+    }),
+    type: Attributes.String({
+      modelKey: 'type',
+    }),
+  };
 
   constructor(props?: SchedulerBookingAdditionalFieldsProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerBookingAdditionalFields.attributes = {
-  dropdownOptions: Attributes.StringList({
-    modelKey: 'dropdownOptions',
-    jsonKey: 'dropdown_options',
-  }),
-  label: Attributes.String({
-    modelKey: 'label',
-  }),
-  multiSelectOptions: Attributes.StringList({
-    modelKey: 'multiSelectOptions',
-    jsonKey: 'multi_select_options',
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  order: Attributes.Number({
-    modelKey: 'order',
-  }),
-  pattern: Attributes.String({
-    modelKey: 'pattern',
-  }),
-  required: Attributes.Boolean({
-    modelKey: 'required',
-  }),
-  type: Attributes.String({
-    modelKey: 'type',
-  }),
-};
 
 export type SchedulerBookingOpeningHoursProperties = {
   accountId?: string;
@@ -206,27 +206,27 @@ export class SchedulerBookingOpeningHours extends Model
   days?: string;
   end?: string;
   start?: string;
+  static attributes: Record<string, Attribute> = {
+    dropdownOptions: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+    }),
+    days: Attributes.String({
+      modelKey: 'days',
+    }),
+    end: Attributes.String({
+      modelKey: 'end',
+    }),
+    start: Attributes.String({
+      modelKey: 'start',
+    }),
+  };
 
   constructor(props?: SchedulerBookingOpeningHoursProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerBookingOpeningHours.attributes = {
-  dropdownOptions: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-  }),
-  days: Attributes.String({
-    modelKey: 'days',
-  }),
-  end: Attributes.String({
-    modelKey: 'end',
-  }),
-  start: Attributes.String({
-    modelKey: 'start',
-  }),
-};
 
 export type SchedulerBookingProperties = {
   additionalFields?: SchedulerBookingAdditionalFieldsProperties[];
@@ -259,68 +259,68 @@ export class SchedulerBooking extends Model
   nameFieldHidden?: boolean;
   openingHours?: SchedulerBookingOpeningHours[];
   schedulingMethod?: string;
+  static attributes: Record<string, Attribute> = {
+    additionalFields: Attributes.Collection({
+      modelKey: 'additionalFields',
+      jsonKey: 'additional_fields',
+      itemClass: SchedulerBookingAdditionalFields,
+    }),
+    availableDaysInFuture: Attributes.Number({
+      modelKey: 'availableDaysInFuture',
+      jsonKey: 'available_days_in_future',
+    }),
+    calendarInviteToGuests: Attributes.Boolean({
+      modelKey: 'calendarInviteToGuests',
+      jsonKey: 'calendar_invites_to_guests',
+    }),
+    cancellationPolicy: Attributes.String({
+      modelKey: 'cancellationPolicy',
+      jsonKey: 'cancellation_policy',
+    }),
+    confirmationEmailsToGuests: Attributes.Boolean({
+      modelKey: 'confirmationEmailsToGuests',
+      jsonKey: 'confirmation_emails_to_guests',
+    }),
+    confirmationEmailToHost: Attributes.Boolean({
+      modelKey: 'confirmationEmailToHost',
+      jsonKey: 'confirmation_email_to_host',
+    }),
+    confirmationMethod: Attributes.String({
+      modelKey: 'confirmationMethod',
+      jsonKey: 'confirmation_method',
+    }),
+    minBookingNotice: Attributes.Number({
+      modelKey: 'minBookingNotice',
+      jsonKey: 'min_booking_notice',
+    }),
+    minBuffer: Attributes.Number({
+      modelKey: 'minBuffer',
+      jsonKey: 'min_buffer',
+    }),
+    minCancellationNotice: Attributes.Number({
+      modelKey: 'minCancellationNotice',
+      jsonKey: 'min_cancellation_notice',
+    }),
+    nameFieldHidden: Attributes.Boolean({
+      modelKey: 'nameFieldHidden',
+      jsonKey: 'name_field_hidden',
+    }),
+    openingHours: Attributes.Collection({
+      modelKey: 'openingHours',
+      jsonKey: 'opening_hours',
+      itemClass: SchedulerBookingOpeningHours,
+    }),
+    schedulingMethod: Attributes.String({
+      modelKey: 'schedulingMethod',
+      jsonKey: 'scheduling_method',
+    }),
+  };
 
   constructor(props?: SchedulerBookingProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerBooking.attributes = {
-  additionalFields: Attributes.Collection({
-    modelKey: 'additionalFields',
-    jsonKey: 'additional_fields',
-    itemClass: SchedulerBookingAdditionalFields,
-  }),
-  availableDaysInFuture: Attributes.Number({
-    modelKey: 'availableDaysInFuture',
-    jsonKey: 'available_days_in_future',
-  }),
-  calendarInviteToGuests: Attributes.Boolean({
-    modelKey: 'calendarInviteToGuests',
-    jsonKey: 'calendar_invites_to_guests',
-  }),
-  cancellationPolicy: Attributes.String({
-    modelKey: 'cancellationPolicy',
-    jsonKey: 'cancellation_policy',
-  }),
-  confirmationEmailsToGuests: Attributes.Boolean({
-    modelKey: 'confirmationEmailsToGuests',
-    jsonKey: 'confirmation_emails_to_guests',
-  }),
-  confirmationEmailToHost: Attributes.Boolean({
-    modelKey: 'confirmationEmailToHost',
-    jsonKey: 'confirmation_email_to_host',
-  }),
-  confirmationMethod: Attributes.String({
-    modelKey: 'confirmationMethod',
-    jsonKey: 'confirmation_method',
-  }),
-  minBookingNotice: Attributes.Number({
-    modelKey: 'minBookingNotice',
-    jsonKey: 'min_booking_notice',
-  }),
-  minBuffer: Attributes.Number({
-    modelKey: 'minBuffer',
-    jsonKey: 'min_buffer',
-  }),
-  minCancellationNotice: Attributes.Number({
-    modelKey: 'minCancellationNotice',
-    jsonKey: 'min_cancellation_notice',
-  }),
-  nameFieldHidden: Attributes.Boolean({
-    modelKey: 'nameFieldHidden',
-    jsonKey: 'name_field_hidden',
-  }),
-  openingHours: Attributes.Collection({
-    modelKey: 'openingHours',
-    jsonKey: 'opening_hours',
-    itemClass: SchedulerBookingOpeningHours,
-  }),
-  schedulingMethod: Attributes.String({
-    modelKey: 'schedulingMethod',
-    jsonKey: 'scheduling_method',
-  }),
-};
 
 export type SchedulerRemindersProperties = {
   deliveryMethod?: string;
@@ -337,34 +337,34 @@ export class SchedulerReminders extends Model
   emailSubject?: string;
   timeBeforeEvent?: number;
   webhookUrl?: string;
+  static attributes: Record<string, Attribute> = {
+    deliveryMethod: Attributes.String({
+      modelKey: 'deliveryMethod',
+      jsonKey: 'delivery_method',
+    }),
+    deliveryRecipient: Attributes.String({
+      modelKey: 'deliveryRecipient',
+      jsonKey: 'delivery_recipient',
+    }),
+    emailSubject: Attributes.String({
+      modelKey: 'emailSubject',
+      jsonKey: 'email_subject',
+    }),
+    timeBeforeEvent: Attributes.Number({
+      modelKey: 'timeBeforeEvent',
+      jsonKey: 'time_before_event',
+    }),
+    webhookUrl: Attributes.String({
+      modelKey: 'webhookUrl',
+      jsonKey: 'webhook_url',
+    }),
+  };
 
   constructor(props?: SchedulerRemindersProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerReminders.attributes = {
-  deliveryMethod: Attributes.String({
-    modelKey: 'deliveryMethod',
-    jsonKey: 'delivery_method',
-  }),
-  deliveryRecipient: Attributes.String({
-    modelKey: 'deliveryRecipient',
-    jsonKey: 'delivery_recipient',
-  }),
-  emailSubject: Attributes.String({
-    modelKey: 'emailSubject',
-    jsonKey: 'email_subject',
-  }),
-  timeBeforeEvent: Attributes.Number({
-    modelKey: 'timeBeforeEvent',
-    jsonKey: 'time_before_event',
-  }),
-  webhookUrl: Attributes.String({
-    modelKey: 'webhookUrl',
-    jsonKey: 'webhook_url',
-  }),
-};
 
 export type SchedulerConfigProperties = {
   appearance?: SchedulerAppearanceProperties;
@@ -413,47 +413,47 @@ export class SchedulerConfig extends Model
   localeForGuests?: string;
   reminders?: SchedulerRemindersProperties[];
   timezone?: string;
+  static attributes: Record<string, Attribute> = {
+    appearance: Attributes.Object({
+      modelKey: 'appearance',
+      itemClass: SchedulerAppearance,
+    }),
+    booking: Attributes.Object({
+      modelKey: 'booking',
+      itemClass: SchedulerBooking,
+    }),
+    calendarIds: Attributes.Object({
+      modelKey: 'calendarIds',
+      jsonKey: 'calendar_ids',
+    }),
+    event: Attributes.Object({
+      modelKey: 'event',
+    }),
+    expireAfter: Attributes.Object({
+      modelKey: 'expireAfter',
+      jsonKey: 'expire_after',
+    }),
+    locale: Attributes.String({
+      modelKey: 'locale',
+    }),
+    localeForGuests: Attributes.String({
+      modelKey: 'localeForGuests',
+      jsonKey: 'locale_for_guests',
+    }),
+    reminders: Attributes.Collection({
+      modelKey: 'reminders',
+      itemClass: SchedulerReminders,
+    }),
+    timezone: Attributes.String({
+      modelKey: 'timezone',
+    }),
+  };
 
   constructor(props?: SchedulerConfigProperties) {
     super();
     this.initAttributes(props);
   }
 }
-SchedulerConfig.attributes = {
-  appearance: Attributes.Object({
-    modelKey: 'appearance',
-    itemClass: SchedulerAppearance,
-  }),
-  booking: Attributes.Object({
-    modelKey: 'booking',
-    itemClass: SchedulerBooking,
-  }),
-  calendarIds: Attributes.Object({
-    modelKey: 'calendarIds',
-    jsonKey: 'calendar_ids',
-  }),
-  event: Attributes.Object({
-    modelKey: 'event',
-  }),
-  expireAfter: Attributes.Object({
-    modelKey: 'expireAfter',
-    jsonKey: 'expire_after',
-  }),
-  locale: Attributes.String({
-    modelKey: 'locale',
-  }),
-  localeForGuests: Attributes.String({
-    modelKey: 'localeForGuests',
-    jsonKey: 'locale_for_guests',
-  }),
-  reminders: Attributes.Collection({
-    modelKey: 'reminders',
-    itemClass: SchedulerReminders,
-  }),
-  timezone: Attributes.String({
-    modelKey: 'timezone',
-  }),
-};
 
 export type SchedulerProperties = {
   accessTokens?: string[];
@@ -478,6 +478,49 @@ export default class Scheduler extends RestfulModel
   slug?: string;
   createdAt?: Date;
   modifiedAt?: Date;
+  static collectionName = 'manage/pages';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    accessTokens: Attributes.StringList({
+      modelKey: 'accessTokens',
+      jsonKey: 'access_tokens',
+    }),
+    appClientId: Attributes.String({
+      modelKey: 'appClientId',
+      jsonKey: 'app_client_id',
+      readOnly: true,
+    }),
+    appOrganizationId: Attributes.Number({
+      modelKey: 'appOrganizationId',
+      jsonKey: 'app_organization_id',
+      readOnly: true,
+    }),
+    config: Attributes.Object({
+      modelKey: 'config',
+      itemClass: SchedulerConfig,
+    }),
+    editToken: Attributes.String({
+      modelKey: 'editToken',
+      jsonKey: 'edit_token',
+      readOnly: true,
+    }),
+    name: Attributes.String({
+      modelKey: 'name',
+    }),
+    slug: Attributes.String({
+      modelKey: 'slug',
+    }),
+    createdAt: Attributes.Date({
+      modelKey: 'createdAt',
+      jsonKey: 'created_at',
+      readOnly: true,
+    }),
+    modifiedAt: Attributes.Date({
+      modelKey: 'modifiedAt',
+      jsonKey: 'modified_at',
+      readOnly: true,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: SchedulerProperties) {
     super(connection, props);
@@ -535,46 +578,3 @@ export default class Scheduler extends RestfulModel
     });
   }
 }
-Scheduler.collectionName = 'manage/pages';
-Scheduler.attributes = {
-  ...RestfulModel.attributes,
-  accessTokens: Attributes.StringList({
-    modelKey: 'accessTokens',
-    jsonKey: 'access_tokens',
-  }),
-  appClientId: Attributes.String({
-    modelKey: 'appClientId',
-    jsonKey: 'app_client_id',
-    readOnly: true,
-  }),
-  appOrganizationId: Attributes.Number({
-    modelKey: 'appOrganizationId',
-    jsonKey: 'app_organization_id',
-    readOnly: true,
-  }),
-  config: Attributes.Object({
-    modelKey: 'config',
-    itemClass: SchedulerConfig,
-  }),
-  editToken: Attributes.String({
-    modelKey: 'editToken',
-    jsonKey: 'edit_token',
-    readOnly: true,
-  }),
-  name: Attributes.String({
-    modelKey: 'name',
-  }),
-  slug: Attributes.String({
-    modelKey: 'slug',
-  }),
-  createdAt: Attributes.Date({
-    modelKey: 'createdAt',
-    jsonKey: 'created_at',
-    readOnly: true,
-  }),
-  modifiedAt: Attributes.Date({
-    modelKey: 'modifiedAt',
-    jsonKey: 'modified_at',
-    readOnly: true,
-  }),
-};

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -1,6 +1,6 @@
 import Message, { MessageProperties } from './message';
 import RestfulModel, { SaveCallback } from './restful-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import EmailParticipant, {
   EmailParticipantProperties,
 } from './email-participant';
@@ -45,6 +45,75 @@ export default class Thread extends RestfulModel implements ThreadProperties {
   draftIds?: string[];
   messages?: Message[];
   drafts?: Message[];
+  static collectionName = 'threads';
+  static attributes: Record<string, Attribute> = {
+    ...RestfulModel.attributes,
+    subject: Attributes.String({
+      modelKey: 'subject',
+    }),
+    participants: Attributes.Collection({
+      modelKey: 'participants',
+      itemClass: EmailParticipant,
+    }),
+    lastMessageTimestamp: Attributes.DateTime({
+      modelKey: 'lastMessageTimestamp',
+      jsonKey: 'last_message_timestamp',
+    }),
+    lastMessageReceivedTimestamp: Attributes.DateTime({
+      modelKey: 'lastMessageReceivedTimestamp',
+      jsonKey: 'last_message_received_timestamp',
+    }),
+    lastMessageSentTimestamp: Attributes.DateTime({
+      modelKey: 'lastMessageSentTimestamp',
+      jsonKey: 'last_message_sent_timestamp',
+    }),
+    firstMessageTimestamp: Attributes.DateTime({
+      modelKey: 'firstMessageTimestamp',
+      jsonKey: 'first_message_timestamp',
+    }),
+    snippet: Attributes.String({
+      modelKey: 'snippet',
+    }),
+    unread: Attributes.Boolean({
+      modelKey: 'unread',
+    }),
+    starred: Attributes.Boolean({
+      modelKey: 'starred',
+    }),
+    hasAttachments: Attributes.Boolean({
+      modelKey: 'has_attachments',
+    }),
+    version: Attributes.String({
+      modelKey: 'version',
+      jsonKey: 'version',
+    }),
+    folders: Attributes.Collection({
+      modelKey: 'folders',
+      itemClass: Folder,
+      jsonKey: 'folders',
+    }),
+    labels: Attributes.Collection({
+      modelKey: 'labels',
+      itemClass: Label,
+      jsonKey: 'labels',
+    }),
+    messageIds: Attributes.StringList({
+      modelKey: 'messageIds',
+      jsonKey: 'message_ids',
+    }),
+    draftIds: Attributes.StringList({
+      modelKey: 'draftIds',
+      jsonKey: 'draft_ids',
+    }),
+    messages: Attributes.Collection({
+      modelKey: 'messages',
+      itemClass: Message,
+    }),
+    drafts: Attributes.Collection({
+      modelKey: 'drafts',
+      itemClass: Message,
+    }),
+  };
 
   constructor(connection: NylasConnection, props?: ThreadProperties) {
     super(connection, props);
@@ -68,72 +137,3 @@ export default class Thread extends RestfulModel implements ThreadProperties {
     return super.save(params, callback);
   }
 }
-Thread.collectionName = 'threads';
-Thread.attributes = {
-  ...RestfulModel.attributes,
-  subject: Attributes.String({
-    modelKey: 'subject',
-  }),
-  participants: Attributes.Collection({
-    modelKey: 'participants',
-    itemClass: EmailParticipant,
-  }),
-  lastMessageTimestamp: Attributes.DateTime({
-    modelKey: 'lastMessageTimestamp',
-    jsonKey: 'last_message_timestamp',
-  }),
-  lastMessageReceivedTimestamp: Attributes.DateTime({
-    modelKey: 'lastMessageReceivedTimestamp',
-    jsonKey: 'last_message_received_timestamp',
-  }),
-  lastMessageSentTimestamp: Attributes.DateTime({
-    modelKey: 'lastMessageSentTimestamp',
-    jsonKey: 'last_message_sent_timestamp',
-  }),
-  firstMessageTimestamp: Attributes.DateTime({
-    modelKey: 'firstMessageTimestamp',
-    jsonKey: 'first_message_timestamp',
-  }),
-  snippet: Attributes.String({
-    modelKey: 'snippet',
-  }),
-  unread: Attributes.Boolean({
-    modelKey: 'unread',
-  }),
-  starred: Attributes.Boolean({
-    modelKey: 'starred',
-  }),
-  hasAttachments: Attributes.Boolean({
-    modelKey: 'has_attachments',
-  }),
-  version: Attributes.String({
-    modelKey: 'version',
-    jsonKey: 'version',
-  }),
-  folders: Attributes.Collection({
-    modelKey: 'folders',
-    itemClass: Folder,
-    jsonKey: 'folders',
-  }),
-  labels: Attributes.Collection({
-    modelKey: 'labels',
-    itemClass: Label,
-    jsonKey: 'labels',
-  }),
-  messageIds: Attributes.StringList({
-    modelKey: 'messageIds',
-    jsonKey: 'message_ids',
-  }),
-  draftIds: Attributes.StringList({
-    modelKey: 'draftIds',
-    jsonKey: 'draft_ids',
-  }),
-  messages: Attributes.Collection({
-    modelKey: 'messages',
-    itemClass: Message,
-  }),
-  drafts: Attributes.Collection({
-    modelKey: 'drafts',
-    itemClass: Message,
-  }),
-};

--- a/src/models/webhook.ts
+++ b/src/models/webhook.ts
@@ -1,5 +1,5 @@
 import ManagementModel from './management-model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 import { SaveCallback } from './restful-model';
 import NylasConnection from '../nylas-connection';
 
@@ -20,6 +20,34 @@ export default class Webhook extends ManagementModel
   id?: string;
   applicationId?: string;
   version?: string;
+  static collectionName = 'webhooks';
+  static attributes: Record<string, Attribute> = {
+    id: Attributes.String({
+      modelKey: 'id',
+    }),
+
+    applicationId: Attributes.String({
+      modelKey: 'applicationId',
+      jsonKey: 'application_id',
+    }),
+
+    callbackUrl: Attributes.String({
+      modelKey: 'callbackUrl',
+      jsonKey: 'callback_url',
+    }),
+
+    state: Attributes.String({
+      modelKey: 'state',
+    }),
+
+    triggers: Attributes.StringList({
+      modelKey: 'triggers',
+    }),
+
+    version: Attributes.String({
+      modelKey: 'version',
+    }),
+  };
 
   constructor(
     connection: NylasConnection,
@@ -49,32 +77,3 @@ export default class Webhook extends ManagementModel
     return super.save(params, callback);
   }
 }
-
-Webhook.collectionName = 'webhooks';
-Webhook.attributes = {
-  id: Attributes.String({
-    modelKey: 'id',
-  }),
-
-  applicationId: Attributes.String({
-    modelKey: 'applicationId',
-    jsonKey: 'application_id',
-  }),
-
-  callbackUrl: Attributes.String({
-    modelKey: 'callbackUrl',
-    jsonKey: 'callback_url',
-  }),
-
-  state: Attributes.String({
-    modelKey: 'state',
-  }),
-
-  triggers: Attributes.StringList({
-    modelKey: 'triggers',
-  }),
-
-  version: Attributes.String({
-    modelKey: 'version',
-  }),
-};

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -1,5 +1,5 @@
 import Model from './model';
-import Attributes from './attributes';
+import Attributes, { Attribute } from './attributes';
 
 export type WhenProperties = {
   startTime?: number;
@@ -19,38 +19,37 @@ export default class When extends Model implements WhenProperties {
   endDate?: string;
   date?: string;
   object?: string;
+  static attributes: Record<string, Attribute> = {
+    startTime: Attributes.Number({
+      modelKey: 'startTime',
+      jsonKey: 'start_time',
+    }),
+    endTime: Attributes.Number({
+      modelKey: 'endTime',
+      jsonKey: 'end_time',
+    }),
+    time: Attributes.Number({
+      modelKey: 'time',
+    }),
+    startDate: Attributes.String({
+      modelKey: 'startDate',
+      jsonKey: 'start_date',
+    }),
+    endDate: Attributes.String({
+      modelKey: 'endDate',
+      jsonKey: 'end_date',
+    }),
+    date: Attributes.String({
+      modelKey: 'date',
+    }),
+    object: Attributes.String({
+      modelKey: 'object',
+      readOnly: true,
+    }),
+  };
 
   constructor(props?: WhenProperties) {
     super();
     this.initAttributes(props);
   }
 }
-
-When.attributes = {
-  startTime: Attributes.Number({
-    modelKey: 'startTime',
-    jsonKey: 'start_time',
-  }),
-  endTime: Attributes.Number({
-    modelKey: 'endTime',
-    jsonKey: 'end_time',
-  }),
-  time: Attributes.Number({
-    modelKey: 'time',
-  }),
-  startDate: Attributes.String({
-    modelKey: 'startDate',
-    jsonKey: 'start_date',
-  }),
-  endDate: Attributes.String({
-    modelKey: 'endDate',
-    jsonKey: 'end_date',
-  }),
-  date: Attributes.String({
-    modelKey: 'date',
-  }),
-  object: Attributes.String({
-    modelKey: 'object',
-    readOnly: true,
-  }),
-};


### PR DESCRIPTION
# Description
This PR's goal is for better readability, one of the proposed changes internally was to move all the `attributes` and `collectionName` properties into the class with as `static` properties.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.