### PR TITLE
v6.3.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-### Unreleased
+### 6.3.2 / 2022-05-04
 * Add missing `fileIdsToAttach` field in `DraftProperties`
+* Fix JSON parse error when using `CalendarRestfulModelCollection.freeBusy`
 * Fix base URL not being set for `SchedulerRestfulModelCollection` functions
 
 ### 6.3.1 / 2022-04-22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.3.1",
+      "version": "6.3.2",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New nylas v6.3.2 release provides the following changes and fixes:
* Add missing `fileIdsToAttach` field in `DraftProperties` (#347, #348)
* Fix JSON parse error when using `CalendarRestfulModelCollection.freeBusy` (#349)
* Fix base URL not being set for `SchedulerRestfulModelCollection` functions (#350)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.