### PR TITLE
[Fix] Wrong body parse error - public_url undefined

### DIFF
--- a/example/webhooks/index.js
+++ b/example/webhooks/index.js
@@ -82,7 +82,7 @@ var webhook_uri;
 // Setup ngrok settings to ensure everything works locally
 request('http://localhost:4040/api/tunnels', function(error, response, body) {
   if (!error && response.statusCode == 200) {
-    webhook_uri = JSON.parse(body).tunnels[1].public_url + '/webhook';
+    webhook_uri = JSON.parse(body).tunnels[0].public_url + '/webhook';
   } else {
     throw "It looks like ngrok isn't running! Make sure you've started that first with 'ngrok http 1234'";
   }


### PR DESCRIPTION
### Changes
1. Fixed the incorrect tunnel index number.

### Error
```
node index.js
/Users/everton/projects/nylas-nodejs/example/webhooks/index.js:85
    webhook_uri = JSON.parse(body).tunnels[1].public_url + '/webhook';
                                             ^

TypeError: Cannot read properties of undefined (reading 'public_url')
    at Request._callback (/Users/everton/projects/nylas-nodejs/example/webhooks/index.js:85:46)
    at self.callback (/Users/everton/projects/nylas-nodejs/example/webhooks/node_modules/request/request.js:185:22)
    at Request.emit (node:events:527:28)
    at Request.<anonymous> (/Users/everton/projects/nylasnodejs/example/webhooks/node_modules/request/request.js:1154:10)
    at Request.emit (node:events:527:28)
    at IncomingMessage.<anonymous> (/Users/everton/projects/nylas-nodejs/example/webhooks/node_modules/request/request.js:1076:12)
    at Object.onceWrapper (node:events:641:28)
    at IncomingMessage.emit (node:events:539:35)
    at endReadableNT (node:internal/streams/readable:1344:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
``` 
<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.