### PR TITLE
v6.2.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.2.1 / 2022-03-25
 * Fix circular dependency issue in `Attribute`
 * Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models
 * Enable Nylas API v2.5 support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v6.2.1 release provides the following changes and fixes:
* Fix circular dependency issue in `Attribute` (#324)
* Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models (#330, #328)
* Enable Nylas API v2.5 support (#329)
* Bump `node-fetch` dependency from 2.6.1 to 2.6.7 (#322)
* Bump `ajv` sub-dependency from 6.10.2 to 6.12.6 (#325)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.