### PR TITLE
[76810] Improve `Delta` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Unreleased
-* Improved `Delta` support: added `Delta` model and `longpoll` support.
+* Improved `Delta` support: added `Delta` model and two new methods; `since` and `longpoll`.
 
 ### 6.1.0 / 2022-01-28
 * Add support for `Event` to ICS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Improved `Delta` support: added `Delta` model and `longpoll` support.
+
 ### 6.1.0 / 2022-01-28
 * Add support for `Event` to ICS
 * Add `comment` and `phoneNumber` fields to `EventParticipant`

--- a/__tests__/delta-spec.js
+++ b/__tests__/delta-spec.js
@@ -1,8 +1,10 @@
 import { PassThrough } from 'stream';
 import fetch, { Response } from 'node-fetch';
 import * as config from '../src/config.ts';
-import Delta from '../src/models/delta';
 import NylasConnection from '../src/nylas-connection';
+import Delta from '../src/models/delta';
+import DeltaCollection from '../src/models/delta-collection';
+import { Deltas } from '../src/models/deltas';
 
 jest.mock('node-fetch', () => {
   const { Request, Response, Headers } = jest.requireActual('node-fetch');
@@ -19,7 +21,7 @@ describe('Delta', () => {
   beforeEach(() => {
     testContext = {};
     testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-    testContext.delta = new Delta(testContext.connection);
+    testContext.delta = new DeltaCollection(testContext.connection);
     jest.useFakeTimers();
   });
 
@@ -199,6 +201,257 @@ describe('Delta', () => {
           expect(e).toEqual('Error.');
           done();
         });
+    });
+  });
+
+  describe('deserialize', () => {
+    test('returns a cursor', done => {
+      const json = {
+        cursor_start: 'start_cursor',
+        cursor_end: 'end_cursor',
+        deltas: [
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              given_name: 'First',
+              surname: 'Last',
+              id: 'id-1234',
+              object: 'contact',
+            },
+            cursor: 'contact_cursor',
+            event: 'create',
+            id: 'delta-1',
+            object: 'contact',
+          },
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              content_type: 'text/plain',
+              filename: 'sample.txt',
+              id: 'id-1234',
+              object: 'file',
+              size: 123,
+            },
+            cursor: 'file_cursor',
+            event: 'create',
+            id: 'delta-2',
+            object: 'file',
+          },
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              to: [{ email: 'foo', name: 'bar' }],
+              subject: 'foo',
+              id: 'id-1234',
+              object: 'message',
+            },
+            cursor: 'message_cursor',
+            event: 'create',
+            id: 'delta-3',
+            object: 'message',
+          },
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              to: [{ email: 'foo', name: 'bar' }],
+              subject: 'foo',
+              id: 'id-1234',
+              object: 'draft',
+            },
+            cursor: 'draft_cursor',
+            event: 'create',
+            id: 'delta-4',
+            object: 'draft',
+          },
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              subject: 'Subject',
+              id: 'id-1234',
+              object: 'thread',
+            },
+            cursor: 'thread_cursor',
+            event: 'create',
+            id: 'delta-5',
+            object: 'thread',
+          },
+          {
+            attributes: {
+              id: 'id-1234',
+              title: 'test event',
+              when: { time: 1409594400, object: 'time' },
+              participants: [
+                {
+                  name: 'foo',
+                  email: 'bar',
+                  status: 'noreply',
+                  comment: 'This is a comment',
+                  phone_number: '416-000-0000',
+                },
+              ],
+              ical_uid: 'id-5678',
+              master_event_id: 'master-1234',
+              original_start_time: 1409592400,
+            },
+            cursor: 'event_cursor',
+            event: 'create',
+            id: 'delta-6',
+            object: 'event',
+          },
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              id: 'id-1234',
+              object: 'folder',
+              name: 'inbox',
+              display_name: 'name',
+            },
+            cursor: 'folder_cursor',
+            event: 'create',
+            id: 'delta-7',
+            object: 'folder',
+          },
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              id: 'id-1234',
+              object: 'label',
+              name: 'inbox',
+            },
+            cursor: 'label_cursor',
+            event: 'create',
+            id: 'delta-8',
+            object: 'label',
+          },
+        ],
+      };
+
+      testContext.connection.request = jest.fn(() => Promise.resolve(json));
+      const deltas = new Deltas(testContext.connection).fromJSON(json);
+
+      expect(deltas.cursorStart).toEqual('start_cursor');
+      expect(deltas.cursorEnd).toEqual('end_cursor');
+      expect(deltas.deltas.length).toBe(8);
+
+      expect(deltas.deltas[0].cursor).toEqual('contact_cursor');
+      expect(deltas.deltas[0].event).toEqual('create');
+      expect(deltas.deltas[0].id).toEqual('delta-1');
+      expect(deltas.deltas[0].object).toEqual('contact');
+      expect(deltas.deltas[0].deltaAttributes.givenName).toEqual('First');
+      expect(deltas.deltas[0].deltaAttributes.surname).toEqual('Last');
+
+      expect(deltas.deltas[1].cursor).toEqual('file_cursor');
+      expect(deltas.deltas[1].event).toEqual('create');
+      expect(deltas.deltas[1].id).toEqual('delta-2');
+      expect(deltas.deltas[1].object).toEqual('file');
+      expect(deltas.deltas[1].deltaAttributes.filename).toEqual('sample.txt');
+      expect(deltas.deltas[1].deltaAttributes.size).toEqual(123);
+      expect(deltas.deltas[1].deltaAttributes.contentType).toEqual(
+        'text/plain'
+      );
+
+      expect(deltas.deltas[2].cursor).toEqual('message_cursor');
+      expect(deltas.deltas[2].event).toEqual('create');
+      expect(deltas.deltas[2].id).toEqual('delta-3');
+      expect(deltas.deltas[2].object).toEqual('message');
+      expect(deltas.deltas[2].deltaAttributes.to[0].email).toEqual('foo');
+      expect(deltas.deltas[2].deltaAttributes.to[0].name).toEqual('bar');
+      expect(deltas.deltas[2].deltaAttributes.subject).toEqual('foo');
+
+      expect(deltas.deltas[3].cursor).toEqual('draft_cursor');
+      expect(deltas.deltas[3].event).toEqual('create');
+      expect(deltas.deltas[3].id).toEqual('delta-4');
+      expect(deltas.deltas[3].object).toEqual('draft');
+      expect(deltas.deltas[3].deltaAttributes.to[0].email).toEqual('foo');
+      expect(deltas.deltas[3].deltaAttributes.to[0].name).toEqual('bar');
+      expect(deltas.deltas[3].deltaAttributes.subject).toEqual('foo');
+
+      expect(deltas.deltas[4].cursor).toEqual('thread_cursor');
+      expect(deltas.deltas[4].event).toEqual('create');
+      expect(deltas.deltas[4].id).toEqual('delta-5');
+      expect(deltas.deltas[4].object).toEqual('thread');
+      expect(deltas.deltas[4].deltaAttributes.subject).toEqual('Subject');
+
+      expect(deltas.deltas[5].cursor).toEqual('event_cursor');
+      expect(deltas.deltas[5].event).toEqual('create');
+      expect(deltas.deltas[5].id).toEqual('delta-6');
+      expect(deltas.deltas[5].object).toEqual('event');
+      expect(deltas.deltas[5].deltaAttributes.participants[0].name).toEqual(
+        'foo'
+      );
+      expect(deltas.deltas[5].deltaAttributes.participants[0].email).toEqual(
+        'bar'
+      );
+      expect(deltas.deltas[5].deltaAttributes.participants[0].status).toEqual(
+        'noreply'
+      );
+      expect(deltas.deltas[5].deltaAttributes.participants[0].comment).toEqual(
+        'This is a comment'
+      );
+      expect(
+        deltas.deltas[5].deltaAttributes.participants[0].phoneNumber
+      ).toEqual('416-000-0000');
+      expect(deltas.deltas[5].deltaAttributes.title).toEqual('test event');
+      expect(deltas.deltas[5].deltaAttributes.when.time).toEqual(1409594400);
+      expect(deltas.deltas[5].deltaAttributes.iCalUID).toEqual('id-5678');
+      expect(deltas.deltas[5].deltaAttributes.masterEventId).toEqual(
+        'master-1234'
+      );
+      expect(deltas.deltas[5].deltaAttributes.originalStartTime).toEqual(
+        new Date(1409592400 * 1000)
+      );
+
+      expect(deltas.deltas[6].cursor).toEqual('folder_cursor');
+      expect(deltas.deltas[6].event).toEqual('create');
+      expect(deltas.deltas[6].id).toEqual('delta-7');
+      expect(deltas.deltas[6].object).toEqual('folder');
+      expect(deltas.deltas[6].deltaAttributes.name).toEqual('inbox');
+      expect(deltas.deltas[6].deltaAttributes.displayName).toEqual('name');
+
+      expect(deltas.deltas[7].cursor).toEqual('label_cursor');
+      expect(deltas.deltas[7].event).toEqual('create');
+      expect(deltas.deltas[7].id).toEqual('delta-8');
+      expect(deltas.deltas[7].object).toEqual('label');
+      expect(deltas.deltas[7].deltaAttributes.name).toEqual('inbox');
+      done();
+    });
+  });
+
+  describe('since', () => {
+    test('returns a cursor', done => {
+      const json = {
+        cursor_start: 'start_cursor',
+        cursor_end: 'end_cursor',
+        deltas: [
+          {
+            attributes: {
+              account_id: 'aid-5678',
+              content_type: 'text/plain',
+              filename: 'sample.txt',
+              id: 'id-1234',
+              object: 'file',
+              size: 123,
+            },
+            cursor: 'file_cursor',
+            event: 'create',
+            id: 'id-1234',
+            object: 'file',
+          },
+        ],
+      };
+
+      testContext.connection.request = jest.fn(() => Promise.resolve(json));
+
+      return testContext.delta.since('end_cursor').then(cursor => {
+        expect(testContext.connection.request).toHaveBeenCalledWith({
+          method: 'GET',
+          path: '/delta',
+          qs: {
+            cursor: 'end_cursor',
+          },
+        });
+        done();
+      });
     });
   });
 });

