### PR TITLE
[v7.0.0] Implement callback instead of event emitter for mailbox token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * `/exchange-mailbox-token` now uses a callback instead of emitting an event
+* Add CSRF Token Generation support for the authentication process in the server bindings
 
 ### 7.0.0-canary.2 / 2022-06-21
 * Remove `routePrefix` config from server bindings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* `/exchange-mailbox-token` now uses a callback instead of emitting an event
+
 ### 7.0.0-canary.2 / 2022-06-21
 * Remove `routePrefix` config from server bindings
 * Remove `cors` configuration from server bindings

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -81,10 +81,8 @@ export default class ExpressBinding extends ServerBinding {
         const accessTokenObj = await this.nylasClient.exchangeCodeForToken(
           req.body.token
         );
-        this.emit(ServerEvents.TokenExchange, {
-          accessTokenObj,
-          res,
-        });
+
+        await this.exchangeMailboxTokenCallback(accessTokenObj, res);
 
         // If the callback event already sent a response then we don't need to do anything
         if (!res.writableEnded) {

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -65,8 +65,8 @@ export default class ExpressBinding extends ServerBinding {
 
     router.post('/generate-auth-url', async (req, res) => {
       let state = '';
-      if (this.tokenExchangeOpts) {
-        state = await this.tokenExchangeOpts.generateCsrfToken(req);
+      if (this.csrfTokenExchangeOpts) {
+        state = await this.csrfTokenExchangeOpts.generateCsrfToken(req);
       }
       const authUrl = this.nylasClient.urlForAuthentication({
         loginHint: req.body.email_address,
@@ -79,9 +79,9 @@ export default class ExpressBinding extends ServerBinding {
 
     router.post('/exchange-mailbox-token', async (req, res) => {
       try {
-        if (this.tokenExchangeOpts) {
+        if (this.csrfTokenExchangeOpts) {
           const csrfToken = req.body.csrfToken;
-          const isValidToken = await this.tokenExchangeOpts.validateCsrfToken(
+          const isValidToken = await this.csrfTokenExchangeOpts.validateCsrfToken(
             csrfToken,
             req
           );

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -1,10 +1,6 @@
 import Nylas from '../nylas';
 import express, { RequestHandler, Response, Router } from 'express';
-import {
-  ServerBindingOptions,
-  ServerBinding,
-  ServerEvents,
-} from './server-binding';
+import { ServerBindingOptions, ServerBinding } from './server-binding';
 import bodyParser from 'body-parser';
 import { WebhookDelta } from '../models/webhook-notification';
 

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -12,10 +12,6 @@ import {
 } from '../services/tunnel';
 
 type Middleware = Router;
-
-export enum ServerEvents {
-  TokenExchange = 'token-exchange',
-}
 type ServerResponse = Response;
 type ExchangeMailboxTokenCallback = (
   accessToken: AccessToken,
@@ -50,20 +46,14 @@ export abstract class ServerBinding extends EventEmitter
   abstract buildMiddleware(): Middleware;
 
   // Taken from the best StackOverflow answer of all time https://stackoverflow.com/a/56228127
-  public on = <K extends WebhookTriggers | ServerEvents>(
+  public on = <K extends WebhookTriggers>(
     event: K,
-    listener: (
-      payload: K extends WebhookTriggers
-        ? WebhookDelta
-        : { accessTokenObj: AccessToken; res: Response }
-    ) => void
+    listener: (payload: WebhookDelta) => void
   ): this => this._untypedOn(event, listener);
 
-  public emit = <K extends WebhookTriggers | ServerEvents>(
+  public emit = <K extends WebhookTriggers>(
     event: K,
-    payload: K extends WebhookTriggers
-      ? WebhookDelta
-      : { accessTokenObj: AccessToken; res: Response }
+    payload: WebhookDelta
   ): boolean => this._untypedEmit(event, payload);
 
   /**

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -16,9 +16,15 @@ type Middleware = Router;
 export enum ServerEvents {
   TokenExchange = 'token-exchange',
 }
+type ServerResponse = Response;
+type ExchangeMailboxTokenCallback = (
+  accessToken: AccessToken,
+  res: ServerResponse
+) => void;
 
 export type ServerBindingOptions = {
   defaultScopes: Scope[];
+  exchangeMailboxTokenCallback: ExchangeMailboxTokenCallback;
   clientUri?: string;
 };
 
@@ -26,6 +32,7 @@ export abstract class ServerBinding extends EventEmitter
   implements ServerBindingOptions {
   nylasClient: Nylas;
   defaultScopes: Scope[];
+  exchangeMailboxTokenCallback: ExchangeMailboxTokenCallback;
   clientUri?: string;
 
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
@@ -36,6 +43,7 @@ export abstract class ServerBinding extends EventEmitter
     super();
     this.nylasClient = nylasClient;
     this.defaultScopes = options.defaultScopes;
+    this.exchangeMailboxTokenCallback = options.exchangeMailboxTokenCallback;
     this.clientUri = options.clientUri;
   }
 


### PR DESCRIPTION
# Description
To ensure that the token exchange response is properly overridden, we need to use a callback instead of emitting an event as we can’t guarantee that the event gets emitted in-order before we return the response from the API. Especially if the user wants to implement any async code.

# Usage
Now, when configuring your server binding, `exchangeMailboxTokenCallback` is a required field and takes a reference to a function that accepts two parameters; `accessToken: AccessToken, res: ServerResponse`. Currently, `ServerResponse` is just `Express.Response` but it will be expanded to include the response object of other frameworks. 

```js
const express = require('express');

const Nylas = require('nylas');
const { Scope } = require('nylas/lib/models/connect');
const { ServerBindings } = require('nylas/lib/config');

// Initialize an instance of the Nylas SDK using the client credentials
const nylasClient = new Nylas({
    clientId: clientId,
    clientSecret: clientSecret,
});

const app = express();

const exchangeMailboxTokenCallback = async (accessTokenObj, res) => {
    const accessToken = accessTokenObj.accessToken
    const emailAddress = accessTokenObj.emailAddress

    user = await db.createUser({
        accessToken,
        emailAddress,
    })

    res.json({
        id: user.id,
        emailAddress: user.emailAddress,
    });
}

const expressBinding = new ServerBindings.express(nylasClient, {
    defaultScopes: [
        Scope.EmailModify,
        Scope.EmailSend,
    ],
    exchangeMailboxTokenCallback,
});
const nylasMiddleware = expressBinding.buildMiddleware();
app.use('/nylas', nylasMiddleware);
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.