### PR TITLE
[80753] Fix circular dependency issue in `Attribute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix circular dependency issue in `Attribute`
+
 ### 6.2.0 / 2022-02-04
 * Add support for returning multiple messages by a list of message IDs
 * Add new field in `Draft` for adding files by file IDs

--- a/__tests__/webhook-notification-spec.js
+++ b/__tests__/webhook-notification-spec.js
@@ -1,5 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
-import Nylas from '../src/nylas';
 import WebhookNotification, {
   LinkClick,
   LinkClickCount,
@@ -11,18 +9,6 @@ import WebhookNotification, {
 import { WebhookTriggers } from '../src/models/webhook';
 
 describe('Webhook Notification', () => {
-  let testContext;
-
-  beforeEach(() => {
-    Nylas.config({
-      clientId: 'myClientId',
-      clientSecret: 'myClientSecret',
-      apiServer: 'https://api.nylas.com',
-    });
-    testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-  });
-
   test('Should deserialize from JSON properly', done => {
     const webhookNotificationJSON = {
       deltas: [


### PR DESCRIPTION
# Description
`RestfulModel` import statement causes a circular dependency issue because `RestfulModel` sets a static variable of `Attributes` type. Instead we should just cast `itemClass` as any object that extends `Model`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.