### PR TITLE
Add `interval_minutes` field in Scheduler booking config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add `interval_minutes` field in Scheduler booking config
 * Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`
 
 ### 6.4.2 / 2022-06-14

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -5,6 +5,7 @@ import Scheduler, {
   SchedulerAvailableCalendars,
 } from '../src/models/scheduler';
 import Calendar from '../src/models/calendar';
+import { SchedulerConfig } from '../src/models/scheduler';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -143,6 +144,30 @@ describe('Scheduler', () => {
         });
         done();
       });
+    });
+
+    test('Should throw an error if SchedulerBooking.intervalMinutes is invalid', done => {
+      // Cannot be set to 0
+      testContext.scheduler.config = new SchedulerConfig({
+        booking: {
+          intervalMinutes: 0,
+        },
+      });
+      expect(() => testContext.scheduler.save()).toThrow();
+
+      // Cannot be negative
+      testContext.scheduler.config.booking.intervalMinutes = -1;
+      expect(() => testContext.scheduler.save()).toThrow();
+
+      // Has to be divisible by 5
+      testContext.scheduler.config.booking.intervalMinutes = 3;
+      expect(() => testContext.scheduler.save()).toThrow();
+
+      // If valid, don't throw
+      testContext.scheduler.config.booking.intervalMinutes = 15;
+      expect(() => testContext.scheduler.save()).not.toThrow();
+
+      done();
     });
   });
 

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -246,6 +246,7 @@ export type SchedulerBookingProperties = {
   minBookingNotice?: number;
   minBuffer?: number;
   minCancellationNotice?: number;
+  intervalMinutes?: number;
   nameFieldHidden?: boolean;
   openingHours?: SchedulerBookingOpeningHoursProperties[];
   schedulingMethod?: string;
@@ -264,6 +265,7 @@ export class SchedulerBooking extends Model
   minBookingNotice?: number;
   minBuffer?: number;
   minCancellationNotice?: number;
+  intervalMinutes?: number;
   nameFieldHidden?: boolean;
   openingHours?: SchedulerBookingOpeningHours[];
   schedulingMethod?: string;
@@ -312,6 +314,10 @@ export class SchedulerBooking extends Model
     minCancellationNotice: Attributes.Number({
       modelKey: 'minCancellationNotice',
       jsonKey: 'min_cancellation_notice',
+    }),
+    intervalMinutes: Attributes.Number({
+      modelKey: 'intervalMinutes',
+      jsonKey: 'interval_minutes',
     }),
     nameFieldHidden: Attributes.Boolean({
       modelKey: 'nameFieldHidden',

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -554,6 +554,7 @@ export default class Scheduler extends RestfulModel
   }
 
   save(params: {} | SaveCallback = {}, callback?: SaveCallback): Promise<this> {
+    this.validate();
     return super.save(params, callback);
   }
 
@@ -601,5 +602,17 @@ export default class Scheduler extends RestfulModel
       },
       baseUrl: this.baseUrl,
     });
+  }
+
+  private validate(): void {
+    const bookingIntervalMinutes = this.config?.booking?.intervalMinutes;
+    if (
+      bookingIntervalMinutes !== undefined &&
+      (bookingIntervalMinutes <= 0 || bookingIntervalMinutes % 5 != 0)
+    ) {
+      throw new Error(
+        'SchedulerBooking.intervalMinutes must be a non-zero positive integer, divisible by 5.'
+      );
+    }
   }
 }


### PR DESCRIPTION
# Description
This PR adds the `intervalMinutes` field in `ScheduleBooking`. Note that this field only takes a non-zero, positive integer that's divisible by 5. Else we have validation that runs when attempting to save that will throw an error.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.