### PR TITLE
Fix `fileIdsToAttach` field not being set when initializing a `Draft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Support collective and group events
+* Fix `fileIdsToAttach` field not being set when initializing a `Draft`
 
 ### 6.3.2 / 2022-05-04
 * Add missing `fileIdsToAttach` field in `DraftProperties`

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -340,6 +340,33 @@ describe('Draft', () => {
           done();
         });
       });
+
+      test('setting fileIdsToAttach via constructor should send the values as file_ids to the API', done => {
+        const draft = new Draft(testContext.connection, {
+          to: [{ name: 'test', email: 'test@email.com' }],
+          fileIdsToAttach: ['file_id1', 'file_id2', 'file_id3'],
+        });
+
+        draft.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.url.toString()).toEqual(
+            'https://api.nylas.com/drafts'
+          );
+          expect(options.method).toEqual('POST');
+          expect(JSON.parse(options.body)).toEqual({
+            to: [{ name: 'test', email: 'test@email.com' }],
+            cc: [],
+            bcc: [],
+            from: [],
+            events: [],
+            labels: [],
+            date: null,
+            file_ids: ['file_id1', 'file_id2', 'file_id3'],
+            reply_to: [],
+          });
+          done();
+        });
+      });
     });
   });
 

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -34,6 +34,10 @@ export default class Draft extends Message implements DraftProperties {
       modelKey: 'rawMime',
       readOnly: true,
     }),
+    fileIdsToAttach: Attributes.StringList({
+      modelKey: 'fileIdsToAttach',
+      readOnly: true,
+    }),
   };
 
   constructor(connection: NylasConnection, props?: DraftProperties) {


### PR DESCRIPTION
# Description
A followup to #348, this PR ensures that when setting `fileIdsToAttach` when initializing a `Draft` it actually sets it.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.