### PR TITLE
v6.4.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.4.0 / 2022-05-10
 * Support collective and group events
 * Fix `fileIdsToAttach` field not being set when initializing a `Draft`
 

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -899,8 +899,12 @@ describe('Event', () => {
     test('should throw an error if capacity is less than the amount of participants', done => {
       testContext.event.capacity = 1;
       testContext.event.participants = [
-        'person1@email.com',
-        'person2@email.com',
+        new EventParticipant({
+          email: 'person1@email.com',
+        }),
+        new EventParticipant({
+          email: 'person2@email.com',
+        }),
       ];
       expect(() => testContext.event.save()).toThrow(
         new Error(
@@ -913,8 +917,12 @@ describe('Event', () => {
     test('should not throw if capacity is -1', done => {
       testContext.event.capacity = -1;
       testContext.event.participants = [
-        'person1@email.com',
-        'person2@email.com',
+        new EventParticipant({
+          email: 'person1@email.com',
+        }),
+        new EventParticipant({
+          email: 'person2@email.com',
+        }),
       ];
       expect(() => testContext.event.save()).not.toThrow(
         new Error(
@@ -924,12 +932,22 @@ describe('Event', () => {
       done();
     });
 
-    test('should not throw if capacity is set but participants are less than capacity', done => {
-      testContext.event.capacity = 3;
+    test('should not throw if capacity is set but participants are less than or equal to capacity', done => {
+      testContext.event.capacity = 2;
       testContext.event.participants = [
-        'person1@email.com',
-        'person2@email.com',
+        new EventParticipant({
+          email: 'person1@email.com',
+        }),
+        new EventParticipant({
+          email: 'person2@email.com',
+        }),
       ];
+      expect(() => testContext.event.save()).not.toThrow(
+        new Error(
+          'The number of participants in the event exceeds the set capacity.'
+        )
+      );
+      testContext.event.capacity = 3;
       expect(() => testContext.event.save()).not.toThrow(
         new Error(
           'The number of participants in the event exceeds the set capacity.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.3.2",
+      "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v6.4.0 release provides the following addition and fix:
* Support collective and group events (#352)
* Fix `fileIdsToAttach` field not being set when initializing a `Draft` (#354)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.