### PR TITLE
v6.3.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.3.1 / 2022-04-22
 * Add missing order and emails field in calendar availability
 * Fix issue where passing in an array of one for `MessageRestfulModelCollection.findMultiple` throws an error
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New nylas v6.3.1 release provides the following changes and fixes:
* Add missing order and emails field in calendar availability (#344)
* Fix issue where passing in an array of one for `MessageRestfulModelCollection.findMultiple` throws an error (#343)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.