### PR TITLE
[TSDK-247] Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix circular dependency issue in `Attribute`
+* Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models
 * Bump `node-fetch` dependency from 2.6.1 to 2.6.7
 
 ### 6.2.0 / 2022-02-04

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -195,7 +195,7 @@ export class SchedulerBookingAdditionalFields extends Model
 
 export type SchedulerBookingOpeningHoursProperties = {
   accountId?: string;
-  days?: string;
+  days?: string[];
   end?: string;
   start?: string;
 };
@@ -203,7 +203,7 @@ export type SchedulerBookingOpeningHoursProperties = {
 export class SchedulerBookingOpeningHours extends Model
   implements SchedulerBookingOpeningHoursProperties {
   accountId?: string;
-  days?: string;
+  days?: string[];
   end?: string;
   start?: string;
   static attributes: Record<string, Attribute> = {
@@ -211,7 +211,7 @@ export class SchedulerBookingOpeningHours extends Model
       modelKey: 'accountId',
       jsonKey: 'account_id',
     }),
-    days: Attributes.String({
+    days: Attributes.StringList({
       modelKey: 'days',
     }),
     end: Attributes.String({

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -67,6 +67,7 @@ export type SchedulerAppearanceProperties = {
   showAutoschedule?: boolean;
   showNylasBranding?: boolean;
   showTimezoneOptions?: boolean;
+  showWeekView?: boolean;
   submitText?: string;
   thankYouRedirect?: string;
   thankYouText?: string;
@@ -82,6 +83,7 @@ export class SchedulerAppearance extends Model
   showAutoschedule?: boolean;
   showNylasBranding?: boolean;
   showTimezoneOptions?: boolean;
+  showWeekView?: boolean;
   submitText?: string;
   thankYouRedirect?: string;
   thankYouText?: string;
@@ -112,6 +114,10 @@ export class SchedulerAppearance extends Model
     showTimezoneOptions: Attributes.Boolean({
       modelKey: 'showTimezoneOptions',
       jsonKey: 'show_timezone_options',
+    }),
+    showWeekView: Attributes.Boolean({
+      modelKey: 'showWeekView',
+      jsonKey: 'show_week_view',
     }),
     submitText: Attributes.String({
       modelKey: 'submitText',
@@ -230,6 +236,7 @@ export class SchedulerBookingOpeningHours extends Model
 
 export type SchedulerBookingProperties = {
   additionalFields?: SchedulerBookingAdditionalFieldsProperties[];
+  additionalGuestsHidden?: boolean;
   availableDaysInFuture?: number;
   calendarInviteToGuests?: boolean;
   cancellationPolicy?: string;
@@ -247,6 +254,7 @@ export type SchedulerBookingProperties = {
 export class SchedulerBooking extends Model
   implements SchedulerBookingProperties {
   additionalFields?: SchedulerBookingAdditionalFields[];
+  additionalGuestsHidden?: boolean;
   availableDaysInFuture?: number;
   calendarInviteToGuests?: boolean;
   cancellationPolicy?: string;
@@ -264,6 +272,10 @@ export class SchedulerBooking extends Model
       modelKey: 'additionalFields',
       jsonKey: 'additional_fields',
       itemClass: SchedulerBookingAdditionalFields,
+    }),
+    additionalGuestsHidden: Attributes.Boolean({
+      modelKey: 'additionalGuestsHidden',
+      jsonKey: 'additional_guests_hidden',
     }),
     availableDaysInFuture: Attributes.Number({
       modelKey: 'availableDaysInFuture',
@@ -409,6 +421,7 @@ export class SchedulerConfig extends Model
     date?: number;
     uses?: number;
   };
+  disableEmails?: boolean;
   locale?: string;
   localeForGuests?: string;
   reminders?: SchedulerRemindersProperties[];
@@ -432,6 +445,10 @@ export class SchedulerConfig extends Model
     expireAfter: Attributes.Object({
       modelKey: 'expireAfter',
       jsonKey: 'expire_after',
+    }),
+    disableEmails: Attributes.Boolean({
+      modelKey: 'disableEmails',
+      jsonKey: 'disable_emails',
     }),
     locale: Attributes.String({
       modelKey: 'locale',


### PR DESCRIPTION
# Description
This PR fixes the type `SchedulerBookingOpeningHoursProperties.days` to be a `string[]` and added in the following fields:
* `showWeekView` in `SchedulerAppearance`
* `additionalGuestsHidden` in `SchedulerBooking`
* `disableEmails` in `SchedulerConfig`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.