### PR TITLE
Fix issue where passing in an array of one for `MessageRestfulModelCollection.findMultiple` throws an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue where passing in an array of one for `MessageRestfulModelCollection.findMultiple` throws an error
+
 ### 6.3.0 / 2022-04-14
 * Add support for revoking a single access token
 * Improve Outbox job status support

--- a/src/models/message-restful-model-collection.ts
+++ b/src/models/message-restful-model-collection.ts
@@ -37,6 +37,13 @@ export default class MessageRestfulModelCollection extends RestfulModelCollectio
       delete options.view;
     }
 
+    // If only one message ID was passed in, use the normal find function
+    if (messageIds.length == 1) {
+      return this.find(messageIds[0], options).then((message: Message) => {
+        return [message];
+      });
+    }
+
     return this.range({
       path: `${this.path()}/${messageIds.join()}`,
       ...options,


### PR DESCRIPTION
# Description
This PR fixes a small bug where if someone passes in an array of one in findMultiple, it would throw an error because the API response is not an array.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.