### PR TITLE
Delete tunnel webhook on exit

### DIFF
--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -20,9 +20,11 @@ const deleteTunnelWebhook = (
   nylasWebhook: Webhook
 ): void => {
   if (nylasWebhook && nylasWebhook.id) {
+    /* eslint-disable no-console */
     console.log(
       'Shutting down the webhook tunnel and deleting id: ' + nylasWebhook.id
     );
+    /* eslint-enable no-console */
     nylasClient.webhooks.delete(nylasWebhook);
   }
 };


### PR DESCRIPTION
# Description
Upon exiting somehow, we should clean up by deleting the created webhook. Couple of notes:

- Only invoke `deleteTunnelWebhook` on exit and point the other signals to `exit`, otherwise we override the default `SIGTERM`, etc. behavour: https://stackoverflow.com/a/14372355/1995715
- Can't listen on `SIGKILL`: https://nodejs.org/api/process.html#process_signal_events

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.