### PR TITLE
Convert `Nylas` class from a static to a non-static class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 7.0.0 / TBD
+* **BREAKING CHANGE**: Convert `Nylas` class from a static to a non-static class
+
 ### 6.4.2 / 2022-06-14
 * Add `Message.save()` functionality for updating existing messages
 * Add missing `reminderMinutes` field in `Event`

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import { Days, RoundRobin } from '../src/models/calendar-availability';
 
 jest.mock('node-fetch', () => {
@@ -17,15 +16,13 @@ describe('CalendarRestfulModelCollection', () => {
   const testAccessToken = 'test-access-token';
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection(testAccessToken, {
-      clientId: 'myClientId',
-    });
+    testContext.connection = nylasClient.with(testAccessToken);
     jest.spyOn(testContext.connection, 'request');
 
     const response = {

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -1,4 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
 import Calendar from '../src/models/calendar';
 import fetch from 'node-fetch';
 import Nylas from '../src/nylas';
@@ -15,13 +14,13 @@ describe('Calendar', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     const calendarJSON = {
       account_id: 'eof2wrhqkl7kdwhy9hylpv9o9',
       description: 'All the holidays',

--- a/__tests__/component-spec.js
+++ b/__tests__/component-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
 import Component from '../src/models/component';
 
@@ -15,15 +14,13 @@ describe('Component', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', {
-      clientId: 'myClientId',
-    });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/connect-spec.js
+++ b/__tests__/connect-spec.js
@@ -41,15 +41,17 @@ describe('Connect', () => {
   };
 
   describe('authorize without clientId', () => {
+    const testContext = {};
+
     beforeEach(() => {
-      Nylas.config({});
+      testContext.nylasClient = new Nylas({});
     });
 
     test('Should throw an error when the clientId is not passed in to Nylas.config()', done => {
       expect.assertions(2);
       const settings = { username: exchangeEmail, password: password };
       expect(() =>
-        Nylas.connect.authorize(
+        testContext.nylasClient.connect.authorize(
           authorizeOptions(
             exchangeEmail,
             NativeAuthenticationProvider.Exchange,
@@ -57,14 +59,18 @@ describe('Connect', () => {
           )
         )
       ).toThrow();
-      expect(() => Nylas.connect.token(authorizeJSON.code)).toThrow();
+      expect(() =>
+        testContext.nylasClient.connect.token(authorizeJSON.code)
+      ).toThrow();
       done();
     });
   });
 
   describe('authorize with clientId', () => {
+    const testContext = {};
+
     beforeEach(() => {
-      Nylas.config({
+      testContext.nylasClient = new Nylas({
         clientId: CLIENT_ID,
         clientSecret: CLIENT_SECRET,
       });
@@ -73,10 +79,10 @@ describe('Connect', () => {
     test('Should do a POST request to /connect/authorize', done => {
       expect.assertions(2);
       const settings = { username: exchangeEmail, password: password };
-      Nylas.connect.connection.request = jest.fn(() =>
+      testContext.nylasClient.connect.connection.request = jest.fn(() =>
         Promise.resolve(authorizeJSON)
       );
-      Nylas.connect
+      testContext.nylasClient.connect
         .authorize(
           authorizeOptions(
             exchangeEmail,
@@ -86,7 +92,9 @@ describe('Connect', () => {
         )
         .then(resp => {
           expect(resp).toEqual(authorizeJSON);
-          expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
+          expect(
+            testContext.nylasClient.connect.connection.request
+          ).toHaveBeenCalledWith({
             method: 'POST',
             path: '/connect/authorize',
             body: {
@@ -104,12 +112,14 @@ describe('Connect', () => {
 
     test('Should do a POST request to /connect/token', done => {
       expect.assertions(2);
-      Nylas.connect.connection.request = jest.fn(() =>
+      testContext.nylasClient.connect.connection.request = jest.fn(() =>
         Promise.resolve(tokenJSON)
       );
-      Nylas.connect.token(authorizeJSON.code).then(resp => {
+      testContext.nylasClient.connect.token(authorizeJSON.code).then(resp => {
         expect(resp.toJSON()).toEqual(tokenJSON);
-        expect(Nylas.connect.connection.request).toHaveBeenCalledWith({
+        expect(
+          testContext.nylasClient.connect.connection.request
+        ).toHaveBeenCalledWith({
           method: 'POST',
           path: '/connect/token',
           body: {

--- a/__tests__/contact-restful-model-collection-spec.js
+++ b/__tests__/contact-restful-model-collection-spec.js
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import { Group } from '../src/models/contact';
 
 jest.mock('node-fetch', () => {
@@ -17,15 +16,13 @@ describe('RestfulModelCollection', () => {
   const testAccessToken = 'test-access-token';
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection(testAccessToken, {
-      clientId: 'foo',
-    });
+    testContext.connection = nylasClient.with(testAccessToken);
     jest.spyOn(testContext.connection, 'request');
 
     const contactJSON = [

--- a/__tests__/contact-spec.js
+++ b/__tests__/contact-spec.js
@@ -1,4 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
 import Contact from '../src/models/contact';
 import Nylas from '../src/nylas';
 import fetch from 'node-fetch';
@@ -15,13 +14,13 @@ describe('Contact', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -1,4 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
 import Draft from '../src/models/draft';
 import Message from '../src/models/message';
 import Nylas from '../src/nylas';
@@ -17,13 +16,13 @@ describe('Draft', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -1,4 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
 import Event from '../src/models/event';
 import EventConferencing from '../src/models/event-conferencing';
 import Nylas from '../src/nylas';
@@ -19,13 +18,13 @@ describe('Event', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/file-spec.js
+++ b/__tests__/file-spec.js
@@ -1,4 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
 import File from '../src/models/file';
 import fetch from 'node-fetch';
 import Nylas from '../src/nylas';
@@ -15,13 +14,13 @@ describe('File', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const headers = new Map();

--- a/__tests__/folder-spec.js
+++ b/__tests__/folder-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
 import Folder from '../src/models/folder';
 
@@ -15,13 +14,13 @@ describe('Label', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -2,7 +2,6 @@ import fetch from 'node-fetch';
 const { Response } = jest.requireActual('node-fetch');
 
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import JobStatus from '../src/models/job-status';
 import OutboxJobStatus from '../src/models/outbox-job-status';
 
@@ -19,15 +18,13 @@ describe('Job Status', () => {
   const testAccessToken = 'test-access-token';
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection(testAccessToken, {
-      clientId: 'myClientId',
-    });
+    testContext.connection = nylasClient.with(testAccessToken);
     testContext.listApiResponse = [
       {
         id: 'dcjq3eyd5svm7cnz055tb6cry',

--- a/__tests__/label-spec.js
+++ b/__tests__/label-spec.js
@@ -1,4 +1,3 @@
-import NylasConnection from '../src/nylas-connection';
 import { Label } from '../src/models/folder';
 import fetch from 'node-fetch';
 import Nylas from '../src/nylas';
@@ -15,13 +14,13 @@ describe('Label', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/management-account-spec.js
+++ b/__tests__/management-account-spec.js
@@ -5,8 +5,9 @@ import ManagementAccount from '../src/models/management-account';
 describe('ManagementAccount', () => {
   const CLIENT_ID = 'abc';
   const ACCOUNT_ID = '8rilmlwuo4zmpjedz8bcplclk';
+  let nylasClient;
   beforeEach(() => {
-    Nylas.config({
+    nylasClient = new Nylas({
       clientId: CLIENT_ID,
       clientSecret: 'xyz',
     });
@@ -14,7 +15,7 @@ describe('ManagementAccount', () => {
 
   describe('list', () => {
     test('should do a GET request to get the account list', done => {
-      Nylas.accounts.connection.request = jest.fn(() =>
+      nylasClient.accounts.connection.request = jest.fn(() =>
         Promise.resolve([
           {
             account_id: '8rilmlwuo4zmpjedz8bcplclk',
@@ -31,7 +32,7 @@ describe('ManagementAccount', () => {
           },
         ])
       );
-      Nylas.accounts.list({}, (err, accounts) => {
+      nylasClient.accounts.list({}, (err, accounts) => {
         expect(accounts.length).toEqual(1);
         expect(accounts[0].id).toEqual('8rilmlwuo4zmpjedz8bcplclk');
         expect(accounts[0].billingState).toEqual('paid');
@@ -43,7 +44,7 @@ describe('ManagementAccount', () => {
         expect(accounts[0].metadata).toEqual({
           test: 'true',
         });
-        expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+        expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
           method: 'GET',
           qs: { limit: 100, offset: 0 },
           path: `/a/${CLIENT_ID}/accounts`,
@@ -70,18 +71,20 @@ describe('ManagementAccount', () => {
           ])
         )
         .mockReturnValueOnce(Promise.resolve({ success: 'true' }));
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.upgrade())
         .then(resp => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledTimes(
+            2
+          );
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
             path: `/a/${CLIENT_ID}/accounts`,
           });
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/upgrade`,
           });
@@ -108,18 +111,20 @@ describe('ManagementAccount', () => {
           ])
         )
         .mockReturnValueOnce(Promise.resolve({ success: 'true' }));
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.downgrade())
         .then(resp => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledTimes(
+            2
+          );
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
             path: `/a/${CLIENT_ID}/accounts`,
           });
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/downgrade`,
           });
@@ -146,18 +151,20 @@ describe('ManagementAccount', () => {
           ])
         )
         .mockReturnValueOnce(Promise.resolve({ success: 'true' }));
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.revokeAll())
         .then(resp => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledTimes(
+            2
+          );
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
             path: `/a/${CLIENT_ID}/accounts`,
           });
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
             body: { keep_access_token: undefined },
@@ -182,18 +189,20 @@ describe('ManagementAccount', () => {
           ])
         )
         .mockReturnValueOnce(Promise.resolve({ success: 'true' }));
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.revokeAll('abc123'))
         .then(resp => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledTimes(
+            2
+          );
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
             path: `/a/${CLIENT_ID}/accounts`,
           });
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/revoke-all`,
             body: { keep_access_token: 'abc123' },
@@ -235,12 +244,12 @@ describe('ManagementAccount', () => {
             updated_at: 1544658529,
           })
         );
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.ipAddresses())
         .then(resp => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             path: `/a/${CLIENT_ID}/ip_addresses`,
           });
@@ -274,18 +283,20 @@ describe('ManagementAccount', () => {
             updated_at: 1563496685,
           })
         );
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.tokenInfo('abc123'))
         .then(resp => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledTimes(
+            2
+          );
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
             path: `/a/${CLIENT_ID}/accounts`,
           });
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/token-info`,
             body: { access_token: 'abc123' },
@@ -314,18 +325,20 @@ describe('ManagementAccount', () => {
           ])
         )
         .mockReturnValueOnce(Promise.reject('Error: No access_token passed.'));
-      Nylas.accounts.connection.request = requestMock;
-      Nylas.accounts
+      nylasClient.accounts.connection.request = requestMock;
+      nylasClient.accounts
         .first()
         .then(account => account.tokenInfo())
         .catch(() => {
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledTimes(2);
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledTimes(
+            2
+          );
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'GET',
             qs: { limit: 1, offset: 0 },
             path: `/a/${CLIENT_ID}/accounts`,
           });
-          expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+          expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
             method: 'POST',
             path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}/token-info`,
             body: { access_token: undefined },
@@ -337,10 +350,12 @@ describe('ManagementAccount', () => {
 
   describe('save', () => {
     test('Should update only metadata when saving', async done => {
-      Nylas.accounts.connection = new NylasConnection('123', {
+      nylasClient.accounts.connection = new NylasConnection('123', {
         clientId: CLIENT_ID,
       });
-      Nylas.accounts.connection.request = jest.fn(() => Promise.resolve({}));
+      nylasClient.accounts.connection.request = jest.fn(() =>
+        Promise.resolve({})
+      );
       const accJson = {
         account_id: '8rilmlwuo4zmpjedz8bcplclk',
         billing_state: 'paid',
@@ -352,7 +367,7 @@ describe('ManagementAccount', () => {
         trial: false,
       };
       const account = new ManagementAccount(
-        Nylas.accounts.connection,
+        nylasClient.accounts.connection,
         CLIENT_ID,
         accJson
       );
@@ -361,7 +376,7 @@ describe('ManagementAccount', () => {
       };
 
       account.save().then(() => {
-        expect(Nylas.accounts.connection.request).toHaveBeenCalledWith({
+        expect(nylasClient.accounts.connection.request).toHaveBeenCalledWith({
           method: 'PUT',
           path: `/a/${CLIENT_ID}/accounts/${ACCOUNT_ID}`,
           qs: {},

--- a/__tests__/message-spec.js
+++ b/__tests__/message-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import File from '../src/models/file';
 import Message from '../src/models/message';
 import { Label } from '../src/models/folder';
@@ -19,13 +18,13 @@ describe('Message', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/neural-spec.js
+++ b/__tests__/neural-spec.js
@@ -1,6 +1,5 @@
 import Nylas from '../src/nylas';
 import File from '../src/models/file';
-import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
 
 jest.mock('node-fetch', () => {
@@ -15,13 +14,13 @@ describe('Neural', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = Nylas.with('123');
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
   });
 
@@ -286,10 +285,6 @@ describe('Neural', () => {
           ],
         },
       ];
-
-      testContext = {};
-      testContext.connection = new NylasConnection('123', { clientId: 'foo' });
-      jest.spyOn(testContext.connection, 'request');
 
       const response = () => {
         return {

--- a/__tests__/outbox-spec.js
+++ b/__tests__/outbox-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
 import Draft from '../src/models/draft';
 import OutboxMessage from '../src/models/outbox-message';
@@ -18,13 +17,13 @@ describe('Outbox', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/resource-spec.js
+++ b/__tests__/resource-spec.js
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import Resource from '../src/models/resource';
 
 jest.mock('node-fetch', () => {
@@ -17,15 +16,13 @@ describe('Resource', () => {
   const testAccessToken = 'test-access-token';
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection(testAccessToken, {
-      clientId: 'myClientId',
-    });
+    testContext.connection = nylasClient.with(testAccessToken);
     testContext.apiResponse = [
       {
         object: 'room_resource',

--- a/__tests__/restful-model-collection-spec.js
+++ b/__tests__/restful-model-collection-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import RestfulModelCollection from '../src/models/restful-model-collection';
 import Draft from '../src/models/draft';
 import Event from '../src/models/event';
@@ -9,14 +8,12 @@ describe('RestfulModelCollection', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('test-access-token', {
-      clientId: 'foo',
-    });
+    testContext.connection = nylasClient.with('test-access-token');
     testContext.connection.request = jest.fn(() => Promise.resolve());
     testContext.collection = new RestfulModelCollection(
       Thread,

--- a/__tests__/scheduler-restful-model-collection-spec.js
+++ b/__tests__/scheduler-restful-model-collection-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
 import SchedulerTimeSlot from '../src/models/scheduler-time-slot';
 import SchedulerBookingRequest from '../src/models/scheduler-booking-request';
@@ -16,15 +15,13 @@ describe('SchedulerRestfulModelCollection', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('abc-123', {
-      clientId: 'myClientId',
-    });
+    testContext.connection = nylasClient.with('abc-123');
     jest.spyOn(testContext.connection, 'request');
   });
 

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import fetch from 'node-fetch';
 import Scheduler, {
   SchedulerAvailableCalendars,
@@ -18,13 +17,13 @@ describe('Scheduler', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/thread-spec.js
+++ b/__tests__/thread-spec.js
@@ -1,5 +1,4 @@
 import Nylas from '../src/nylas';
-import NylasConnection from '../src/nylas-connection';
 import Thread from '../src/models/thread';
 import Message from '../src/models/message';
 import Folder, { Label } from '../src/models/folder';
@@ -18,13 +17,13 @@ describe('Thread', () => {
   let testContext;
 
   beforeEach(() => {
-    Nylas.config({
+    const nylasClient = new Nylas({
       clientId: 'myClientId',
       clientSecret: 'myClientSecret',
       apiServer: 'https://api.nylas.com',
     });
     testContext = {};
-    testContext.connection = new NylasConnection('123', { clientId: 'foo' });
+    testContext.connection = nylasClient.with('123');
     jest.spyOn(testContext.connection, 'request');
 
     const response = receivedBody => {

--- a/__tests__/webhook-spec.js
+++ b/__tests__/webhook-spec.js
@@ -11,8 +11,10 @@ describe('Webhook', () => {
     triggers: ['message.opened', 'message.link_clicked'],
     version: '2.0',
   };
+  let nylasClient;
+
   beforeEach(() => {
-    Nylas.config({
+    nylasClient = new Nylas({
       clientId: CLIENT_ID,
       clientSecret: 'xyz',
     });
@@ -21,13 +23,13 @@ describe('Webhook', () => {
   describe('list', () => {
     test('Should do a GET request to get the webhook list', done => {
       expect.assertions(3);
-      Nylas.webhooks.connection.request = jest.fn(() =>
+      nylasClient.webhooks.connection.request = jest.fn(() =>
         Promise.resolve([webhookJSON])
       );
-      return Nylas.webhooks.list({}, (err, webhooks) => {
+      return nylasClient.webhooks.list({}, (err, webhooks) => {
         expect(webhooks.length).toEqual(1);
         expect(webhooks[0].id).toEqual(WEBHOOK_ID);
-        expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
+        expect(nylasClient.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'GET',
           qs: { limit: 100, offset: 0 },
           path: `/a/${CLIENT_ID}/webhooks`,
@@ -40,12 +42,12 @@ describe('Webhook', () => {
   describe('Get an existing webhook', () => {
     test('Should do a GET request to /a/<client_id>/webhooks/<id>', done => {
       expect.assertions(2);
-      Nylas.webhooks.connection.request = jest.fn(() =>
+      nylasClient.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
       );
-      return Nylas.webhooks.find(WEBHOOK_ID).then(webhookResp => {
+      return nylasClient.webhooks.find(WEBHOOK_ID).then(webhookResp => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
-        expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
+        expect(nylasClient.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'GET',
           path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},
@@ -58,10 +60,10 @@ describe('Webhook', () => {
   describe('Create a new webhook', () => {
     test('Should do a POST request to /a/<client_id>/webhooks', done => {
       expect.assertions(2);
-      Nylas.webhooks.connection.request = jest.fn(() =>
+      nylasClient.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
       );
-      const webhook = Nylas.webhooks.build({
+      const webhook = nylasClient.webhooks.build({
         applicationId: CLIENT_ID,
         callbackUrl: 'https://wwww.myapp.com/webhook',
         state: 'active',
@@ -70,7 +72,7 @@ describe('Webhook', () => {
       });
       return webhook.save().then(webhookResp => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
-        expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
+        expect(nylasClient.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'POST',
           path: `/a/${CLIENT_ID}/webhooks`,
           qs: {},
@@ -88,10 +90,10 @@ describe('Webhook', () => {
   describe('Update an existing webhook', () => {
     test('Should do a PUT request to /a/<client_id>/webhooks/<id>', done => {
       expect.assertions(2);
-      Nylas.webhooks.connection.request = jest.fn(() =>
+      nylasClient.webhooks.connection.request = jest.fn(() =>
         Promise.resolve(webhookJSON)
       );
-      const webhook = Nylas.webhooks.build({
+      const webhook = nylasClient.webhooks.build({
         id: WEBHOOK_ID,
         applicationId: CLIENT_ID,
         callbackUrl: 'https://wwww.myapp.com/webhook',
@@ -101,7 +103,7 @@ describe('Webhook', () => {
       });
       return webhook.save().then(webhookResp => {
         expect(webhookResp.toJSON()).toEqual(webhookJSON);
-        expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
+        expect(nylasClient.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'PUT',
           path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},
@@ -115,8 +117,10 @@ describe('Webhook', () => {
   describe('Delete an existing webhook', () => {
     test('Should do a DELETE request to /a/<client_id>/webhooks/<id>', done => {
       expect.assertions(1);
-      Nylas.webhooks.connection.request = jest.fn(() => Promise.resolve(null));
-      const webhook = Nylas.webhooks.build({
+      nylasClient.webhooks.connection.request = jest.fn(() =>
+        Promise.resolve(null)
+      );
+      const webhook = nylasClient.webhooks.build({
         id: WEBHOOK_ID,
         applicationId: CLIENT_ID,
         callbackUrl: 'https://wwww.myapp.com/webhook',
@@ -124,8 +128,8 @@ describe('Webhook', () => {
         triggers: ['message.opened', 'message.link_clicked'],
         version: '2.0',
       });
-      return Nylas.webhooks.delete(webhook).then(() => {
-        expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
+      return nylasClient.webhooks.delete(webhook).then(() => {
+        expect(nylasClient.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'DELETE',
           path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},
@@ -137,9 +141,11 @@ describe('Webhook', () => {
 
     test('Should DELETE webhook by ID', done => {
       expect.assertions(1);
-      Nylas.webhooks.connection.request = jest.fn(() => Promise.resolve(null));
-      return Nylas.webhooks.delete(WEBHOOK_ID).then(() => {
-        expect(Nylas.webhooks.connection.request).toHaveBeenCalledWith({
+      nylasClient.webhooks.connection.request = jest.fn(() =>
+        Promise.resolve(null)
+      );
+      return nylasClient.webhooks.delete(WEBHOOK_ID).then(() => {
+        expect(nylasClient.webhooks.connection.request).toHaveBeenCalledWith({
           method: 'DELETE',
           path: `/a/${CLIENT_ID}/webhooks/${WEBHOOK_ID}`,
           qs: {},

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -16,26 +16,26 @@ import ApplicationDetails, {
 } from './models/application-details';
 
 class Nylas {
-  static clientId = '';
-  static get clientSecret(): string {
+  clientId = '';
+  get clientSecret(): string {
     return config.clientSecret;
   }
-  static set clientSecret(newClientSecret: string) {
+  set clientSecret(newClientSecret: string) {
     config.setClientSecret(newClientSecret);
   }
-  static get apiServer(): string | null {
+  get apiServer(): string | null {
     return config.apiServer;
   }
-  static set apiServer(newApiServer: string | null) {
+  set apiServer(newApiServer: string | null) {
     config.setApiServer(newApiServer);
   }
-  static accounts:
+  accounts:
     | ManagementModelCollection<ManagementAccount>
     | RestfulModelCollection<Account>;
-  static connect: Connect;
-  static webhooks: ManagementModelCollection<Webhook>;
+  connect: Connect;
+  webhooks: ManagementModelCollection<Webhook>;
 
-  static config(config: NylasConfig): Nylas {
+  constructor(config: NylasConfig) {
     if (config.apiServer && config.apiServer.indexOf('://') === -1) {
       throw new Error(
         'Please specify a fully qualified URL for the API Server.'
@@ -75,18 +75,18 @@ class Nylas {
     return this;
   }
 
-  static clientCredentials(): boolean {
+  clientCredentials(): boolean {
     return this.clientId != null && this.clientSecret != null;
   }
 
-  static with(accessToken: string): NylasConnection {
+  with(accessToken: string): NylasConnection {
     if (!accessToken) {
       throw new Error('This function requires an access token');
     }
     return new NylasConnection(accessToken, { clientId: this.clientId });
   }
 
-  static application(
+  application(
     options?: ApplicationDetailsProperties
   ): Promise<ApplicationDetails> {
     if (!this.clientId) {
@@ -115,7 +115,7 @@ class Nylas {
     });
   }
 
-  static exchangeCodeForToken(
+  exchangeCodeForToken(
     code: string,
     callback?: (error: Error | null, accessToken?: string) => void
   ): Promise<AccessToken> {
@@ -161,7 +161,7 @@ class Nylas {
       );
   }
 
-  static urlForAuthentication(options: AuthenticateUrlConfig): string {
+  urlForAuthentication(options: AuthenticateUrlConfig): string {
     if (!this.clientId) {
       throw new Error(
         'urlForAuthentication() cannot be called until you provide a clientId via config()'
@@ -193,8 +193,8 @@ class Nylas {
    * Revoke a single access token
    * @param accessToken The access token to revoke
    */
-  static revoke(accessToken: string): Promise<void> {
-    return Nylas.with(accessToken)
+  revoke(accessToken: string): Promise<void> {
+    return this.with(accessToken)
       .request({
         method: 'POST',
         path: '/oauth/revoke',

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -75,10 +75,19 @@ class Nylas {
     return this;
   }
 
+  /**
+   * Checks if the Nylas instance has been configured with credentials
+   * @return True if the Nylas instance has been configured with credentials
+   */
   clientCredentials(): boolean {
     return this.clientId != null && this.clientSecret != null;
   }
 
+  /**
+   * Configure a NylasConnection instance to access a user's resources
+   * @param accessToken The access token to access the user's resources
+   * @return The configured NylasConnection instance
+   */
   with(accessToken: string): NylasConnection {
     if (!accessToken) {
       throw new Error('This function requires an access token');
@@ -86,6 +95,11 @@ class Nylas {
     return new NylasConnection(accessToken, { clientId: this.clientId });
   }
 
+  /**
+   * Return information about a Nylas application
+   * @param options Application details to overwrite
+   * @return Information about the Nylas application
+   */
   application(
     options?: ApplicationDetailsProperties
   ): Promise<ApplicationDetails> {
@@ -115,6 +129,12 @@ class Nylas {
     });
   }
 
+  /**
+   * Exchange an authorization code for an access token
+   * @param code Application details to overwrite
+   * @param callback Application details to overwrite
+   * @return Information about the Nylas application
+   */
   exchangeCodeForToken(
     code: string,
     callback?: (error: Error | null, accessToken?: string) => void
@@ -161,6 +181,11 @@ class Nylas {
       );
   }
 
+  /**
+   * Build the URL for authenticating users to your application via Hosted Authentication
+   * @param options Configuration for the authentication process
+   * @return The URL for hosted authentication
+   */
   urlForAuthentication(options: AuthenticateUrlConfig): string {
     if (!this.clientId) {
       throw new Error(


### PR DESCRIPTION
# Description
This PR converts the SDK's entry point, the `Nylas` class, from being static to non-static. The reason behind this change is to enable multiple configurations and more reuse of the `Nylas` object. Note that this also changes all the class's variables and functions to non-static.

# Usage
The new way to init the Node SDK is like so:
```js
const Nylas = require('nylas');
const nylasClient = new Nylas({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylasConnection = nylasClient.with('access_token');

// Get all messages found in the user's inbox
nylasConnection.messages.list().then(messages => console.log(messages));

// Access to variables belonging to Nylas
const clientId = nylasClient.clientId;
const clientSecret = nylasClient.clientSecret;
const apiServer = nylasClient.apiServer;
const accounts = nylasClient.accounts;
const connect = nylasClient.connect;
const webhooks = nylasClient.webhooks;

// Access to functions belonging to Nylas
nylasClient.application();
nylasClient.exchangeCodeForToken("code");
nylasClient.urlForAuthentication({
  "redirectURI": "url"
});
nylasClient.revoke("access_token");
```

Where as previously:
```js
const Nylas = require('nylas');
Nylas.config({clientId: 'clientId', clientSecret: 'clientSecret'});
const nylas = Nylas.with('access_token');

// Get all messages found in the user's inbox
nylas.messages.list().then(messages => console.log(messages));

// Access to variables belonging to Nylas
const clientId = Nylas.clientId;
const clientSecret = Nylas.clientSecret;
const apiServer = Nylas.apiServer;
const accounts = Nylas.accounts;
const connect = Nylas.connect;
const webhooks = Nylas.webhooks;

// Access to functions belonging to Nylas
Nylas.application();
Nylas.exchangeCodeForToken("code");
Nylas.urlForAuthentication({
  "redirectURI": "url"
});
Nylas.revoke("access_token");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.