### PR TITLE
Remove use of `.clone` in `node-fetch` operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Fixed issue where API response data was being lost
+* Fixed incorrect tunnel index number in webhook example
+
 ### 6.4.0 / 2022-05-10
 * Support collective and group events
 * Fix `fileIdsToAttach` field not being set when initializing a `Draft`

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -30,14 +30,12 @@ describe('CalendarRestfulModelCollection', () => {
 
     const response = {
       status: 200,
-      clone: () => response,
-      buffer: () => {
-        return Promise.resolve('body');
-      },
-      json: () => {
-        return Promise.resolve({
-          body: 'body',
-        });
+      text: () => {
+        return Promise.resolve(
+          JSON.stringify({
+            body: 'body',
+          })
+        );
       },
       headers: new Map(),
     };
@@ -65,30 +63,28 @@ describe('CalendarRestfulModelCollection', () => {
     test('Should fetch results with params', done => {
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve([
-            {
-              object: 'free_busy',
-              email: 'jane@email.com',
-              time_slots: [
-                {
-                  object: 'time_slot',
-                  status: 'busy',
-                  start_time: 1590454800,
-                  end_time: 1590780800,
-                  capacity: {
-                    event_id: 'abc-123',
-                    current_capacity: 2,
-                    max_capacity: 5,
+        text: () => {
+          return Promise.resolve(
+            JSON.stringify([
+              {
+                object: 'free_busy',
+                email: 'jane@email.com',
+                time_slots: [
+                  {
+                    object: 'time_slot',
+                    status: 'busy',
+                    start_time: 1590454800,
+                    end_time: 1590780800,
+                    capacity: {
+                      event_id: 'abc-123',
+                      current_capacity: 2,
+                      max_capacity: 5,
+                    },
                   },
-                },
-              ],
-            },
-          ]);
+                ],
+              },
+            ])
+          );
         },
         headers: new Map(),
       };

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -39,20 +39,16 @@ describe('Calendar', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
+        text: () => {
           if (receivedBody === null) {
-            return Promise.resolve(calendarJSON);
+            return Promise.resolve(JSON.stringify(calendarJSON));
           }
 
           const j = JSON.parse(receivedBody.toString());
           if (!j.id) {
             j.id = calendarJSON.id;
           }
-          return Promise.resolve(j);
+          return Promise.resolve(JSON.stringify(j));
         },
         headers: new Map(),
       };

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -29,12 +29,8 @@ describe('Component', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
         text: () => {
-          return Promise.resolve(receivedBody);
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };
@@ -155,13 +151,11 @@ describe('Component', () => {
       const response = req => {
         return {
           status: 200,
-          text: () => {},
-          clone: () => response(req),
-          json: () => {
+          text: () => {
             if (!req.url.includes('abc-123')) {
-              return Promise.resolve([componentJSON]);
+              return Promise.resolve(JSON.stringify([componentJSON]));
             }
-            return Promise.resolve(componentJSON);
+            return Promise.resolve(JSON.stringify(componentJSON));
           },
           headers: new Map(),
         };

--- a/__tests__/contact-restful-model-collection-spec.js
+++ b/__tests__/contact-restful-model-collection-spec.js
@@ -40,12 +40,8 @@ describe('RestfulModelCollection', () => {
 
     const response = {
       status: 200,
-      clone: () => response,
-      buffer: () => {
-        return Promise.resolve('body');
-      },
-      json: () => {
-        return Promise.resolve(contactJSON);
+      text: () => {
+        return Promise.resolve(JSON.stringify(contactJSON));
       },
       headers: new Map(),
     };

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -27,12 +27,8 @@ describe('Contact', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+        text: () => {
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -29,12 +29,8 @@ describe('Draft', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
         text: () => {
-          return Promise.resolve(receivedBody);
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -31,7 +31,9 @@ describe('Event', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
+        text: () => {
+          return Promise.resolve(receivedBody);
+        },
         buffer: () => {
           return Promise.resolve('body');
         },
@@ -779,7 +781,13 @@ describe('Event', () => {
       const response = () => {
         return {
           status: 200,
-          clone: () => response(),
+          text: () => {
+            return Promise.resolve(
+              JSON.stringify({
+                ics: 'ics_string',
+              })
+            );
+          },
           buffer: () => {
             return Promise.resolve('body');
           },

--- a/__tests__/file-spec.js
+++ b/__tests__/file-spec.js
@@ -30,20 +30,19 @@ describe('File', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
         buffer: () => {
           return Promise.resolve('body');
         },
-        json: () => {
+        text: () => {
           // Just a placeholder so that we can mimic returning data after uploading
           // This data is not used
           if (
             receivedBody === null ||
             receivedBody.constructor.name === 'FormData'
           ) {
-            return Promise.resolve([JSON.stringify(testContext.file.toJSON())]);
+            return Promise.resolve(JSON.stringify([testContext.file.toJSON()]));
           }
-          return Promise.resolve(receivedBody);
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: headers,
       };

--- a/__tests__/folder-spec.js
+++ b/__tests__/folder-spec.js
@@ -27,12 +27,8 @@ describe('Label', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+        text: () => {
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -68,9 +68,8 @@ describe('Job Status', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        json: () => {
-          return Promise.resolve(testContext.listApiResponse);
+        text: () => {
+          return Promise.resolve(JSON.stringify(testContext.listApiResponse));
         },
         headers: new Map(),
       };
@@ -121,9 +120,8 @@ describe('Job Status', () => {
     beforeEach(() => {
       const response = {
         status: 200,
-        clone: () => response,
-        json: () => {
-          return Promise.resolve(testContext.getApiResponse);
+        text: () => {
+          return Promise.resolve(JSON.stringify(testContext.getApiResponse));
         },
         headers: new Map(),
       };
@@ -172,9 +170,8 @@ describe('Job Status', () => {
     beforeEach(() => {
       const response = {
         status: 200,
-        clone: () => response,
-        json: () => {
-          return Promise.resolve(testContext.getApiResponse);
+        text: () => {
+          return Promise.resolve(JSON.stringify(testContext.getApiResponse));
         },
         headers: new Map(),
       };
@@ -219,9 +216,8 @@ describe('Job Status', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        json: () => {
-          return Promise.resolve(jobStatuses);
+        text: () => {
+          return Promise.resolve(JSON.stringify(jobStatuses));
         },
         headers: new Map(),
       };

--- a/__tests__/label-spec.js
+++ b/__tests__/label-spec.js
@@ -27,12 +27,8 @@ describe('Label', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+        text: () => {
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -31,16 +31,12 @@ describe('Message', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
+        text: () => {
           // For the raw/MIME flow
           if (receivedBody === null) {
             return Promise.resolve('MIME');
           }
-          return Promise.resolve(receivedBody);
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };
@@ -159,22 +155,22 @@ describe('Message', () => {
       const response = request => {
         return {
           status: 200,
-          clone: () => response(request),
-          buffer: () => {
-            return Promise.resolve('body');
-          },
-          json: () => {
+          text: () => {
             // For the raw/MIME flow
             if (request.headers.get('Accept') === 'message/rfc822') {
               return Promise.resolve('MIME');
             }
             if (!request.url.includes(',')) {
-              return Promise.resolve(testContext.message.toJSON(false));
+              return Promise.resolve(
+                JSON.stringify(testContext.message.toJSON(false))
+              );
             } else {
-              return Promise.resolve([
-                testContext.message.toJSON(false),
-                secondMessage.toJSON(false),
-              ]);
+              return Promise.resolve(
+                JSON.stringify([
+                  testContext.message.toJSON(false),
+                  secondMessage.toJSON(false),
+                ])
+              );
             }
           },
           headers: new Map(),

--- a/__tests__/neural-spec.js
+++ b/__tests__/neural-spec.js
@@ -294,12 +294,8 @@ describe('Neural', () => {
       const response = () => {
         return {
           status: 200,
-          clone: () => response(),
-          buffer: () => {
-            return Promise.resolve('body');
-          },
-          json: () => {
-            return Promise.resolve(serverResponse);
+          text: () => {
+            return Promise.resolve(JSON.stringify(serverResponse));
           },
           headers: new Map(),
         };

--- a/__tests__/resource-spec.js
+++ b/__tests__/resource-spec.js
@@ -44,12 +44,8 @@ describe('Resource', () => {
     const response = () => {
       return {
         status: 200,
-        clone: () => response(),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(testContext.apiResponse);
+        text: () => {
+          return Promise.resolve(JSON.stringify(testContext.apiResponse));
         },
         headers: new Map(),
       };

--- a/__tests__/scheduler-restful-model-collection-spec.js
+++ b/__tests__/scheduler-restful-model-collection-spec.js
@@ -32,12 +32,8 @@ describe('SchedulerRestfulModelCollection', () => {
     test('Base URL was set properly', done => {
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve({});
+        text: () => {
+          return Promise.resolve(JSON.stringify({}));
         },
         headers: new Map(),
       };

--- a/__tests__/scheduler-restful-model-collection-spec.js
+++ b/__tests__/scheduler-restful-model-collection-spec.js
@@ -65,12 +65,8 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(availability);
+        text: () => {
+          return Promise.resolve(JSON.stringify(availability));
         },
         headers: new Map(),
       };
@@ -124,12 +120,8 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(availability);
+        text: () => {
+          return Promise.resolve(JSON.stringify(availability));
         },
         headers: new Map(),
       };
@@ -153,12 +145,8 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(schedulerJSON);
+        text: () => {
+          return Promise.resolve(JSON.stringify(schedulerJSON));
         },
         headers: new Map(),
       };
@@ -201,12 +189,8 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(schedulerTimeSlots);
+        text: () => {
+          return Promise.resolve(JSON.stringify(schedulerTimeSlots));
         },
         headers: new Map(),
       };
@@ -240,12 +224,8 @@ describe('SchedulerRestfulModelCollection', () => {
 
       const response = {
         status: 200,
-        clone: () => response,
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(success);
+        text: () => {
+          return Promise.resolve(JSON.stringify(success));
         },
         headers: new Map(),
       };
@@ -291,12 +271,8 @@ describe('SchedulerRestfulModelCollection', () => {
 
         const response = {
           status: 200,
-          clone: () => response,
-          buffer: () => {
-            return Promise.resolve('body');
-          },
-          json: () => {
-            return Promise.resolve(bookingConfirmation);
+          text: () => {
+            return Promise.resolve(JSON.stringify(bookingConfirmation));
           },
           headers: new Map(),
         };

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -30,12 +30,8 @@ describe('Scheduler', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+        text: () => {
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };
@@ -169,12 +165,8 @@ describe('Scheduler', () => {
       const response = () => {
         return {
           status: 200,
-          clone: () => response(),
-          buffer: () => {
-            return Promise.resolve('body');
-          },
-          json: () => {
-            return Promise.resolve(calendarsJSON);
+          text: () => {
+            return Promise.resolve(JSON.stringify(calendarsJSON));
           },
           headers: new Map(),
         };

--- a/__tests__/thread-spec.js
+++ b/__tests__/thread-spec.js
@@ -30,12 +30,8 @@ describe('Thread', () => {
     const response = receivedBody => {
       return {
         status: 200,
-        clone: () => response(receivedBody),
-        buffer: () => {
-          return Promise.resolve('body');
-        },
-        json: () => {
-          return Promise.resolve(receivedBody);
+        text: () => {
+          return Promise.resolve(JSON.stringify(receivedBody));
         },
         headers: new Map(),
       };

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -248,17 +248,17 @@ export default class NylasConnection {
           if (response.status > 299) {
             return response.text().then(body => {
               try {
-                const jsonError = JSON.parse(body);
+                const parsedApiError = JSON.parse(body);
                 const error = new NylasApiError(
                   response.status,
-                  jsonError.type,
-                  jsonError.message
+                  parsedApiError.type,
+                  parsedApiError.message
                 );
-                if (jsonError.missing_fields) {
-                  error.missingFields = jsonError.missing_fields;
+                if (parsedApiError.missing_fields) {
+                  error.missingFields = parsedApiError.missing_fields;
                 }
-                if (jsonError.server_error) {
-                  error.serverError = jsonError.server_error;
+                if (parsedApiError.server_error) {
+                  error.serverError = parsedApiError.server_error;
                 }
                 return reject(error);
               } catch (e) {


### PR DESCRIPTION
# Description
Since the release of v6.3.0 we incorporated the use of `node-fetch`'s `.clone` function which allows us to clone the response body before exhausting the stream, in case we run into some sort of parsing error (usually with JSON parsing). This led to some issues with fetching in general, and after some research it seems to be a known issue on node-fetch < 3.0.0 where if `.clone` is used on a large response, it won't properly read the stream (https://github.com/node-fetch/node-fetch/issues/396, https://github.com/node-fetch/node-fetch/issues/151). 

This issue was fixed in v3 of node-fetch but we're not able to directly jump to that version as it has breaking changes. As a result, we've switched to removing the use of `clone` and instead we just get the buffer as a string and try to parse the JSON ourselves, allowing us to still retain the buffered data in case of a parsing error. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.