### PR TITLE
Add support for getting raw messages directly from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for getting raw messages directly from the API
+
 ### 6.2.1 / 2022-03-25
 * Fix circular dependency issue in `Attribute`
 * Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -163,7 +163,7 @@ describe('Message', () => {
           },
           json: () => {
             // For the raw/MIME flow
-            if (request.headers.get("Accept") === "message/rfc822") {
+            if (request.headers.get('Accept') === 'message/rfc822') {
               return Promise.resolve('MIME');
             }
             return Promise.resolve([
@@ -235,13 +235,11 @@ describe('Message', () => {
     });
 
     test('should support getting raw messages', done => {
-      return testContext.collection.findRaw("abc-123").then(rawMessage => {
+      return testContext.collection.findRaw('abc-123').then(rawMessage => {
         const options = testContext.connection.request.mock.calls[0][0];
-        expect(options.path.toString()).toEqual(
-          '/messages/abc-123'
-        );
+        expect(options.path.toString()).toEqual('/messages/abc-123');
         expect(options.method).toEqual('GET');
-        expect(options.headers['Accept']).toEqual("message/rfc822");
+        expect(options.headers['Accept']).toEqual('message/rfc822');
         expect(rawMessage).toBe('MIME');
         done();
       });

--- a/src/models/message-restful-model-collection.ts
+++ b/src/models/message-restful-model-collection.ts
@@ -57,8 +57,6 @@ export default class MessageRestfulModelCollection extends RestfulModelCollectio
         },
         path: `${this.path()}/${messageId}`,
       })
-      .catch(err => {
-        Promise.reject(err)
-      });
+      .catch(err => Promise.reject(err));
   }
 }

--- a/src/models/message-restful-model-collection.ts
+++ b/src/models/message-restful-model-collection.ts
@@ -42,4 +42,23 @@ export default class MessageRestfulModelCollection extends RestfulModelCollectio
       ...options,
     });
   }
+
+  /**
+   * Return raw message contents
+   * @param messageId The message to fetch content of
+   * @returns The raw message contents
+   */
+  findRaw(messageId: string): Promise<string> {
+    return this.connection
+      .request({
+        method: 'GET',
+        headers: {
+          Accept: 'message/rfc822',
+        },
+        path: `${this.path()}/${messageId}`,
+      })
+      .catch(err => {
+        Promise.reject(err)
+      });
+  }
 }


### PR DESCRIPTION
# Description
This PR enables support for directly getting a raw message from the API. Currently on the SDK you would need to get a message first then run `getRaw()` on it, which results in 2 API calls. This function exists on `MessageRestfulModelCollection` allowing you to get the message as raw directly using a message ID resulting in just one API call.

# Usage
```ts
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

const messages = await nylas.messages.findRaw("message_id");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.