### PR TITLE
v6.4.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.4.1 / 2022-06-06
 * Fixed issue where API response data was being lost
 * Fixed incorrect tunnel index number in webhook example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New nylas v6.4.1 release provides the following fixes:
* Fixed issue where API response data was being lost (#358, #356)
* Fixed incorrect tunnel index number in webhook example (#357)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.