### PR TITLE
Tunneling fixes

### DIFF
--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -18,7 +18,7 @@ const buildTunnelWebhook = (
   callbackDomain: string,
   tunnelId: string,
   triggers: WebhookTriggers[]
-) => {
+): Promise<Webhook> => {
   const callbackUrl = `https://${callbackDomain}/${tunnelId}`;
   return nylasClient.webhooks
     .build({
@@ -48,7 +48,7 @@ export const openWebhookTunnel = (config: {
   onConnect?: (wsClient: WebSocketClient) => void;
   region?: Region;
   triggers?: WebhookTriggers[];
-}) => {
+}): Promise<Webhook> => {
   const triggers = config.triggers || DEFAULT_WEBHOOK_TRIGGERS;
   const region = config.region || DEFAULT_REGION;
   const { websocketDomain, callbackDomain } = regionConfig[region];

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -12,14 +12,19 @@ import { WebhookDelta } from '../models/webhook-notification';
 
 /**
  * Create a webhook to the Nylas forwarding service which will pass messages to our websocket
+ * @param nylasClient The configured Nylas application
+ * @param callbackDomain The domain name of the callback
+ * @param tunnelPath The path to the tunnel
+ * @param triggers The list of triggers to subscribe to
+ * @return The webhook details response from the API
  */
 const buildTunnelWebhook = (
   nylasClient: Nylas,
   callbackDomain: string,
-  tunnelId: string,
+  tunnelPath: string,
   triggers: WebhookTriggers[]
 ): Promise<Webhook> => {
-  const callbackUrl = `https://${callbackDomain}/${tunnelId}`;
+  const callbackUrl = `https://${callbackDomain}/${tunnelPath}`;
   return nylasClient.webhooks
     .build({
       callbackUrl,
@@ -31,6 +36,7 @@ const buildTunnelWebhook = (
 };
 
 /**
+ * Open a webhook tunnel and register it with the Nylas API
  * 1. Creates a UUID
  * 2. Opens a websocket connection to Nylas' webhook forwarding service,
  *    with the UUID as a header
@@ -38,6 +44,9 @@ const buildTunnelWebhook = (
  *
  * When an event is received by the forwarding service, it will push directly to this websocket
  * connection
+ *
+ * @param config Configuration for the webhook tunnel, including callback functions, region, and events to subscribe to
+ * @return The webhook details response from the API
  */
 export const openWebhookTunnel = (config: {
   nylasClient: Nylas;

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -56,7 +56,7 @@ export const openWebhookTunnel = (config: {
   // This UUID will map our websocket to a webhook in the forwarding server
   const tunnelId = uuidv4();
 
-  var client = new WebSocketClient({ closeTimeout: 60000 });
+  const client = new WebSocketClient({ closeTimeout: 60000 });
 
   client.on('connectFailed', function(error) {
     config.onConnectFail && config.onConnectFail(error);

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -76,7 +76,8 @@ export const openWebhookTunnel = (config: {
     connection.on('message', function(message) {
       // This shouldn't happen. If any of these are seen, open an issue
       if (message.type === 'binary') {
-        console.log('Unknown binary message received');
+        config.onError &&
+          config.onError(new Error('Unknown binary message received'));
         return;
       }
 


### PR DESCRIPTION
# Description
Just noticed some things testing #366:
- `message.utf8Data.body` is doubly serialized so we need to deserialize twice. It's also in API-json format not `WebhookNotificationProperties`, so we need to convert it from JSON to WebhookDelta
- Replace console.log line with error
- Replace var with consst
- Added return types and jsdoc formatted comments

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.