### PR TITLE
Add `metadata` field to `JobStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add `metadata` field to `JobStatus`
 * Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`
 
 ### 6.4.2 / 2022-06-14

--- a/__tests__/job-status-spec.js
+++ b/__tests__/job-status-spec.js
@@ -37,6 +37,9 @@ describe('Job Status', () => {
         created_at: 1592374298,
         job_status_id: 'eslvh7ieykvf5yf2xx9k9yrn8',
         status: 'successful',
+        metadata: {
+          sdk: true,
+        },
       },
       {
         id: '2ab73sqyim3poa8qjm4rv0o2',
@@ -56,6 +59,9 @@ describe('Job Status', () => {
       created_at: 1592374298,
       job_status_id: 'eslvh7ieykvf5yf2xx9k9yrn8',
       status: 'successful',
+      metadata: {
+        sdk: true,
+      },
     };
     jest.spyOn(testContext.connection, 'request');
   });
@@ -97,7 +103,7 @@ describe('Job Status', () => {
     });
 
     test('should resolve to job status object(s)', done => {
-      expect.assertions(8);
+      expect.assertions(9);
       testContext.connection.request = jest.fn(() =>
         Promise.resolve(testContext.listApiResponse)
       );
@@ -109,6 +115,9 @@ describe('Job Status', () => {
         expect(data[0].action).toBe('create_calendar');
         expect(data[0].jobStatusId).toBe('eslvh7ieykvf5yf2xx9k9yrn8');
         expect(data[0].status).toBe('successful');
+        expect(data[0].metadata).toEqual({
+          sdk: true,
+        });
         expect(data[0] instanceof JobStatus).toBe(true);
         expect(data[0].createdAt instanceof Date).toBe(true);
         done();
@@ -147,7 +156,7 @@ describe('Job Status', () => {
     });
 
     test('should resolve to job status object', done => {
-      expect.assertions(8);
+      expect.assertions(9);
       testContext.connection.request = jest.fn(() =>
         Promise.resolve(testContext.getApiResponse)
       );
@@ -159,6 +168,9 @@ describe('Job Status', () => {
         expect(data.action).toBe('create_calendar');
         expect(data.jobStatusId).toBe('eslvh7ieykvf5yf2xx9k9yrn8');
         expect(data.status).toBe('successful');
+        expect(data.metadata).toEqual({
+          sdk: true,
+        });
         expect(data instanceof JobStatus).toBe(true);
         expect(data.createdAt instanceof Date).toBe(true);
         done();

--- a/src/models/job-status.ts
+++ b/src/models/job-status.ts
@@ -9,6 +9,7 @@ export type JobStatusProperties = {
   jobStatusId?: string;
   status?: string;
   originalData?: Message;
+  metadata?: object;
 };
 
 export default class JobStatus extends RestfulModel
@@ -18,6 +19,7 @@ export default class JobStatus extends RestfulModel
   jobStatusId?: string;
   status?: string;
   originalData?: Message;
+  metadata?: object;
   static collectionName = 'job-statuses';
   static attributes: Record<string, Attribute> = {
     ...RestfulModel.attributes,
@@ -42,6 +44,10 @@ export default class JobStatus extends RestfulModel
     originalData: Attributes.Object({
       modelKey: 'originalData',
       jsonKey: 'original_data',
+      readOnly: true,
+    }),
+    metadata: Attributes.Object({
+      modelKey: 'metadata',
       readOnly: true,
     }),
   };


### PR DESCRIPTION
# Description
This PR adds a new `metadata` field to the `JobStatus` class.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.