### PR TITLE
Add missing order and emails field in calendar availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add missing order and emails field in calendar availability
 * Fix issue where passing in an array of one for `MessageRestfulModelCollection.findMultiple` throws an error
 
 ### 6.3.0 / 2022-04-14

--- a/src/models/calendar-availability.ts
+++ b/src/models/calendar-availability.ts
@@ -120,17 +120,22 @@ export class CalendarConsecutiveAvailability extends Model
 
 export type CalendarAvailabilityProperties = {
   timeSlots: TimeSlotProperties[];
+  order?: string[];
 };
 
 export default class CalendarAvailability extends Model
   implements CalendarAvailabilityProperties {
   object = 'availability';
   timeSlots: TimeSlot[] = [];
+  order?: string[];
   static attributes: Record<string, Attribute> = {
     timeSlots: Attributes.Collection({
       modelKey: 'timeSlots',
       jsonKey: 'time_slots',
       itemClass: TimeSlot,
+    }),
+    order: Attributes.StringList({
+      modelKey: 'order',
     }),
   };
 

--- a/src/models/free-busy.ts
+++ b/src/models/free-busy.ts
@@ -38,6 +38,7 @@ export type TimeSlotProperties = {
   status: string;
   startTime: number;
   endTime: number;
+  emails?: string[];
 };
 
 export class TimeSlot extends Model implements TimeSlotProperties {
@@ -45,6 +46,7 @@ export class TimeSlot extends Model implements TimeSlotProperties {
   status = '';
   startTime = 0;
   endTime = 0;
+  emails?: string[];
   static attributes: Record<string, Attribute> = {
     object: Attributes.String({
       modelKey: 'object',
@@ -59,6 +61,9 @@ export class TimeSlot extends Model implements TimeSlotProperties {
     endTime: Attributes.Number({
       modelKey: 'endTime',
       jsonKey: 'end_time',
+    }),
+    emails: Attributes.StringList({
+      modelKey: 'emails',
     }),
   };
 


### PR DESCRIPTION
# Description
For calendar availability the response now includes `order` and for time slot there is an `emails` field as well. This PR adds both fields.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.