### PR TITLE
Add Message.save() functionality for updating existing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add `Message.save()` functionality for updating existing messages
+
 ### 6.4.1 / 2022-06-06
 * Fixed issue where API response data was being lost
 * Fixed incorrect tunnel index number in webhook example

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -116,6 +116,15 @@ describe('Message', () => {
       });
     });
 
+    test('should throw an error if the message has no ID (messages cannot be created)', done => {
+      testContext.message.id = undefined;
+      testContext.message.metadata = {
+        test: 'yes',
+      };
+      expect(() => testContext.message.save()).toThrow();
+      done();
+    });
+
     test('should resolve with the message object', done => {
       return testContext.message.save().then(message => {
         expect(message.id).toBe('4333');

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -1,4 +1,4 @@
-import RestfulModel from './restful-model';
+import RestfulModel, { SaveCallback } from './restful-model';
 import Attributes, { Attribute } from './attributes';
 import File, { FileProperties } from './file';
 import Event, { EventProperties } from './event';
@@ -186,5 +186,16 @@ export default class Message extends RestfulModel implements MessageProperties {
     json['unread'] = this.unread;
     json['metadata'] = this.metadata;
     return json;
+  }
+
+  save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
+    // A Message can only be updated
+    if (this.constructor.name === 'Message' && !this.id) {
+      throw new Error(
+        'Cannot create a message. Please create and send a draft instead.'
+      );
+    }
+
+    return super.save(params, callback);
   }
 }


### PR DESCRIPTION
# Description
The `Message` class was missing a `save()` function for updating an already existing message, so this PR adds it in.

# Usage
```js
const Nylas = require('nylas');
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

const message = await nylas.messages.first();
message.metadata = { "test": true };
message.save();
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.