### PR TITLE
Fix typing issues in event and scheduler open hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Unreleased
 * Add `interval_minutes` field in Scheduler booking config
-* Adjust `Event.originalStartTime` type to include `Date`
-* Fix `SchedulerBookingOpeningHours.accountId` deserialization
+* Fixed `Event.originalStartTime` type to be `Date`
+* Fixed `SchedulerBookingOpeningHours.accountId` deserialization
 * Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`
 
 ### 6.4.2 / 2022-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add `interval_minutes` field in Scheduler booking config
+* Adjust `Event.originalStartTime` type to include `Date`
 * Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`
 
 ### 6.4.2 / 2022-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Add `interval_minutes` field in Scheduler booking config
 * Adjust `Event.originalStartTime` type to include `Date`
+* Fix `SchedulerBookingOpeningHours.accountId` deserialization
 * Fixed json value for `confirmationEmailToHost` in `SchedulerBooking`
 
 ### 6.4.2 / 2022-06-14

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -46,7 +46,7 @@ export type EventProperties = {
     timezone: string;
   };
   masterEventId?: string;
-  originalStartTime?: number | Date;
+  originalStartTime?: Date;
   capacity?: number;
   conferencing?: EventConferencingProperties;
   notifications?: EventNotificationProperties[];
@@ -74,7 +74,7 @@ export default class Event extends RestfulModel {
     timezone: string;
   };
   masterEventId?: string;
-  originalStartTime?: number | Date;
+  originalStartTime?: Date;
   capacity?: number;
   conferencing?: EventConferencing;
   reminderMinutes?: string;

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -46,7 +46,7 @@ export type EventProperties = {
     timezone: string;
   };
   masterEventId?: string;
-  originalStartTime?: number;
+  originalStartTime?: number | Date;
   capacity?: number;
   conferencing?: EventConferencingProperties;
   notifications?: EventNotificationProperties[];
@@ -74,7 +74,7 @@ export default class Event extends RestfulModel {
     timezone: string;
   };
   masterEventId?: string;
-  originalStartTime?: number;
+  originalStartTime?: number | Date;
   capacity?: number;
   conferencing?: EventConferencing;
   reminderMinutes?: string;

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -213,7 +213,7 @@ export class SchedulerBookingOpeningHours extends Model
   end?: string;
   start?: string;
   static attributes: Record<string, Attribute> = {
-    dropdownOptions: Attributes.String({
+    accountId: Attributes.String({
       modelKey: 'accountId',
       jsonKey: 'account_id',
     }),


### PR DESCRIPTION
# Description
This PR fixes issues relating to typing in:
- `Event`: `originalStartTime` should deserialize to `Date`, so replace `number` type to `Date`.
- `SchedulerBookingOpenHours`: The `account_id` filed from the API was being deseralized to `dropdownOptions` instead of `accountId`.


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.