### PR TITLE
v6.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.1.0 / 2022-01-28
 * Add support for `Event` to ICS
 * Add `comment` and `phoneNumber` fields to `EventParticipant`
 * Add support for `calendar` field in free-busy, availability, and consecutive availability queries

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -17,22 +17,22 @@ export class FreeBusyCalendar extends Model
   implements FreeBusyCalendarProperties {
   accountId = '';
   calendarIds: string[] = [];
+  static attributes: Record<string, Attribute> = {
+    accountId: Attributes.String({
+      modelKey: 'accountId',
+      jsonKey: 'account_id',
+    }),
+    calendarIds: Attributes.StringList({
+      modelKey: 'calendarIds',
+      jsonKey: 'calendar_ids',
+    }),
+  };
 
   constructor(props?: FreeBusyCalendarProperties) {
     super();
     this.initAttributes(props);
   }
 }
-FreeBusyCalendar.attributes = {
-  accountId: Attributes.String({
-    modelKey: 'accountId',
-    jsonKey: 'account_id',
-  }),
-  calendarIds: Attributes.StringList({
-    modelKey: 'calendarIds',
-    jsonKey: 'calendar_ids',
-  }),
-};
 
 export type TimeSlotProperties = {
   status: string;


### PR DESCRIPTION
# Description
New `nylas` v6.1.0 minor release provides the following new features:
* Add support for `Event` to ICS (#308)
* Add `comment` and `phoneNumber` fields to `EventParticipant` (#305)
* Add support for `calendar` field in free-busy, availability, and consecutive availability queries (#306)

and the following fix:
* Fix issue where properties of `Model` type were sending read-only attributes to the API (#309) 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.