### PR TITLE
v6.2.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.2.2 / 2022-04-01
 * Add support for getting raw messages directly from the API
 * Add new `ManagementAccount.authenticationType` field
 * Fix error when Nylas API returns non-JSON error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 ### 6.2.2 / 2022-04-01
-* Add support for getting raw messages directly from the API
-* Add new `ManagementAccount.authenticationType` field
-* Fix error when Nylas API returns non-JSON error
+* Allow getting raw message by message ID directly instead of needing to fetch the message first
+* Add new `authenticationType` field in `ManagementAccount`
+* Fix JSON error thrown when Nylas API returns non-JSON error payload
 
 ### 6.2.1 / 2022-03-25
 * Fix circular dependency issue in `Attribute`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.2.1",
+      "version": "6.2.2",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v6.2.2 release provides the following changes and fixes:

* Allow getting raw message by message ID directly instead of needing to fetch the message first
* Add new `authenticationType` field in `ManagementAccount`
* Fix JSON error thrown when Nylas API returns non-JSON error payload

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.