### PR TITLE
Catch a JSON error and return undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for revoking a single access token
+* Fix issue where an empty response body could trigger a JSON deserialization error
 
 ### 6.2.2 / 2022-04-01
 * Allow getting raw message by message ID directly instead of needing to fetch the message first

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -30,6 +30,7 @@ describe('CalendarRestfulModelCollection', () => {
 
     const response = {
       status: 200,
+      clone: () => response,
       buffer: () => {
         return Promise.resolve('body');
       },
@@ -66,6 +67,7 @@ describe('CalendarRestfulModelCollection', () => {
     test('Should fetch results with params', done => {
       const response = {
         status: 200,
+        clone: () => response,
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -39,6 +39,7 @@ describe('Calendar', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -29,6 +29,7 @@ describe('Component', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         text: () => {
           return Promise.resolve(receivedBody);
         },
@@ -155,6 +156,7 @@ describe('Component', () => {
         return {
           status: 200,
           text: () => {},
+          clone: () => response(req),
           json: () => {
             if (!req.url.includes('abc-123')) {
               return Promise.resolve([componentJSON]);

--- a/__tests__/contact-restful-model-collection-spec.js
+++ b/__tests__/contact-restful-model-collection-spec.js
@@ -40,6 +40,7 @@ describe('RestfulModelCollection', () => {
 
     const response = {
       status: 200,
+      clone: () => response,
       buffer: () => {
         return Promise.resolve('body');
       },

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -27,6 +27,7 @@ describe('Contact', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -29,6 +29,7 @@ describe('Draft', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         text: () => {
           return Promise.resolve(receivedBody);
         },

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -31,6 +31,7 @@ describe('Event', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -797,6 +798,7 @@ describe('Event', () => {
       const response = () => {
         return {
           status: 200,
+          clone: () => response(),
           buffer: () => {
             return Promise.resolve('body');
           },

--- a/__tests__/file-spec.js
+++ b/__tests__/file-spec.js
@@ -30,6 +30,7 @@ describe('File', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/folder-spec.js
+++ b/__tests__/folder-spec.js
@@ -27,6 +27,7 @@ describe('Label', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -219,6 +219,7 @@ describe('Job Status', () => {
 
       const response = {
         status: 200,
+        clone: () => response,
         json: () => {
           return Promise.resolve(jobStatuses);
         },

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+const { Response } = jest.requireActual('node-fetch');
 
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
@@ -60,8 +61,13 @@ describe('Job Status', () => {
 
   describe('list job statuses', () => {
     beforeEach(() => {
+      fetch.mockReturnValue(
+        Promise.resolve(new Response(testContext.listApiResponse))
+      );
+
       const response = {
         status: 200,
+        clone: () => response,
         json: () => {
           return Promise.resolve(testContext.listApiResponse);
         },
@@ -114,6 +120,7 @@ describe('Job Status', () => {
     beforeEach(() => {
       const response = {
         status: 200,
+        clone: () => response,
         json: () => {
           return Promise.resolve(testContext.getApiResponse);
         },
@@ -164,6 +171,7 @@ describe('Job Status', () => {
     beforeEach(() => {
       const response = {
         status: 200,
+        clone: () => response,
         json: () => {
           return Promise.resolve(testContext.getApiResponse);
         },

--- a/__tests__/label-spec.js
+++ b/__tests__/label-spec.js
@@ -27,6 +27,7 @@ describe('Label', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -31,6 +31,7 @@ describe('Message', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -158,6 +159,7 @@ describe('Message', () => {
       const response = request => {
         return {
           status: 200,
+          clone: () => response(request),
           buffer: () => {
             return Promise.resolve('body');
           },

--- a/__tests__/neural-spec.js
+++ b/__tests__/neural-spec.js
@@ -294,6 +294,7 @@ describe('Neural', () => {
       const response = () => {
         return {
           status: 200,
+          clone: () => response(),
           buffer: () => {
             return Promise.resolve('body');
           },

--- a/__tests__/nylas-connection-spec.js
+++ b/__tests__/nylas-connection-spec.js
@@ -1,3 +1,7 @@
+jest.mock('node-fetch');
+import fetch from 'node-fetch';
+const { Response } = jest.requireActual('node-fetch');
+
 import NylasConnection from '../src/nylas-connection';
 import * as config from '../src/config.ts';
 import PACKAGE_JSON from '../package.json';
@@ -48,6 +52,147 @@ describe('NylasConnection', () => {
       expect(warnApi).toEqual(
         `WARNING: SDK version may not support your Nylas API version. SDK supports version 2.0 of the API and your application is currently running on version 1.0 of the API. Please update the version of the API that your application is using through the developer dashboard.`
       );
+    });
+  });
+  describe('request', () => {
+    describe('error status', () => {
+      test('Should fill and return a NylasApiError from a JSON error', done => {
+        const errorJson = {
+          message: 'Invalid datetime value z for start_time',
+          type: 'invalid_request_error',
+          missing_fields: ['start_time'],
+          server_error: 'This is also a server error',
+        };
+
+        fetch.mockReturnValue(
+          Promise.resolve(
+            new Response(JSON.stringify(errorJson), {
+              status: 400,
+            })
+          )
+        );
+
+        return testContext.connection
+          .request({
+            path: '/test',
+            method: 'GET',
+          })
+          .catch(err => {
+            expect(err.message).toEqual(
+              'Invalid datetime value z for start_time'
+            );
+            expect(err.statusCode).toEqual(400);
+            expect(err.name).toEqual('Bad Request');
+            expect(err.type).toEqual('invalid_request_error');
+            expect(err.missingFields).toEqual(['start_time']);
+            expect(err.serverError).toEqual('This is also a server error');
+            done();
+          });
+      });
+
+      test('Should return a NylasApiError if error was a non-JSON', done => {
+        fetch.mockReturnValue(
+          Promise.resolve(
+            new Response('This is an error text.', {
+              status: 404,
+              statusText: 'Not Found',
+            })
+          )
+        );
+
+        return testContext.connection
+          .request({
+            path: '/test',
+            method: 'GET',
+          })
+          .catch(err => {
+            expect(err.message).toEqual('This is an error text.');
+            expect(err.statusCode).toEqual(404);
+            expect(err.name).toEqual('Not Found');
+            expect(err.type).toEqual('Not Found');
+            done();
+          });
+      });
+    });
+    describe('successful status', () => {
+      test('Should return undefined if the content-length header is 0', async () => {
+        fetch.mockReturnValue(
+          Promise.resolve(
+            new Response('This is just text', {
+              headers: {
+                'content-length': 0,
+              },
+            })
+          )
+        );
+
+        const response = await testContext.connection.request({
+          path: '/test',
+          method: 'GET',
+        });
+        expect(response).toBeUndefined();
+      });
+
+      test('Should return text if the content-type header is "message/rfc822"', async () => {
+        fetch.mockReturnValue(
+          Promise.resolve(
+            new Response('This is just text', {
+              headers: {
+                'content-length': 17,
+                'Content-Type': 'message/rfc822',
+              },
+            })
+          )
+        );
+
+        const response = await testContext.connection.request({
+          path: '/test',
+          method: 'GET',
+        });
+        expect(response).toEqual('This is just text');
+      });
+
+      test('Should deserialize JSON properly', async () => {
+        const mockJson = {
+          text: 'This is just text',
+        };
+
+        fetch.mockReturnValue(
+          Promise.resolve(
+            new Response(JSON.stringify(mockJson), {
+              headers: {
+                'content-length': 17,
+                'Content-Type': 'application/json',
+              },
+            })
+          )
+        );
+
+        const response = await testContext.connection.request({
+          path: '/test',
+          method: 'GET',
+        });
+        expect(response).toEqual(mockJson);
+      });
+
+      test('Should return text if JSON body parsing fails', async () => {
+        fetch.mockReturnValue(
+          Promise.resolve(
+            new Response('This is just text', {
+              headers: {
+                'content-length': 17,
+                'Content-Type': 'application/json',
+              },
+            })
+          )
+        );
+
+        const a = await testContext.connection.request({
+          path: '/test',
+          method: 'GET',
+        });
+        expect(a).toEqual('This is just text');
+      });
     });
   });
 });

--- a/__tests__/outbox-spec.js
+++ b/__tests__/outbox-spec.js
@@ -30,6 +30,7 @@ describe('Outbox', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         text: () => {
           return Promise.resolve(receivedBody);
         },
@@ -234,6 +235,7 @@ describe('Outbox', () => {
       const response = () => {
         return {
           status: 200,
+          clone: () => response(),
           text: () => {
             return Promise.resolve({});
           },

--- a/__tests__/resource-spec.js
+++ b/__tests__/resource-spec.js
@@ -44,6 +44,7 @@ describe('Resource', () => {
     const response = () => {
       return {
         status: 200,
+        clone: () => response(),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/__tests__/scheduler-restful-model-collection-spec.js
+++ b/__tests__/scheduler-restful-model-collection-spec.js
@@ -43,6 +43,7 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
+        clone: () => response,
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -101,6 +102,7 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
+        clone: () => response,
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -129,6 +131,7 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
+        clone: () => response,
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -176,6 +179,7 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
+        clone: () => response,
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -214,6 +218,7 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
+        clone: () => response,
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -264,6 +269,7 @@ describe('SchedulerRestfulModelCollection', () => {
 
         const response = {
           status: 200,
+          clone: () => response,
           buffer: () => {
             return Promise.resolve('body');
           },

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -30,6 +30,7 @@ describe('Scheduler', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -168,6 +169,7 @@ describe('Scheduler', () => {
       const response = () => {
         return {
           status: 200,
+          clone: () => response(),
           buffer: () => {
             return Promise.resolve('body');
           },

--- a/__tests__/thread-spec.js
+++ b/__tests__/thread-spec.js
@@ -30,6 +30,7 @@ describe('Thread', () => {
     const response = receivedBody => {
       return {
         status: 200,
+        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -248,6 +248,7 @@ export default class NylasConnection {
 
           if (response.status > 299) {
             return response
+              .clone()
               .json()
               .then(body => {
                 const error = new NylasApiError(
@@ -310,13 +311,11 @@ export default class NylasConnection {
               return resolve(response.text());
             } else {
               return response
+                .clone()
                 .json()
-                .then(json => {
-                  return resolve(json);
-                })
-                .catch(() => {
-                  return resolve(undefined);
-                });
+                .catch(() => response.text())
+                .then(data => resolve(data))
+                .catch(() => resolve(undefined));
             }
           }
         })

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -309,7 +309,14 @@ export default class NylasConnection {
             ) {
               return resolve(response.text());
             } else {
-              return resolve(response.json());
+              return response
+                .json()
+                .then(json => {
+                  return resolve(json);
+                })
+                .catch(() => {
+                  return resolve(undefined);
+                });
             }
           }
         })


### PR DESCRIPTION
# Description
Sometimes the API won't respond with a JSON body, but given that the request completed without a status error, just return undefined.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.