### PR TITLE
[79906] Add support for returning multiple messages by a list of message IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for returning multiple messages by a list of message IDs
+
 ### 6.1.0 / 2022-01-28
 * Add support for `Event` to ICS
 * Add `comment` and `phoneNumber` fields to `EventParticipant`

--- a/src/models/message-restful-model-collection.ts
+++ b/src/models/message-restful-model-collection.ts
@@ -1,0 +1,45 @@
+import RestfulModelCollection from './restful-model-collection';
+import Message from './message';
+import NylasConnection from '../nylas-connection';
+
+export default class MessageRestfulModelCollection extends RestfulModelCollection<
+  Message
+> {
+  connection: NylasConnection;
+  modelClass: typeof Message;
+
+  constructor(connection: NylasConnection) {
+    super(Message, connection);
+    this.connection = connection;
+    this.modelClass = Message;
+  }
+
+  /**
+   * Return Multiple Messages by a list of Message IDs.
+   * @param messageIds The list of message ids to find.
+   * @param options Additional options including: view, offset, limit, and callback
+   * @returns The list of messages.
+   */
+  findMultiple(
+    messageIds: string[],
+    options?: {
+      view?: string;
+      offset?: number;
+      limit?: number;
+      callback?: (error: Error | null, results?: Message[]) => void;
+    }
+  ): Promise<Message[]> {
+    if (options && options.view) {
+      // view is a parameter, so move it into a params object
+      (options as Record<string, unknown>).params = {
+        view: options.view,
+      };
+      delete options.view;
+    }
+
+    return this.range({
+      path: `${this.path()}/${messageIds.join()}`,
+      ...options,
+    });
+  }
+}

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -8,7 +8,6 @@ import ContactRestfulModelCollection from './models/contact-restful-model-collec
 import RestfulModelInstance from './models/restful-model-instance';
 import Account from './models/account';
 import Thread from './models/thread';
-import Message from './models/message';
 import Draft from './models/draft';
 import File from './models/file';
 import Event from './models/event';
@@ -21,6 +20,7 @@ import Neural from './models/neural';
 import NylasApiError from './models/nylas-api-error';
 import ComponentRestfulModelCollection from './models/component-restful-model-collection';
 import SchedulerRestfulModelCollection from './models/scheduler-restful-model-collection';
+import MessageRestfulModelCollection from './models/message-restful-model-collection';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -55,8 +55,7 @@ export default class NylasConnection {
   contacts: ContactRestfulModelCollection = new ContactRestfulModelCollection(
     this
   );
-  messages: RestfulModelCollection<Message> = new RestfulModelCollection(
-    Message,
+  messages: MessageRestfulModelCollection = new MessageRestfulModelCollection(
     this
   );
   drafts: RestfulModelCollection<Draft> = new RestfulModelCollection(


### PR DESCRIPTION
# Description
This PR enables support for getting multiple messages by an array of message IDs, as documented [here](https://developer.nylas.com/docs/api#get/messages/id).

# Usage
```js
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

const messages = await nylas.messages.findMultiple(['message_id_1', 'message_id_2']);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.