### PR TITLE
Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`
+
 ### 6.4.2 / 2022-06-14
 * Add `Message.save()` functionality for updating existing messages
 * Add missing `reminderMinutes` field in `Event`

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -295,7 +295,7 @@ export class SchedulerBooking extends Model
     }),
     confirmationEmailToHost: Attributes.Boolean({
       modelKey: 'confirmationEmailToHost',
-      jsonKey: 'confirmation_email_to_host',
+      jsonKey: 'confirmation_emails_to_host',
     }),
     confirmationMethod: Attributes.String({
       modelKey: 'confirmationMethod',


### PR DESCRIPTION
# Description
This PR fixes the json value mapped to `confermationEmailToHost` as "email" is actually plural. Adjusting the actual model variable name will be introduced in v7 as it's a breaking change.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.