### PR TITLE
Add missing `fileIdsToAttach` field in `DraftProperties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add missing `fileIdsToAttach` field in `DraftProperties`
+
 ### 6.3.1 / 2022-04-22
 * Add missing order and emails field in calendar availability
 * Fix issue where passing in an array of one for `MessageRestfulModelCollection.findMultiple` throws an error

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -12,6 +12,7 @@ export type DraftProperties = MessageProperties & {
   rawMime?: string;
   replyToMessageId?: string;
   version?: number;
+  fileIdsToAttach?: string[];
 };
 
 export default class Draft extends Message implements DraftProperties {


### PR DESCRIPTION
# Description
This PR adds the missing `fileIdsToAttach` field into `DraftProperties` so that a user can pass that field in while initializing a new Draft.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.