### PR TITLE
Enable Nylas API v2.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix circular dependency issue in `Attribute`
+* Enable Nylas API v2.5 support
 * Bump `node-fetch` dependency from 2.6.1 to 2.6.7
 
 ### 6.2.0 / 2022-02-04

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -25,7 +25,7 @@ import Outbox from './models/outbox';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
-const SUPPORTED_API_VERSION = '2.3';
+const SUPPORTED_API_VERSION = '2.5';
 
 export enum AuthMethod {
   BASIC,


### PR DESCRIPTION
# Description
This PR enables support for Nylas API v2.5

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.