### PR TITLE
v6.3.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### Unreleased
 * Add support for revoking a single access token
 * Improve Outbox job status support
+* Support Setting Redirect On Error in Authenticate URL Config
 * Fix issue where an empty response body could trigger a JSON deserialization error
+* Remove usage of unreliable `node-fetch response.size`
 
 ### 6.2.2 / 2022-04-01
 * Allow getting raw message by message ID directly instead of needing to fetch the message first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.3.0 / 2022-04-14
 * Add support for revoking a single access token
 * Improve Outbox job status support
 * Support Setting Redirect On Error in Authenticate URL Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.2.2",
+      "version": "6.3.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v6.3.0 release provides the following changes and fixes:
* Add support for revoking a single access token (#337)
* Improve Outbox job status support (#341)
* Support Setting Redirect On Error in Authenticate URL Config (#338)
* Fix issue where an empty response body could trigger a JSON deserialization error (#340)
* Remove usage of unreliable `node-fetch response.size` (#339)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.