### PR TITLE
Support Nylas API v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Unreleased
 * Add `Message.save()` functionality for updating existing messages
 
+### 6.4.2 / 2022-06-10
+* Add support for new `authState` object for `Account` and `ManagementAccount` collections
+* Deprecate `syncState` field for `Account` and `ManagementAccount` collections, as it is now superseded by `authState`
+
 ### 6.4.1 / 2022-06-06
 * Fixed issue where API response data was being lost
 * Fixed incorrect tunnel index number in webhook example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,13 +1,30 @@
 import RestfulModel from './restful-model';
 import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
+import { NativeAuthenticationProvider, Scope } from './connect';
+
+export enum AuthStatusState {
+  Valid = 'valid',
+  Invalid = 'invalid',
+}
+
+export type AuthStatusProperties = {
+  state: AuthStatusState;
+  provider: NativeAuthenticationProvider;
+  scopes: Scope[];
+  error_message?: string;
+};
 
 export type AccountProperties = {
   name: string;
   emailAddress: string;
   provider: string;
   organizationUnit: string;
+  /**
+   * @deprecated will be removed in future versions. use `authStatus` instead
+   */
   syncState: string;
+  authStatus?: AuthStatusProperties;
   linkedAt: Date;
   billingState?: string;
   accessToken?: string;
@@ -19,6 +36,7 @@ export default class Account extends RestfulModel implements AccountProperties {
   provider = '';
   organizationUnit = '';
   syncState = '';
+  authStatus = undefined;
   linkedAt = new Date();
   accessToken = '';
   billingState?: string;
@@ -47,6 +65,11 @@ export default class Account extends RestfulModel implements AccountProperties {
     syncState: Attributes.String({
       modelKey: 'syncState',
       jsonKey: 'sync_state',
+    }),
+
+    authStatus: Attributes.Object({
+      modelKey: 'authStatus',
+      jsonKey: 'auth_status',
     }),
 
     billingState: Attributes.String({

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -11,7 +11,7 @@ export enum AuthStatusState {
 export type AuthStatusProperties = {
   state: AuthStatusState;
   provider: NativeAuthenticationProvider;
-  scopes: Scope[];
+  scopes: string;
   error_message?: string;
 };
 

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,7 +1,7 @@
 import RestfulModel from './restful-model';
 import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
-import { NativeAuthenticationProvider, Scope } from './connect';
+import { NativeAuthenticationProvider } from './connect';
 
 export enum AuthStatusState {
   Valid = 'valid',

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -73,7 +73,7 @@ export type ManagementAccountProperties = {
   namespaceId: string;
   provider: string;
   /**
-   * @deprecated use `authStatus` instead
+   * @deprecated will be removed in future versions. use `authStatus` instead
    */
   syncState: string;
   authStatus?: AuthStatusProperties;

--- a/src/models/management-account.ts
+++ b/src/models/management-account.ts
@@ -3,6 +3,7 @@ import Attributes, { Attribute } from './attributes';
 import NylasConnection from '../nylas-connection';
 import Model from './model';
 import { SaveCallback } from './restful-model';
+import { AuthStatusProperties } from './account';
 
 export type ApplicationIPAddressesProperties = {
   ipAddresses: string[];
@@ -71,7 +72,11 @@ export type ManagementAccountProperties = {
   emailAddress: string;
   namespaceId: string;
   provider: string;
+  /**
+   * @deprecated use `authStatus` instead
+   */
   syncState: string;
+  authStatus?: AuthStatusProperties;
   authenticationType: string;
   trial: boolean;
   metadata?: object;
@@ -88,6 +93,7 @@ export default class ManagementAccount extends ManagementModel
   namespaceId = '';
   provider = '';
   syncState = '';
+  authStatus = undefined;
   authenticationType = '';
   trial = false;
   metadata?: object;
@@ -112,6 +118,10 @@ export default class ManagementAccount extends ManagementModel
     syncState: Attributes.String({
       modelKey: 'syncState',
       jsonKey: 'sync_state',
+    }),
+    authStatus: Attributes.Object({
+      modelKey: 'authStatus',
+      jsonKey: 'auth_status',
     }),
     authenticationType: Attributes.String({
       modelKey: 'authenticationType',


### PR DESCRIPTION
- Bump version (`6.4.1` => `6.4.2`)
- Add `authState` object support/typing to both `account` and `management-account` endpoints
- Mark `syncState` as deprecated, as it is now superceded by `authState`