### PR TITLE
Remove `routePrefix` config from server bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 7.0.0-canary.2 / Unreleased
+* Remove `routePrefix` config from server bindings
+
 ### 7.0.0-canary.1 / 2022-06-18
 * Fix dependency issue when using websocket tunneling service
 

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -19,7 +19,6 @@ export enum ServerEvents {
 
 export type ServerBindingOptions = {
   defaultScopes: Scope[];
-  routePrefix?: string;
   clientUri?: string;
 };
 
@@ -27,7 +26,6 @@ export abstract class ServerBinding extends EventEmitter
   implements ServerBindingOptions {
   nylasClient: Nylas;
   defaultScopes: Scope[];
-  routePrefix?: string;
   clientUri?: string;
 
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
@@ -38,7 +36,6 @@ export abstract class ServerBinding extends EventEmitter
     super();
     this.nylasClient = nylasClient;
     this.defaultScopes = options.defaultScopes;
-    this.routePrefix = options.routePrefix;
     this.clientUri = options.clientUri;
   }
 

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -30,7 +30,6 @@ export abstract class ServerBinding extends EventEmitter
   routePrefix?: string;
   clientUri?: string;
 
-  static DEFAULT_ROUTE_PREFIX = '/nylas';
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
   private _untypedOn = this.on;
   private _untypedEmit = this.emit;
@@ -113,16 +112,4 @@ export abstract class ServerBinding extends EventEmitter
   protected handleDeltaEvent = (d: WebhookDelta): void => {
     d.type && this.emit(d.type as WebhookTriggers, d);
   };
-
-  /**
-   * Builds the full route with a path
-   * @param path The path to append
-   * @return The full route
-   */
-  protected buildRoute(path: string): string {
-    const prefix = this.routePrefix
-      ? this.routePrefix
-      : ServerBinding.DEFAULT_ROUTE_PREFIX;
-    return prefix + path;
-  }
 }


### PR DESCRIPTION
# Description
This PR removes confusion as behind the scenes, `buildRoute` was taking either `routPrefix` or `/nylas` (if unset) and appending it to the paths. So if someone mounts the middleware at `/nylas`, the routes would have been `/nylas/nylas/...`. 

# Usage
If we want to mount endpoints to /nylas:
```js
const express = require('express');
const Nylas = require('nylas');
const { ServerBindings } = require('nylas/lib/config');

// The port the express app will run on
const port = 9000;
// The uri for the frontend
const clientUri = 'http://localhost:3000';

// Initialize an instance of the Nylas SDK using the client credentials
const nylasClient = new Nylas({
    clientId: clientId,
    clientSecret: clientSecret,
});
const app = express();
app.listen(port, () => console.log('App listening on port ' + port));

// Use the express bindings provided by the SDK and pass in additional configuration such as auth scopes
const nylasMiddleware = new ServerBindings
    .express(nylasClient, {
        defaultScopes: [
            Scope.EmailModify,
            Scope.EmailSend,
        ],
        clientUri,
    })
    .buildMiddleware();

// Mount it on /nylas
app.use('/nylas', nylasMiddleware);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.