### PR TITLE
Fix error when Nylas API returns non-JSON error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix error when Nylas API returns non-JSON error
+
 ### 6.2.1 / 2022-03-25
 * Fix circular dependency issue in `Attribute`
 * Fix `SchedulerBookingOpeningHoursProperties.days` and add missing fields to Scheduler models

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -260,6 +260,13 @@ export default class NylasConnection {
                 error.serverError = body.server_error;
               }
               return reject(error);
+            }).catch(() => {
+              const error = new NylasApiError(
+                response.status,
+                "API Error",
+                "Error encountered during request, non-JSON formatted error received."
+              );
+              return reject(error);
             });
           } else {
             if (options.downloadRequest) {

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -247,27 +247,30 @@ export default class NylasConnection {
           }
 
           if (response.status > 299) {
-            return response.json().then(body => {
-              const error = new NylasApiError(
-                response.status,
-                body.type,
-                body.message
-              );
-              if (body.missing_fields) {
-                error.missingFields = body.missing_fields;
-              }
-              if (body.server_error) {
-                error.serverError = body.server_error;
-              }
-              return reject(error);
-            }).catch(() => {
-              const error = new NylasApiError(
-                response.status,
-                "API Error",
-                "Error encountered during request, non-JSON formatted error received."
-              );
-              return reject(error);
-            });
+            return response
+              .json()
+              .then(body => {
+                const error = new NylasApiError(
+                  response.status,
+                  body.type,
+                  body.message
+                );
+                if (body.missing_fields) {
+                  error.missingFields = body.missing_fields;
+                }
+                if (body.server_error) {
+                  error.serverError = body.server_error;
+                }
+                return reject(error);
+              })
+              .catch(() => {
+                const error = new NylasApiError(
+                  response.status,
+                  'API Error',
+                  'Error encountered during request, non-JSON formatted error received.'
+                );
+                return reject(error);
+              });
           } else {
             if (options.downloadRequest) {
               response

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -264,12 +264,24 @@ export default class NylasConnection {
                 return reject(error);
               })
               .catch(() => {
-                const error = new NylasApiError(
-                  response.status,
-                  'API Error',
-                  'Error encountered during request, non-JSON formatted error received.'
-                );
-                return reject(error);
+                return response
+                  .text()
+                  .then(text => {
+                    const error = new NylasApiError(
+                      response.status,
+                      response.statusText,
+                      text
+                    );
+                    return reject(error);
+                  })
+                  .catch(() => {
+                    const error = new NylasApiError(
+                      response.status,
+                      response.statusText,
+                      'Error encountered during request, unable to extract error message.'
+                    );
+                    return reject(error);
+                  });
               });
           } else {
             if (options.downloadRequest) {


### PR DESCRIPTION
# Description
Sometimes a call to the API might result in a 5xx server error with an HTML response. We should be accounting for this case and return a proper error instead of erroring out due to failed JSON parsing.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.