--- a/__tests__/delta-spec.js
+++ b/__tests__/delta-spec.js
@@ -337,16 +337,16 @@ describe('Delta', () => {
       expect(deltas.deltas[0].event).toEqual('create');
       expect(deltas.deltas[0].id).toEqual('delta-1');
       expect(deltas.deltas[0].object).toEqual('contact');
-      expect(deltas.deltas[0].deltaAttributes.givenName).toEqual('First');
-      expect(deltas.deltas[0].deltaAttributes.surname).toEqual('Last');
+      expect(deltas.deltas[0].objectAttributes.givenName).toEqual('First');
+      expect(deltas.deltas[0].objectAttributes.surname).toEqual('Last');
 
       expect(deltas.deltas[1].cursor).toEqual('file_cursor');
       expect(deltas.deltas[1].event).toEqual('create');
       expect(deltas.deltas[1].id).toEqual('delta-2');
       expect(deltas.deltas[1].object).toEqual('file');
-      expect(deltas.deltas[1].deltaAttributes.filename).toEqual('sample.txt');
-      expect(deltas.deltas[1].deltaAttributes.size).toEqual(123);
-      expect(deltas.deltas[1].deltaAttributes.contentType).toEqual(
+      expect(deltas.deltas[1].objectAttributes.filename).toEqual('sample.txt');
+      expect(deltas.deltas[1].objectAttributes.size).toEqual(123);
+      expect(deltas.deltas[1].objectAttributes.contentType).toEqual(
         'text/plain'
       );
 
@@ -354,50 +354,50 @@ describe('Delta', () => {
       expect(deltas.deltas[2].event).toEqual('create');
       expect(deltas.deltas[2].id).toEqual('delta-3');
       expect(deltas.deltas[2].object).toEqual('message');
-      expect(deltas.deltas[2].deltaAttributes.to[0].email).toEqual('foo');
-      expect(deltas.deltas[2].deltaAttributes.to[0].name).toEqual('bar');
-      expect(deltas.deltas[2].deltaAttributes.subject).toEqual('foo');
+      expect(deltas.deltas[2].objectAttributes.to[0].email).toEqual('foo');
+      expect(deltas.deltas[2].objectAttributes.to[0].name).toEqual('bar');
+      expect(deltas.deltas[2].objectAttributes.subject).toEqual('foo');
 
       expect(deltas.deltas[3].cursor).toEqual('draft_cursor');
       expect(deltas.deltas[3].event).toEqual('create');
       expect(deltas.deltas[3].id).toEqual('delta-4');
       expect(deltas.deltas[3].object).toEqual('draft');
-      expect(deltas.deltas[3].deltaAttributes.to[0].email).toEqual('foo');
-      expect(deltas.deltas[3].deltaAttributes.to[0].name).toEqual('bar');
-      expect(deltas.deltas[3].deltaAttributes.subject).toEqual('foo');
+      expect(deltas.deltas[3].objectAttributes.to[0].email).toEqual('foo');
+      expect(deltas.deltas[3].objectAttributes.to[0].name).toEqual('bar');
+      expect(deltas.deltas[3].objectAttributes.subject).toEqual('foo');
 
       expect(deltas.deltas[4].cursor).toEqual('thread_cursor');
       expect(deltas.deltas[4].event).toEqual('create');
       expect(deltas.deltas[4].id).toEqual('delta-5');
       expect(deltas.deltas[4].object).toEqual('thread');
-      expect(deltas.deltas[4].deltaAttributes.subject).toEqual('Subject');
+      expect(deltas.deltas[4].objectAttributes.subject).toEqual('Subject');
 
       expect(deltas.deltas[5].cursor).toEqual('event_cursor');
       expect(deltas.deltas[5].event).toEqual('create');
       expect(deltas.deltas[5].id).toEqual('delta-6');
       expect(deltas.deltas[5].object).toEqual('event');
-      expect(deltas.deltas[5].deltaAttributes.participants[0].name).toEqual(
+      expect(deltas.deltas[5].objectAttributes.participants[0].name).toEqual(
         'foo'
       );
-      expect(deltas.deltas[5].deltaAttributes.participants[0].email).toEqual(
+      expect(deltas.deltas[5].objectAttributes.participants[0].email).toEqual(
         'bar'
       );
-      expect(deltas.deltas[5].deltaAttributes.participants[0].status).toEqual(
+      expect(deltas.deltas[5].objectAttributes.participants[0].status).toEqual(
         'noreply'
       );
-      expect(deltas.deltas[5].deltaAttributes.participants[0].comment).toEqual(
+      expect(deltas.deltas[5].objectAttributes.participants[0].comment).toEqual(
         'This is a comment'
       );
       expect(
-        deltas.deltas[5].deltaAttributes.participants[0].phoneNumber
+        deltas.deltas[5].objectAttributes.participants[0].phoneNumber
       ).toEqual('416-000-0000');
-      expect(deltas.deltas[5].deltaAttributes.title).toEqual('test event');
-      expect(deltas.deltas[5].deltaAttributes.when.time).toEqual(1409594400);
-      expect(deltas.deltas[5].deltaAttributes.iCalUID).toEqual('id-5678');
-      expect(deltas.deltas[5].deltaAttributes.masterEventId).toEqual(
+      expect(deltas.deltas[5].objectAttributes.title).toEqual('test event');
+      expect(deltas.deltas[5].objectAttributes.when.time).toEqual(1409594400);
+      expect(deltas.deltas[5].objectAttributes.iCalUID).toEqual('id-5678');
+      expect(deltas.deltas[5].objectAttributes.masterEventId).toEqual(
         'master-1234'
       );
-      expect(deltas.deltas[5].deltaAttributes.originalStartTime).toEqual(
+      expect(deltas.deltas[5].objectAttributes.originalStartTime).toEqual(
         new Date(1409592400 * 1000)
       );
 
@@ -405,14 +405,14 @@ describe('Delta', () => {
       expect(deltas.deltas[6].event).toEqual('create');
       expect(deltas.deltas[6].id).toEqual('delta-7');
       expect(deltas.deltas[6].object).toEqual('folder');
-      expect(deltas.deltas[6].deltaAttributes.name).toEqual('inbox');
-      expect(deltas.deltas[6].deltaAttributes.displayName).toEqual('name');
+      expect(deltas.deltas[6].objectAttributes.name).toEqual('inbox');
+      expect(deltas.deltas[6].objectAttributes.displayName).toEqual('name');
 
       expect(deltas.deltas[7].cursor).toEqual('label_cursor');
       expect(deltas.deltas[7].event).toEqual('create');
       expect(deltas.deltas[7].id).toEqual('delta-8');
       expect(deltas.deltas[7].object).toEqual('label');
-      expect(deltas.deltas[7].deltaAttributes.name).toEqual('inbox');
+      expect(deltas.deltas[7].objectAttributes.name).toEqual('inbox');
       done();
     });
   });

--- a/__tests__/delta-spec.js
+++ b/__tests__/delta-spec.js
@@ -442,7 +442,7 @@ describe('Delta', () => {
 
       testContext.connection.request = jest.fn(() => Promise.resolve(json));
 
-      return testContext.delta.since('end_cursor').then(cursor => {
+      return testContext.delta.since('end_cursor').then(() => {
         expect(testContext.connection.request).toHaveBeenCalledWith({
           method: 'GET',
           path: '/delta',

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -64,7 +64,12 @@ export default class DeltaCollection {
     params?: DeltaParams
   ): Promise<DeltaLongPoll> {
     const queryParams = this.buildDeltaParams(params);
-    const stream = new DeltaLongPoll(this.connection, cursor, timeout, queryParams);
+    const stream = new DeltaLongPoll(
+      this.connection,
+      cursor,
+      timeout,
+      queryParams
+    );
     await stream.open(true);
     return stream;
   }

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -83,12 +83,13 @@ export default class DeltaCollection {
     return stream;
   }
 
-  private buildDeltaParams(params?: DeltaParams): Partial<DeltaParams> {
-    const queryString: Partial<DeltaParams> = {
-       ...(params?.view && {view: params.view}),
-       ...(params?.exclude_types && {exclude_types: params.exclude_types.join()}),
-       ...(params?.includeTypes && {includeTypes: params.includeTypes.join()})
+  private buildDeltaParams(params?: DeltaParams): Record<string, unknown> {
+    return {
+      ...(params?.view && { view: params.view }),
+      ...(params?.excludeTypes && {
+        exclude_types: params.excludeTypes.join(),
+      }),
+      ...(params?.includeTypes && { includeTypes: params.includeTypes.join() }),
     };
-    return queryString;
   }
 }

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -1,5 +1,5 @@
 import NylasConnection from '../nylas-connection';
-import DeltaStream from './delta-stream';
+import DeltaStream, { DeltaLongPoll } from './delta-stream';
 import { DeltaParams } from './delta';
 import { Deltas } from './deltas';
 
@@ -57,6 +57,16 @@ export default class DeltaCollection {
       .catch(err => {
         return Promise.reject(err);
       });
+  }
+
+  async longPoll(
+    cursor: string,
+    timeout: number,
+    params?: Record<string, unknown>
+  ): Promise<DeltaLongPoll> {
+    const stream = new DeltaLongPoll(this.connection, cursor, timeout, params);
+    await stream.open(true);
+    return stream;
   }
 
   async startStream(

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -39,6 +39,26 @@ export default class DeltaCollection {
       });
   }
 
+  since(cursor: string, params?: DeltaParams): Promise<Deltas> {
+    return this.connection
+      .request({
+        method: 'GET',
+        path: `${this.path}`,
+        qs: {
+          cursor: cursor,
+          view: params?.view,
+          excluded_types: params?.excludeTypes,
+          include_types: params?.includeTypes,
+        },
+      })
+      .then(response => {
+        return Promise.resolve(new Deltas(this.connection).fromJSON(response));
+      })
+      .catch(err => {
+        return Promise.reject(err);
+      });
+  }
+
   async startStream(
     cursor: string,
     params: Record<string, unknown> = {}

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -62,7 +62,7 @@ export default class DeltaCollection {
   async longPoll(
     cursor: string,
     timeout: number,
-    params?: Record<string, unknown>
+    params?: DeltaParams
   ): Promise<DeltaLongPoll> {
     const stream = new DeltaLongPoll(this.connection, cursor, timeout, params);
     await stream.open(true);

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -83,19 +83,12 @@ export default class DeltaCollection {
     return stream;
   }
 
-  private buildDeltaParams(params?: DeltaParams): Record<string, unknown> {
-    const queryString: Record<string, unknown> = {};
-    if (params) {
-      if (params.view) {
-        queryString.view = params.view;
-      }
-      if (params.excludeTypes) {
-        queryString.exclude_types = params.excludeTypes.join();
-      }
-      if (params.includeTypes) {
-        queryString.include_types = params.includeTypes.join();
-      }
-    }
+  private buildDeltaParams(params?: DeltaParams): Partial<DeltaParams> {
+    const queryString: Partial<DeltaParams> = {
+       ...(params?.view && {view: params.view}),
+       ...(params?.exclude_types && {exclude_types: params.exclude_types.join()}),
+       ...(params?.includeTypes && {includeTypes: params.includeTypes.join()})
+    };
     return queryString;
   }
 }

--- a/src/models/delta-collection.ts
+++ b/src/models/delta-collection.ts
@@ -1,0 +1,50 @@
+import NylasConnection from '../nylas-connection';
+import DeltaStream from './delta-stream';
+import { DeltaParams } from './delta';
+import { Deltas } from './deltas';
+
+export type LatestCursor = {
+  cursor: string;
+};
+
+export default class DeltaCollection {
+  connection: NylasConnection;
+  private path = '/delta';
+
+  constructor(connection: NylasConnection) {
+    this.connection = connection;
+  }
+
+  latestCursor(
+    callback: (error: Error | null, cursor: string | null) => void
+  ): Promise<string> {
+    const reqOpts = {
+      method: 'POST',
+      path: `${this.path}/latest_cursor`,
+    };
+
+    return this.connection
+      .request(reqOpts)
+      .then((response: LatestCursor) => {
+        if (callback) {
+          callback(null, response.cursor);
+        }
+        return Promise.resolve(response.cursor);
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err, null);
+        }
+        return Promise.reject(err);
+      });
+  }
+
+  async startStream(
+    cursor: string,
+    params: Record<string, unknown> = {}
+  ): Promise<DeltaStream> {
+    const stream = new DeltaStream(this.connection, cursor, params);
+    await stream.open();
+    return stream;
+  }
+}

--- a/src/models/delta-stream.ts
+++ b/src/models/delta-stream.ts
@@ -13,7 +13,7 @@ import fetch, { Request } from 'node-fetch';
 import AbortController from 'abort-controller';
 import backoff from 'backoff';
 import JSONStream from 'JSONStream';
-import Delta from './delta';
+import Delta, { DeltaParams } from './delta';
 
 export default class DeltaStream extends EventEmitter {
   // Max number of times to retry a connection if we receive no data heartbeats
@@ -21,11 +21,7 @@ export default class DeltaStream extends EventEmitter {
   static MAX_RESTART_RETRIES = 5;
   connection: NylasConnection;
   cursor?: string;
-  params: {
-    includeTypes?: string[];
-    excludeTypes?: string[];
-    expanded?: boolean;
-  };
+  params: DeltaParams;
   requestInfo?: {
     request: Request;
     controller: AbortController;

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -1,20 +1,86 @@
 import NylasConnection from '../nylas-connection';
-import DeltaStream from './delta-stream';
+import Attributes, { Attribute } from './attributes';
+import RestfulModel from './restful-model';
+import Contact from './contact';
+import File from './file';
+import Message from './message';
+import Draft from './draft';
+import Thread from './thread';
+import Event from './event';
+import Folder, { Label } from './folder';
 
-export type LatestCursor = {
-  cursor: string;
+const DeltaClassMap: Record<string, typeof RestfulModel> = Object.freeze({
+  contact: Contact,
+  file: File,
+  message: Message,
+  draft: Draft,
+  thread: Thread,
+  event: Event,
+  folder: Folder,
+  label: Label,
+});
+
+export type DeltaParams = {
+  view?: string;
+  includeTypes?: string[];
+  excludeTypes?: string[];
+  expanded?: boolean;
 };
 
-export default class Delta {
-  connection: NylasConnection;
-  static streamingTimeoutMs = 15000;
+export type DeltaProperties = {
+  id: string;
+  cursor: string;
+  event: string;
+  object: string;
+  deltaAttributes?: unknown;
+};
 
-  constructor(connection: NylasConnection) {
+export default class Delta extends RestfulModel implements DeltaProperties {
+  id = '';
+  cursor = '';
+  event = '';
+  object = '';
+  connection: NylasConnection;
+  deltaAttributes?: RestfulModel;
+  static streamingTimeoutMs = 15000;
+  static attributes: Record<string, Attribute> = {
+    id: Attributes.String({
+      modelKey: 'id',
+    }),
+    cursor: Attributes.String({
+      modelKey: 'cursor',
+    }),
+    event: Attributes.String({
+      modelKey: 'event',
+    }),
+    object: Attributes.String({
+      modelKey: 'object',
+    }),
+    deltaAttributes: Attributes.Object({
+      modelKey: 'deltaAttributes',
+      jsonKey: 'attributes',
+    }),
+  };
+
+  constructor(connection: NylasConnection, props?: DeltaProperties) {
+    super(connection);
     this.connection = connection;
-    if (!(this.connection instanceof NylasConnection)) {
-      throw new Error('Connection object not provided');
+    this.initAttributes(props);
+    if (this.deltaAttributes && DeltaClassMap[this.object]) {
+      this.deltaAttributes = new DeltaClassMap[this.object](
+        connection,
+        this.deltaAttributes
+      );
     }
   }
 
+  fromJSON(json: Record<string, unknown>): this {
+    super.fromJSON(json);
+    if (this.deltaAttributes && DeltaClassMap[this.object]) {
+      this.deltaAttributes = new DeltaClassMap[this.object](
+        this.connection
+      ).fromJSON(this.deltaAttributes);
+    }
+    return this;
   }
 }

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -32,7 +32,7 @@ export type DeltaProperties = {
   cursor: string;
   event: string;
   object: string;
-  deltaAttributes?: unknown;
+  objectAttributes?: unknown;
 };
 
 export default class Delta extends RestfulModel implements DeltaProperties {
@@ -41,7 +41,7 @@ export default class Delta extends RestfulModel implements DeltaProperties {
   event = '';
   object = '';
   connection: NylasConnection;
-  deltaAttributes?: RestfulModel;
+  objectAttributes?: RestfulModel;
   static streamingTimeoutMs = 15000;
   static attributes: Record<string, Attribute> = {
     id: Attributes.String({
@@ -56,8 +56,8 @@ export default class Delta extends RestfulModel implements DeltaProperties {
     object: Attributes.String({
       modelKey: 'object',
     }),
-    deltaAttributes: Attributes.Object({
-      modelKey: 'deltaAttributes',
+    objectAttributes: Attributes.Object({
+      modelKey: 'objectAttributes',
       jsonKey: 'attributes',
     }),
   };
@@ -66,20 +66,20 @@ export default class Delta extends RestfulModel implements DeltaProperties {
     super(connection);
     this.connection = connection;
     this.initAttributes(props);
-    if (this.deltaAttributes && DeltaClassMap[this.object]) {
-      this.deltaAttributes = new DeltaClassMap[this.object](
+    if (this.objectAttributes && DeltaClassMap[this.object]) {
+      this.objectAttributes = new DeltaClassMap[this.object](
         connection,
-        this.deltaAttributes
+        this.objectAttributes
       );
     }
   }
 
   fromJSON(json: Record<string, unknown>): this {
     super.fromJSON(json);
-    if (this.deltaAttributes && DeltaClassMap[this.object]) {
-      this.deltaAttributes = new DeltaClassMap[this.object](
+    if (this.objectAttributes && DeltaClassMap[this.object]) {
+      this.objectAttributes = new DeltaClassMap[this.object](
         this.connection
-      ).fromJSON(this.deltaAttributes);
+      ).fromJSON(this.objectAttributes);
     }
     return this;
   }

--- a/src/models/delta.ts
+++ b/src/models/delta.ts
@@ -16,36 +16,5 @@ export default class Delta {
     }
   }
 
-  latestCursor(
-    callback: (error: Error | null, cursor: string | null) => void
-  ): Promise<string> {
-    const reqOpts = {
-      method: 'POST',
-      path: '/delta/latest_cursor',
-    };
-
-    return this.connection
-      .request(reqOpts)
-      .then((response: LatestCursor) => {
-        if (callback) {
-          callback(null, response.cursor);
-        }
-        return Promise.resolve(response.cursor);
-      })
-      .catch(err => {
-        if (callback) {
-          callback(err, null);
-        }
-        return Promise.reject(err);
-      });
-  }
-
-  async startStream(
-    cursor: string,
-    params: Record<string, unknown> = {}
-  ): Promise<DeltaStream> {
-    const stream = new DeltaStream(this.connection, cursor, params);
-    await stream.open();
-    return stream;
   }
 }

--- a/src/models/deltas.ts
+++ b/src/models/deltas.ts
@@ -1,0 +1,37 @@
+import Model from './model';
+import NylasConnection from '../nylas-connection';
+import Attributes, { Attribute } from './attributes';
+import Delta, { DeltaProperties } from './delta';
+
+export type DeltasProperties = {
+  cursorStart: string;
+  cursorEnd: string;
+  deltas: DeltaProperties[];
+};
+
+export class Deltas extends Model implements DeltasProperties {
+  cursorStart = '';
+  cursorEnd = '';
+  deltas: Delta[] = [];
+  connection: NylasConnection;
+  static attributes: Record<string, Attribute> = {
+    cursorStart: Attributes.String({
+      modelKey: 'cursorStart',
+      jsonKey: 'cursor_start',
+    }),
+    cursorEnd: Attributes.String({
+      modelKey: 'cursorEnd',
+      jsonKey: 'cursor_end',
+    }),
+    deltas: Attributes.Collection({
+      modelKey: 'deltas',
+      itemClass: Delta,
+    }),
+  };
+
+  constructor(connection: NylasConnection, props?: DeltasProperties) {
+    super();
+    this.connection = connection;
+    this.initAttributes(props);
+  }
+}

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -14,13 +14,13 @@ import File from './models/file';
 import Event from './models/event';
 import JobStatus from './models/job-status';
 import Resource from './models/resource';
-import Delta from './models/delta';
 import Folder, { Label } from './models/folder';
 import FormData, { AppendOptions } from 'form-data';
 import Neural from './models/neural';
 import NylasApiError from './models/nylas-api-error';
 import ComponentRestfulModelCollection from './models/component-restful-model-collection';
 import SchedulerRestfulModelCollection from './models/scheduler-restful-model-collection';
+import DeltaCollection from './models/delta-collection';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -79,7 +79,7 @@ export default class NylasConnection {
     Resource,
     this
   );
-  deltas = new Delta(this);
+  deltas = new DeltaCollection(this);
   labels: RestfulModelCollection<Label> = new RestfulModelCollection(
     Label,
     this


### PR DESCRIPTION
# Description
This PR improves `Delta` support by adding a couple of new models and adding support for requesting a cursor (`/delta`) and long-polling (`/delta/longpoll`). The following changes have been made:

- `Delta` is now a RestfulModel representing a Delta object type
- `Deltas` is a new class representing the API object that contains a set of `Delta` objects
- `DeltaCollection` is a new class that contains all delta-related operations (including `latestCursor` and `startStream`)
- `NylasConnection.deltas` now returns a `DeltaCollection` object to maintain backwards compatibility as `latestCursor` and `startStream` have been moved out and `Delta` has become a model.
- `DeltaCollection.since(cursor: string)` returns the most recent set of deltas since the cursor passed in (GET `/delta`)
- `DeltaCollection.longPoll(cursor: string, timeout: string, params?: DeltaParams)` polls the API for `Deltas` since the cursor until either the provided timeout is reached, or the server sends a response.

# Usage
To return a set of delta cursors since a specific cursor:
```js
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

const deltas = nylas.deltas.since("CURSOR");

/*
* There are a few options you can pass in to this endpoint:
* view: string - This type of view to return within the delta objects
* includeTypes: string[] - The list of types to include in the query ('file', 'event', etc.)
* excludeTypes: string[] - The list of types to exclude in the query ('file', 'event', etc.)
*/

const deltas = nylas.deltas.since("CURSOR", {
  view: 'expanded',
  excludeTypes: ['file', 'event'],
  includeTypes: ['message'],
});
```

To long-poll for delta cursors since a specific cursor:
```js
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

// long-poll for 30 seconds
nylas.deltas.longPoll("CURSOR", 30).then(deltaEmitter => {
  deltaEmitter.on('delta', delta => {
    console.log("Recieved a delta!");
    console.log(delta);
  });
});

/*
* There are a few options you can pass in to this endpoint:
* view: string - This type of view to return within the delta objects
* includeTypes: string[] - The list of types to include in the query ('file', 'event', etc.)
* excludeTypes: string[] - The list of types to exclude in the query ('file', 'event', etc.)
*/

nylas.deltas.longPoll("CURSOR", 30, {
  view: 'expanded',
  excludeTypes: ['file', 'event'],
  includeTypes: ['message'],
}).then(deltaEmitter => {
  deltaEmitter.on('delta', delta => {
    console.log("Recieved a delta!");
    console.log(delta);
  });
});
```

Getting the latest cursor and streaming has not changed:
```js
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

// Get the latest cursor
const latestCursor = await nylas.deltas.latestCursor();

// Start streaming
nylas.deltas.startStream(latestCursor).then(deltaEmitter => {
  deltaEmitter.on('delta', delta => {
    console.log("Recieved a delta!");
    console.log(delta);
  });
});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.