### PR TITLE
[TSDK-273] Support revoking single access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for revoking a single access token
+
 ### 6.2.2 / 2022-04-01
 * Allow getting raw message by message ID directly instead of needing to fetch the message first
 * Add new `authenticationType` field in `ManagementAccount`

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -300,7 +300,7 @@ export default class NylasConnection {
                   return reject(e);
                 });
             } else if (
-              response.headers.get('content-length') &&
+              !response.headers.get('content-length') ||
               Number(response.headers.get('content-length')) == 0
             ) {
               return resolve();

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -185,6 +185,19 @@ class Nylas {
     }
     return url;
   }
+
+  /**
+   * Revoke a single access token
+   * @param accessToken The access token to revoke
+   */
+  static revoke(accessToken: string): Promise<void> {
+    return Nylas.with(accessToken)
+      .request({
+        method: 'POST',
+        path: '/oauth/revoke'
+      })
+      .catch(err => Promise.reject(err));
+  }
 }
 
 export = Nylas;


### PR DESCRIPTION
# Description
This PR adds support for revoking a single access token.

# Usage
```javascript
const Nylas = require('nylas');
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});

Nylas.revoke("ACCESS_TOKEN_TO_REVOKE");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.