### PR TITLE
[Bugfix] Fix bug in CalendarRestfulModelCollection

### DIFF
--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -35,11 +35,9 @@ describe('CalendarRestfulModelCollection', () => {
         return Promise.resolve('body');
       },
       json: () => {
-        return Promise.resolve(
-          {
-            body: 'body',
-          }
-        );
+        return Promise.resolve({
+          body: 'body',
+        });
       },
       headers: new Map(),
     };
@@ -72,22 +70,20 @@ describe('CalendarRestfulModelCollection', () => {
           return Promise.resolve('body');
         },
         json: () => {
-          return Promise.resolve(
-            [
-              {
-                object: 'free_busy',
-                email: 'jane@email.com',
-                time_slots: [
-                  {
-                    object: 'time_slot',
-                    status: 'busy',
-                    start_time: 1590454800,
-                    end_time: 1590780800,
-                  },
-                ],
-              },
-            ]
-          );
+          return Promise.resolve([
+            {
+              object: 'free_busy',
+              email: 'jane@email.com',
+              time_slots: [
+                {
+                  object: 'time_slot',
+                  status: 'busy',
+                  start_time: 1590454800,
+                  end_time: 1590780800,
+                },
+              ],
+            },
+          ]);
         },
         headers: new Map(),
       };

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -36,9 +36,9 @@ describe('CalendarRestfulModelCollection', () => {
       },
       json: () => {
         return Promise.resolve(
-          JSON.stringify({
+          {
             body: 'body',
-          })
+          }
         );
       },
       headers: new Map(),
@@ -73,7 +73,7 @@ describe('CalendarRestfulModelCollection', () => {
         },
         json: () => {
           return Promise.resolve(
-            JSON.stringify([
+            [
               {
                 object: 'free_busy',
                 email: 'jane@email.com',
@@ -86,7 +86,7 @@ describe('CalendarRestfulModelCollection', () => {
                   },
                 ],
               },
-            ])
+            ]
           );
         },
         headers: new Map(),

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -47,7 +47,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
           callback(null, json);
         }
         const freeBusy = [];
-        for (const fb of JSON.parse(json)) {
+        for (const fb of json) {
           freeBusy.push(new FreeBusy().fromJSON(fb));
         }
         return Promise.resolve(freeBusy);


### PR DESCRIPTION
I noticed the following error while attempting to use the "free busy" functionality:
![image](https://user-images.githubusercontent.com/727536/166723734-e2afd039-08e8-4935-83e2-580d4b0477d7.png)

Doing a manual CURL request with the same parameters was successful.

After some debugging I noticed that the code was attempting to `JSON.parse(json)`, where `json` was a JSON object and not a string. This resulted in the error I witnessed.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.