### PR TITLE
v6.4.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-### Unreleased
+### 6.4.2 / 2022-06-14
 * Add `Message.save()` functionality for updating existing messages
+* Add missing `reminderMinutes` field in `Event`
 
 ### 6.4.1 / 2022-06-06
 * Fixed issue where API response data was being lost

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Describe
New nylas v6.4.2 release provides the following changes:
* Add `Message.save()` functionality for updating existing messages (#362)
* Add missing `reminderMinutes` field in `Event` (#361)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.