### PR TITLE
[TSDK-277] Improve Outbox job status support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for revoking a single access token
+* Improve Outbox job status support
 
 ### 6.2.2 / 2022-04-01
 * Allow getting raw message by message ID directly instead of needing to fetch the message first

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import Nylas from '../src/nylas';
 import NylasConnection from '../src/nylas-connection';
 import JobStatus from '../src/models/job-status';
+import OutboxJobStatus from '../src/models/outbox-job-status';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -178,6 +179,52 @@ describe('Job Status', () => {
         expect(jobStatus.isSuccessful()).toBe(true);
         jobStatus.status = 'failure';
         expect(jobStatus.isSuccessful()).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe('JobStatusRestfulModelCollection', () => {
+    beforeEach(() => {
+      const jobStatuses = [
+        testContext.getApiResponse,
+        {
+          action: 'new_outbox',
+          created_at: 1646245940,
+          send_at: 1646245940,
+          original_send_at: 1646245940,
+          job_status_id: 'job-status-id',
+          status: 'pending',
+          account_id: 'account-id',
+          message_id: 'message-id',
+          thread_id: 'thread-id',
+          object: 'message',
+          original_data: {
+            to: [{ name: 'me', email: 'test@email.com' }],
+            subject: 'This is an email',
+            send_at: 1646245940,
+            original_send_at: 1646245940,
+            retry_limit_datetime: 1646332340,
+          },
+        },
+      ];
+
+      const response = {
+        status: 200,
+        json: () => {
+          return Promise.resolve(jobStatuses);
+        },
+        headers: new Map(),
+      };
+
+      fetch.mockImplementation(() => Promise.resolve(response));
+    });
+
+    test('should call API with correct authentication', done => {
+      testContext.connection.jobStatuses.list().then(jobStatuses => {
+        expect(jobStatuses.length).toBe(2);
+        expect(jobStatuses[0]).toBeInstanceOf(JobStatus);
+        expect(jobStatuses[1]).toBeInstanceOf(OutboxJobStatus)
         done();
       });
     });

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -224,7 +224,7 @@ describe('Job Status', () => {
       testContext.connection.jobStatuses.list().then(jobStatuses => {
         expect(jobStatuses.length).toBe(2);
         expect(jobStatuses[0]).toBeInstanceOf(JobStatus);
-        expect(jobStatuses[1]).toBeInstanceOf(OutboxJobStatus)
+        expect(jobStatuses[1]).toBeInstanceOf(OutboxJobStatus);
         done();
       });
     });

--- a/__tests__/outbox-spec.js
+++ b/__tests__/outbox-spec.js
@@ -178,9 +178,15 @@ describe('Outbox', () => {
 
     test('should deserialize OutboxJobStatus properly', () => {
       const json = {
+        action: 'new_outbox',
+        created_at: 1646245940,
+        send_at: 1646245940,
+        original_send_at: 1646245940,
         job_status_id: 'job-status-id',
         status: 'pending',
         account_id: 'account-id',
+        message_id: 'message-id',
+        thread_id: 'thread-id',
         original_data: {
           to: [{ name: 'me', email: 'test@email.com' }],
           subject: 'This is an email',
@@ -190,12 +196,19 @@ describe('Outbox', () => {
         },
       };
 
-      const outboxJobStatus = new OutboxJobStatus().fromJSON(
-        json,
+      const outboxJobStatus = new OutboxJobStatus(
         testContext.connection
-      );
+      ).fromJSON(json);
 
       expect(outboxJobStatus.jobStatusId).toEqual('job-status-id');
+      expect(outboxJobStatus.messageId).toEqual('message-id');
+      expect(outboxJobStatus.threadId).toEqual('thread-id');
+      expect(outboxJobStatus.sendAt).toEqual(new Date(1646245940 * 1000));
+      expect(outboxJobStatus.originalSendAt).toEqual(
+        new Date(1646245940 * 1000)
+      );
+      expect(outboxJobStatus.createdAt).toEqual(new Date(1646245940 * 1000));
+      expect(outboxJobStatus.action).toEqual('new_outbox');
       expect(outboxJobStatus.status).toEqual('pending');
       expect(outboxJobStatus.accountId).toEqual('account-id');
       expect(outboxJobStatus.originalData.to.length).toBe(1);

--- a/src/models/job-status-restful-model-collection.ts
+++ b/src/models/job-status-restful-model-collection.ts
@@ -1,0 +1,25 @@
+import RestfulModelCollection from './restful-model-collection';
+import JobStatus from './job-status';
+import NylasConnection from '../nylas-connection';
+import OutboxJobStatus from './outbox-job-status';
+
+export default class JobStatusRestfulModelCollection extends RestfulModelCollection<
+  JobStatus
+> {
+  connection: NylasConnection;
+  modelClass: typeof JobStatus;
+
+  constructor(connection: NylasConnection) {
+    super(JobStatus, connection);
+    this.connection = connection;
+    this.modelClass = JobStatus;
+  }
+
+  protected createModel(json: Record<string, unknown>): JobStatus {
+    if (json['object'] && json['object'] === 'message') {
+      return new OutboxJobStatus(this.connection).fromJSON(json);
+    }
+
+    return new this.modelClass(this.connection).fromJSON(json);
+  }
+}

--- a/src/models/outbox-job-status.ts
+++ b/src/models/outbox-job-status.ts
@@ -1,35 +1,43 @@
 import OutboxMessage, { OutboxMessageProperties } from './outbox-message';
-import Model from './model';
 import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
+import JobStatus, { JobStatusProperties } from './job-status';
 
-export type OutboxJobStatusProperties = {
-  jobStatusId: string;
-  accountId: string;
-  status: string;
+export type OutboxJobStatusProperties = JobStatusProperties & {
+  messageId?: string;
+  threadId?: string;
+  sendAt?: Date;
+  originalSendAt?: Date;
   originalData?: OutboxMessageProperties;
 };
 
-export default class OutboxJobStatus extends Model
+export default class OutboxJobStatus extends JobStatus
   implements OutboxJobStatusProperties {
-  jobStatusId = '';
-  status = '';
-  accountId = '';
+  messageId?: string;
+  threadId?: string;
+  sendAt?: Date;
+  originalSendAt?: Date;
   originalData?: OutboxMessage;
-  private _connection?: NylasConnection;
   static attributes: Record<string, Attribute> = {
-    jobStatusId: Attributes.String({
-      modelKey: 'jobStatusId',
-      jsonKey: 'job_status_id',
+    ...JobStatus.attributes,
+    messageId: Attributes.String({
+      modelKey: 'messageId',
+      jsonKey: 'message_id',
       readOnly: true,
     }),
-    status: Attributes.String({
-      modelKey: 'status',
+    threadId: Attributes.String({
+      modelKey: 'threadId',
+      jsonKey: 'thread_id',
       readOnly: true,
     }),
-    accountId: Attributes.String({
-      modelKey: 'accountId',
-      jsonKey: 'account_id',
+    sendAt: Attributes.DateTime({
+      modelKey: 'sendAt',
+      jsonKey: 'send_at',
+      readOnly: true,
+    }),
+    originalSendAt: Attributes.DateTime({
+      modelKey: 'originalSendAt',
+      jsonKey: 'original_send_at',
       readOnly: true,
     }),
     originalData: Attributes.Object({
@@ -40,20 +48,8 @@ export default class OutboxJobStatus extends Model
     }),
   };
 
-  constructor(props?: OutboxJobStatusProperties) {
-    super();
+  constructor(connection: NylasConnection, props?: OutboxJobStatusProperties) {
+    super(connection, props);
     this.initAttributes(props);
-  }
-
-  get connection(): NylasConnection | undefined {
-    return this._connection;
-  }
-
-  fromJSON(json: Record<string, unknown>, connection?: NylasConnection): this {
-    // Allow a connection object to be passed in to instantiate a Calendar sub object
-    if (connection) {
-      this._connection = connection;
-    }
-    return super.fromJSON(json);
   }
 }

--- a/src/models/outbox.ts
+++ b/src/models/outbox.ts
@@ -59,7 +59,7 @@ export default class Outbox {
       body: body,
     })
       .then(json => {
-        const message = new OutboxJobStatus().fromJSON(json, this.connection);
+        const message = new OutboxJobStatus(this.connection).fromJSON(json);
 
         if (options.callback) {
           options.callback(null, message);
@@ -92,7 +92,7 @@ export default class Outbox {
       path: `/${jobStatusId}`,
       body: body,
     }).then(json => {
-      const message = new OutboxJobStatus().fromJSON(json, this.connection);
+      const message = new OutboxJobStatus(this.connection).fromJSON(json);
       return Promise.resolve(message);
     });
   }

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -11,7 +11,6 @@ import Thread from './models/thread';
 import Draft from './models/draft';
 import File from './models/file';
 import Event from './models/event';
-import JobStatus from './models/job-status';
 import Resource from './models/resource';
 import Folder, { Label } from './models/folder';
 import FormData, { AppendOptions } from 'form-data';

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -22,6 +22,7 @@ import SchedulerRestfulModelCollection from './models/scheduler-restful-model-co
 import MessageRestfulModelCollection from './models/message-restful-model-collection';
 import DeltaCollection from './models/delta-collection';
 import Outbox from './models/outbox';
+import JobStatusRestfulModelCollection from './models/job-status-restful-model-collection';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -73,8 +74,7 @@ export default class NylasConnection {
   calendars: CalendarRestfulModelCollection = new CalendarRestfulModelCollection(
     this
   );
-  jobStatuses: RestfulModelCollection<JobStatus> = new RestfulModelCollection(
-    JobStatus,
+  jobStatuses: JobStatusRestfulModelCollection = new JobStatusRestfulModelCollection(
     this
   );
   events: RestfulModelCollection<Event> = new RestfulModelCollection(


### PR DESCRIPTION
# Description
This PR improves Outbox job status for the Node SDK by allowing for fetching an `OutboxJobStatus` object by job status ID, as well as add in some missing fields from an Outbox job status object.

# Usage
To get an outbox job status by ID, it's the same as you would get any Job Status, but in the background the SDK will identify if the job status is an outbox job status, and if so it will return the correct type:
```ts
const Nylas = require('nylas');
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

const jobStatus = nylas.jobstatuses.find("outbox-job-status-id");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.