### PR TITLE
[TSDK-262] Add new authentication method field to ManagementAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add new `ManagementAccount.authenticationType` field
+
 ### 6.2.1 / 2022-03-25
 * Fix circular dependency issue in `Attribute`
 * Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -23,6 +23,7 @@ describe('ManagementAccount', () => {
             id: ACCOUNT_ID,
             provider: 'gmail',
             sync_state: 'running',
+            authentication_type: 'password',
             trial: false,
             metadata: {
               test: 'true',
@@ -36,6 +37,9 @@ describe('ManagementAccount', () => {
         expect(accounts[0].billingState).toEqual('paid');
         expect(accounts[0].emailAddress).toEqual('margaret@hamilton.com');
         expect(accounts[0].provider).toEqual('gmail');
+        expect(accounts[0].syncState).toEqual('running');
+        expect(accounts[0].authenticationType).toEqual('password');
+        expect(accounts[0].trial).toBe(false);
         expect(accounts[0].metadata).toEqual({
           test: 'true',
         });
@@ -344,6 +348,7 @@ describe('ManagementAccount', () => {
         id: ACCOUNT_ID,
         provider: 'gmail',
         sync_state: 'running',
+        authentication_type: 'password',
         trial: false,
       };
       const account = new ManagementAccount(

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -72,6 +72,7 @@ export type ManagementAccountProperties = {
   namespaceId: string;
   provider: string;
   syncState: string;
+  authenticationType: string;
   trial: boolean;
   metadata?: object;
 };
@@ -87,6 +88,7 @@ export default class ManagementAccount extends ManagementModel
   namespaceId = '';
   provider = '';
   syncState = '';
+  authenticationType = '';
   trial = false;
   metadata?: object;
   static collectionName = 'accounts';
@@ -110,6 +112,10 @@ export default class ManagementAccount extends ManagementModel
     syncState: Attributes.String({
       modelKey: 'syncState',
       jsonKey: 'sync_state',
+    }),
+    authenticationType: Attributes.String({
+      modelKey: 'authenticationType',
+      jsonKey: 'authentication_type',
     }),
     trial: Attributes.Boolean({
       modelKey: 'trial',


### PR DESCRIPTION
# Description
This PR adds support for new `authentication_method` field in `ManagementAccount`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.