### PR TITLE
Support Setting Redirect On Error in Authenticate URL Config

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -10,7 +10,7 @@ If you have a question about how to use the Node SDK, please [create an issue](h
 # How To Contribute
 ## Report a Bug or Request a Feature
 
-If you encounter any bugs while using this software, or want to request a new feature or enhancement, please [create an issue](https://github.com/nylas/nylas-python/issues) to report it, and make sure you add a label to indicate what type of issue it is.
+If you encounter any bugs while using this software, or want to request a new feature or enhancement, please [create an issue](https://github.com/nylas/nylas-nodejs/issues) to report it, and make sure you add a label to indicate what type of issue it is.
 
 ## Contribute Code
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export type NylasConfig = {
 
 export type AuthenticateUrlConfig = {
   redirectURI: string;
+  redirectOnError?: boolean;
   loginHint?: string;
   state?: string;
   provider?: string;

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -183,8 +183,8 @@ class Nylas {
     if (options.provider != null) {
       url += `&provider=${options.provider}`;
     }
-    if(options.redirectOnError){
-      url += "&redirect_on_error=true"
+    if (options.redirectOnError) {
+      url += '&redirect_on_error=true';
     }
     return url;
   }

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -183,6 +183,9 @@ class Nylas {
     if (options.provider != null) {
       url += `&provider=${options.provider}`;
     }
+    if(options.redirectOnError){
+      url += "&redirect_on_error=true"
+    }
     return url;
   }
 


### PR DESCRIPTION
Support the ability to set the `redirect_on_error` url param so that when using hosted authentication  the user can be redirected back to the app on error. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.