### PR TITLE
[79908] Add new field in `Draft` for adding files by file IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add new field in `Draft` for adding files by file IDs
 * Improved `Delta` support: added `Delta` model and two new methods; `since` and `longpoll`.
 
 ### 6.1.0 / 2022-01-28

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -3,6 +3,7 @@ import Draft from '../src/models/draft';
 import Message from '../src/models/message';
 import Nylas from '../src/nylas';
 import fetch from 'node-fetch';
+import File from '../src/models/file';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -160,6 +161,183 @@ describe('Draft', () => {
             done();
           })
           .catch(() => {});
+      });
+    });
+
+    describe('files', () => {
+      test('setting fileIdsToAttach should set file_ids on a save', done => {
+        testContext.draft.id = undefined;
+        testContext.draft.fileIdsToAttach = [
+          'file_id1',
+          'file_id2',
+          'file_id3',
+        ];
+        return testContext.draft.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/drafts'
+          );
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            to: [],
+            cc: [],
+            bcc: [],
+            from: [],
+            date: null,
+            body: undefined,
+            events: [],
+            unread: undefined,
+            snippet: undefined,
+            thread_id: undefined,
+            subject: undefined,
+            version: undefined,
+            folder: undefined,
+            starred: undefined,
+            labels: [],
+            file_ids: ['file_id1', 'file_id2', 'file_id3'],
+            headers: undefined,
+            reply_to: [],
+            reply_to_message_id: undefined,
+          });
+          done();
+        });
+      });
+
+      test('setting only files set should parse and send file_ids on a save', done => {
+        testContext.draft.id = undefined;
+        testContext.draft.files = [
+          new File(testContext.connection).fromJSON({ id: 'file_id4' }),
+          new File(testContext.connection).fromJSON({ id: 'file_id5' }),
+          new File(testContext.connection).fromJSON({ id: 'file_id6' }),
+        ];
+        return testContext.draft.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/drafts'
+          );
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            to: [],
+            cc: [],
+            bcc: [],
+            from: [],
+            date: null,
+            body: undefined,
+            events: [],
+            unread: undefined,
+            snippet: undefined,
+            thread_id: undefined,
+            subject: undefined,
+            version: undefined,
+            folder: undefined,
+            starred: undefined,
+            labels: [],
+            file_ids: ['file_id4', 'file_id5', 'file_id6'],
+            headers: undefined,
+            reply_to: [],
+            reply_to_message_id: undefined,
+          });
+          done();
+        });
+      });
+
+      test('setting fileIdsToAttach with files already set should merge onto file_ids on a save', done => {
+        testContext.draft.id = undefined;
+        testContext.draft.fileIdsToAttach = [
+          'file_id1',
+          'file_id2',
+          'file_id3',
+        ];
+        testContext.draft.files = [
+          new File(testContext.connection).fromJSON({ id: 'file_id4' }),
+          new File(testContext.connection).fromJSON({ id: 'file_id5' }),
+          new File(testContext.connection).fromJSON({ id: 'file_id6' }),
+        ];
+        return testContext.draft.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/drafts'
+          );
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            to: [],
+            cc: [],
+            bcc: [],
+            from: [],
+            date: null,
+            body: undefined,
+            events: [],
+            unread: undefined,
+            snippet: undefined,
+            thread_id: undefined,
+            subject: undefined,
+            version: undefined,
+            folder: undefined,
+            starred: undefined,
+            labels: [],
+            file_ids: [
+              'file_id4',
+              'file_id5',
+              'file_id6',
+              'file_id1',
+              'file_id2',
+              'file_id3',
+            ],
+            headers: undefined,
+            reply_to: [],
+            reply_to_message_id: undefined,
+          });
+          done();
+        });
+      });
+
+      test('setting fileIdsToAttach with duplicate ids in files set should only save unique file_ids on a save', done => {
+        testContext.draft.id = undefined;
+        testContext.draft.fileIdsToAttach = [
+          'file_id1',
+          'file_id2',
+          'file_id3',
+        ];
+        testContext.draft.files = [
+          new File(testContext.connection).fromJSON({ id: 'file_id3' }),
+          new File(testContext.connection).fromJSON({ id: 'file_id4' }),
+          new File(testContext.connection).fromJSON({ id: 'file_id5' }),
+        ];
+        return testContext.draft.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/drafts'
+          );
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            to: [],
+            cc: [],
+            bcc: [],
+            from: [],
+            date: null,
+            body: undefined,
+            events: [],
+            unread: undefined,
+            snippet: undefined,
+            thread_id: undefined,
+            subject: undefined,
+            version: undefined,
+            folder: undefined,
+            starred: undefined,
+            labels: [],
+            file_ids: [
+              'file_id3',
+              'file_id4',
+              'file_id5',
+              'file_id1',
+              'file_id2',
+            ],
+            headers: undefined,
+            reply_to: [],
+            reply_to_message_id: undefined,
+          });
+          done();
+        });
       });
     });
   });

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -18,6 +18,7 @@ export default class Draft extends Message implements DraftProperties {
   rawMime?: string;
   replyToMessageId?: string;
   version?: number;
+  fileIdsToAttach?: string[];
   static collectionName = 'drafts';
   static attributes: Record<string, Attribute> = {
     ...Message.attributes,
@@ -39,12 +40,22 @@ export default class Draft extends Message implements DraftProperties {
     this.initAttributes(props);
   }
 
+  fileIds(): (string | undefined)[] {
+    let fileIds: (string | undefined)[] = super.fileIds();
+    if (this.fileIdsToAttach) {
+      fileIds = fileIds
+        .concat(this.fileIdsToAttach)
+        .filter((item, idx, mergedArray) => mergedArray.indexOf(item) === idx);
+    }
+    return fileIds;
+  }
+
   toJSON(enforceReadOnly?: boolean): Record<string, any> {
     if (this.rawMime) {
       throw Error('toJSON() cannot be called for raw MIME drafts');
     }
     const json = super.toJSON(enforceReadOnly);
-    json.file_ids = super.fileIds();
+    json.file_ids = this.fileIds();
 
     return json;
   }

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -43,9 +43,7 @@ export default class Draft extends Message implements DraftProperties {
   fileIds(): (string | undefined)[] {
     let fileIds: (string | undefined)[] = super.fileIds();
     if (this.fileIdsToAttach) {
-      fileIds = fileIds
-        .concat(this.fileIdsToAttach)
-        .filter((item, idx, mergedArray) => mergedArray.indexOf(item) === idx);
+      fileIds = Array.from(new Set(fileIds.concat(this.fileIdsToAttach)));
     }
     return fileIds;
   }


### PR DESCRIPTION
# Description
This PR adds support for adding a new field, `fileIdsToAttach: string[]`, in `Draft` which will allow users who want to attach files to a draft via file IDs. Due to the existence of `fileIds()` function in the `Message` superclass, we can't set this variable to a friendlier name without causing a breaking change.

Please note that this variable only adds files to a draft, to remove a file it must be done on the files array. Upon saving we will make sure to merge unique values in the outgoing payload.

# Usage
```js
const Nylas = require('nylas');
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

const draft = new Draft(nylas, {
  to: [{ name: 'Nylas Swag', email: 'swag@nylas.com' }],
  fileIdsToAttach = ["file_id_1", "file_id_2"],
});
draft.save();
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.