### PR TITLE
Fix scheduler endpoint URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add missing `fileIdsToAttach` field in `DraftProperties`
+* Fix base URL not being set for `SchedulerRestfulModelCollection` functions
 
 ### 6.3.1 / 2022-04-22
 * Add missing order and emails field in calendar availability

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -35,11 +35,9 @@ describe('CalendarRestfulModelCollection', () => {
         return Promise.resolve('body');
       },
       json: () => {
-        return Promise.resolve(
-          JSON.stringify({
-            body: 'body',
-          })
-        );
+        return Promise.resolve({
+          body: 'body',
+        });
       },
       headers: new Map(),
     };
@@ -72,22 +70,20 @@ describe('CalendarRestfulModelCollection', () => {
           return Promise.resolve('body');
         },
         json: () => {
-          return Promise.resolve(
-            JSON.stringify([
-              {
-                object: 'free_busy',
-                email: 'jane@email.com',
-                time_slots: [
-                  {
-                    object: 'time_slot',
-                    status: 'busy',
-                    start_time: 1590454800,
-                    end_time: 1590780800,
-                  },
-                ],
-              },
-            ])
-          );
+          return Promise.resolve([
+            {
+              object: 'free_busy',
+              email: 'jane@email.com',
+              time_slots: [
+                {
+                  object: 'time_slot',
+                  status: 'busy',
+                  start_time: 1590454800,
+                  end_time: 1590780800,
+                },
+              ],
+            },
+          ]);
         },
         headers: new Map(),
       };

--- a/__tests__/scheduler-restful-model-collection-spec.js
+++ b/__tests__/scheduler-restful-model-collection-spec.js
@@ -28,6 +28,32 @@ describe('SchedulerRestfulModelCollection', () => {
     jest.spyOn(testContext.connection, 'request');
   });
 
+  describe('Configuration', () => {
+    test('Base URL was set properly', done => {
+      const response = {
+        status: 200,
+        clone: () => response,
+        buffer: () => {
+          return Promise.resolve('body');
+        },
+        json: () => {
+          return Promise.resolve({});
+        },
+        headers: new Map(),
+      };
+
+      fetch.mockImplementation(() => Promise.resolve(response));
+
+      testContext.connection.scheduler.find('abc-123').then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.schedule.nylas.com/manage/pages/abc-123'
+        );
+        done();
+      });
+    });
+  });
+
   describe('ProviderAvailability', () => {
     beforeEach(() => {
       const availability = {

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -47,7 +47,7 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
           callback(null, json);
         }
         const freeBusy = [];
-        for (const fb of JSON.parse(json)) {
+        for (const fb of json) {
           freeBusy.push(new FreeBusy().fromJSON(fb));
         }
         return Promise.resolve(freeBusy);

--- a/src/models/model-collection.ts
+++ b/src/models/model-collection.ts
@@ -9,6 +9,7 @@ export default class ModelCollection<T extends Model> {
   connection: NylasConnection;
   modelClass: any;
   _path: string;
+  baseUrl?: string;
 
   constructor(modelClass: any, connection: NylasConnection, path: string) {
     this.modelClass = modelClass;
@@ -206,6 +207,7 @@ export default class ModelCollection<T extends Model> {
         method: 'GET',
         path,
         qs: { ...params, offset, limit },
+        baseUrl: this.baseUrl,
       });
     }
 
@@ -225,6 +227,7 @@ export default class ModelCollection<T extends Model> {
         method: 'GET',
         path: `${this.path()}/${id}`,
         qs: params,
+        baseUrl: this.baseUrl,
       })
       .then(json => {
         const model = this.createModel(json);
@@ -243,6 +246,7 @@ export default class ModelCollection<T extends Model> {
         method: 'GET',
         path,
         qs: { ...params, offset, limit },
+        baseUrl: this.baseUrl,
       })
       .then((jsonArray: []) => {
         const models = jsonArray.map(json => {

--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -10,7 +10,6 @@ export default class RestfulModelCollection<
   T extends RestfulModel
 > extends ModelCollection<any> {
   modelClass: typeof RestfulModel;
-  baseUrl?: string;
 
   constructor(modelClass: typeof RestfulModel, connection: NylasConnection) {
     super(modelClass, connection, modelClass.collectionName);

--- a/src/models/scheduler-restful-model-collection.ts
+++ b/src/models/scheduler-restful-model-collection.ts
@@ -22,6 +22,7 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
 > {
   connection: NylasConnection;
   modelClass: typeof Scheduler;
+  baseUrl: string;
 
   constructor(connection: NylasConnection) {
     super(Scheduler, connection);


### PR DESCRIPTION
# Description
The scheduler endpoints were not using the correct base URL for API calls, resulting in errors for any scheduler operation. This PR ensures that the Scheduler endpoints use the correct url.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.