### PR TITLE
[80399] Fix Virtual Calendar logic and serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Improved `Delta` support: added `Delta` model and two new methods; `since` and `longpoll`.
+* Fix Virtual Calendar logic and serialization
 
 ### 6.1.0 / 2022-01-28
 * Add support for `Event` to ICS

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -303,7 +303,7 @@ class AttributeEnumList extends Attribute {
 
   toJSON(val: any[]): string[] {
     const enumList: string[] = [];
-    for (const v in val) {
+    for (const v of val) {
       enumList.push(v.toString());
     }
     return enumList;
@@ -311,7 +311,7 @@ class AttributeEnumList extends Attribute {
 
   fromJSON(val: any[], _parent: any): any[] {
     const enumList: any[] = [];
-    for (const v in val) {
+    for (const v of val) {
       if (Object.values(this.itemClass).includes(val[v])) {
         enumList.push(val[v]);
       }

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -312,8 +312,8 @@ class AttributeEnumList extends Attribute {
   fromJSON(val: any[], _parent: any): any[] {
     const enumList: any[] = [];
     for (const v of val) {
-      if (Object.values(this.itemClass).includes(val[v])) {
-        enumList.push(val[v]);
+      if (Object.values(this.itemClass).includes(v)) {
+        enumList.push(v);
       }
     }
     return enumList;

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -21,9 +21,7 @@ export enum Scope {
 export type VirtualCalendarProperties = {
   name: string;
   emailAddress: string;
-  scopes: Scope[];
   clientId?: string;
-  settings?: Record<string, any>;
 };
 
 export class VirtualCalendar extends Model
@@ -31,7 +29,7 @@ export class VirtualCalendar extends Model
   provider = 'nylas';
   name = '';
   emailAddress = '';
-  scopes: Scope[] = [];
+  scopes: Scope[] = [Scope.Calendar];
   settings = {};
   clientId?: string;
   static attributes: Record<string, Attribute> = {
@@ -77,6 +75,7 @@ export enum NativeAuthenticationProvider {
 }
 
 export type NativeAuthenticationProperties = VirtualCalendarProperties & {
+  scopes: Scope[];
   settings: Record<string, any>;
   provider: NativeAuthenticationProvider;
 };

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -165,7 +165,7 @@ export default class Connect {
     if (!auth.clientId) {
       auth.clientId = this.clientId;
     }
-    if (auth.hasOwnProperty('provider')) {
+    if (auth.hasOwnProperty('provider') && (auth as any).provider != 'nylas') {
       authClass = new NativeAuthentication(
         auth as NativeAuthenticationProperties
       );

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -29,7 +29,7 @@ export class VirtualCalendar extends Model
   provider = 'nylas';
   name = '';
   emailAddress = '';
-  scopes: Scope[] = [Scope.Calendar];
+  scopes: Scope[];
   settings = {};
   clientId?: string;
   static attributes: Record<string, Attribute> = {
@@ -59,6 +59,7 @@ export class VirtualCalendar extends Model
   constructor(props?: VirtualCalendarProperties) {
     super();
     this.initAttributes(props);
+    this.scopes = [Scope.Calendar];
   }
 }
 

--- a/src/models/connect.ts
+++ b/src/models/connect.ts
@@ -166,7 +166,7 @@ export default class Connect {
     if (!auth.clientId) {
       auth.clientId = this.clientId;
     }
-    if (auth.hasOwnProperty('scopes')) {
+    if (auth.hasOwnProperty('provider')) {
       authClass = new NativeAuthentication(
         auth as NativeAuthenticationProperties
       );


### PR DESCRIPTION
# Description
This PR fixes three issues in regards to Virtual Calendars:

1. Serializing a list of enums to JSON
2. The logic in determining a VirtualCalendar versus a NativeAuthentication
3. Unnecessary parameters during `Connect.authorize()` call leading to confusion

To expand on the third point, `Connect.authorize()` now takes 2-3 arguments compared to the previous 3-5:

1. name: string
2. emailAddress: string
3. clientId: string (optional, if not passed in it will just use the current clientId)

Compared to v6.0, `scope` and `settings` are no longer required as the API only accepts `['calendar']` for. scopes and an empty object for settings, so to prevent confusion we do not require these arguments and instead hardcode it in the class itself.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.