### PR TITLE
Abstracting middleware logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 7.0.0-canary.4 / Unreleased
+* Abstract out the middleware logic to a more generalized `Routes`
+* **BREAKING CHANGE**: `exchangeCodeForToken` callback returns the access token as a `AccessToken` type instead of a string
+
 ### 7.0.0-canary.3 / 2022-06-29
 * `/exchange-mailbox-token` now uses a callback instead of emitting an event
 * Add CSRF Token Generation support for the authentication process in the server bindings

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { WebhookTriggers } from './models/webhook';
 import ExpressBinding from './server-bindings/express-binding';
+import AccessToken from './models/access-token';
 
 export let apiServer: string | null = null;
 export function setApiServer(newApiServer: string | null) {
@@ -79,3 +80,8 @@ export const DEFAULT_WEBHOOK_TRIGGERS = Object.values(WebhookTriggers);
 export const ServerBindings = {
   express: ExpressBinding,
 };
+
+export type ExchangeCodeForTokenCallback = (
+  error: Error | null,
+  accessToken?: AccessToken
+) => void;

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -9,7 +9,11 @@ import Connect from './models/connect';
 import RestfulModelCollection from './models/restful-model-collection';
 import ManagementModelCollection from './models/management-model-collection';
 import Webhook from './models/webhook';
-import { AuthenticateUrlConfig, NylasConfig } from './config';
+import {
+  AuthenticateUrlConfig,
+  ExchangeCodeForTokenCallback,
+  NylasConfig,
+} from './config';
 import AccessToken from './models/access-token';
 import ApplicationDetails, {
   ApplicationDetailsProperties,
@@ -131,13 +135,13 @@ class Nylas {
 
   /**
    * Exchange an authorization code for an access token
-   * @param code Application details to overwrite
-   * @param callback Application details to overwrite
-   * @return Information about the Nylas application
+   * @param code One-time authorization code from Nylas
+   * @param callback Callback before returning the access token
+   * @return The {@link AccessToken} object containing the access token and other information
    */
   exchangeCodeForToken(
     code: string,
-    callback?: (error: Error | null, accessToken?: string) => void
+    callback?: ExchangeCodeForTokenCallback
   ): Promise<AccessToken> {
     if (!this.clientId || !this.clientSecret) {
       throw new Error(
@@ -166,10 +170,11 @@ class Nylas {
             if (body && body.message) errorMessage = body.message;
             throw new Error(errorMessage);
           }
+          const accessToken = new AccessToken().fromJSON(body);
           if (callback) {
-            callback(null, body);
+            callback(null, accessToken);
           }
-          return new AccessToken().fromJSON(body);
+          return accessToken;
         },
         error => {
           const newError = new Error(error.message);

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -3,7 +3,7 @@ import express, { RequestHandler, Response, Router } from 'express';
 import { ServerBindingOptions, ServerBinding } from './server-binding';
 import bodyParser from 'body-parser';
 import { WebhookDelta } from '../models/webhook-notification';
-import { DefaultRoutes, Routes } from '../services/routes';
+import { DefaultRoutes } from '../services/routes';
 
 export default class ExpressBinding extends ServerBinding {
   constructor(nylasClient: Nylas, options: ServerBindingOptions) {
@@ -40,7 +40,6 @@ export default class ExpressBinding extends ServerBinding {
   buildMiddleware(): Router {
     const router = express.Router();
     const webhookRoute = '/webhook';
-    const { buildAuthUrl, exchangeCodeForToken } = Routes();
 
     // For the Nylas webhook endpoint, we should get the raw body to use for verification
     router.use(
@@ -70,7 +69,7 @@ export default class ExpressBinding extends ServerBinding {
       if (this.csrfTokenExchangeOpts) {
         state = await this.csrfTokenExchangeOpts.generateCsrfToken(req);
       }
-      const authUrl = await buildAuthUrl(this.nylasClient, {
+      const authUrl = await this.buildAuthUrl(this.nylasClient, {
         scopes: this.defaultScopes,
         clientUri: this.clientUri,
         emailAddress: req.body.email_address,
@@ -92,7 +91,7 @@ export default class ExpressBinding extends ServerBinding {
             return res.status(401).send('Invalid CSRF State Token');
           }
         }
-        const accessTokenObj = await exchangeCodeForToken(
+        const accessTokenObj = await this.exchangeCodeForToken(
           this.nylasClient,
           req.body.token
         );

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -16,7 +16,6 @@ export default class ExpressBinding extends ServerBinding {
   webhookVerificationMiddleware(): RequestHandler {
     return (req, res, next): void | Response => {
       const isVerified = this.verifyWebhookSignature(
-        this.nylasClient,
         req.header(ServerBinding.NYLAS_SIGNATURE_HEADER) as string,
         req.body
       );
@@ -70,7 +69,7 @@ export default class ExpressBinding extends ServerBinding {
       if (this.csrfTokenExchangeOpts) {
         state = await this.csrfTokenExchangeOpts.generateCsrfToken(req);
       }
-      const authUrl = await this.buildAuthUrl(this.nylasClient, {
+      const authUrl = await this.buildAuthUrl({
         scopes: this.defaultScopes,
         clientUri: this.clientUri,
         emailAddress: req.body.email_address,
@@ -92,10 +91,7 @@ export default class ExpressBinding extends ServerBinding {
             return res.status(401).send('Invalid CSRF State Token');
           }
         }
-        const accessTokenObj = await this.exchangeCodeForToken(
-          this.nylasClient,
-          req.body.token
-        );
+        const accessTokenObj = await this.exchangeCodeForToken(req.body.token);
 
         await this.exchangeMailboxTokenCallback(accessTokenObj, res);
 

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -16,6 +16,7 @@ export default class ExpressBinding extends ServerBinding {
   webhookVerificationMiddleware(): RequestHandler {
     return (req, res, next): void | Response => {
       const isVerified = this.verifyWebhookSignature(
+        this.nylasClient,
         req.header(ServerBinding.NYLAS_SIGNATURE_HEADER) as string,
         req.body
       );

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -2,7 +2,7 @@ import Nylas from '../nylas';
 import express, { RequestHandler, Response, Router } from 'express';
 import { ServerBindingOptions, ServerBinding } from './server-binding';
 import bodyParser from 'body-parser';
-import { DefaultRoutes } from '../services/routes';
+import { DefaultPaths } from '../services/routes';
 
 export default class ExpressBinding extends ServerBinding {
   constructor(nylasClient: Nylas, options: ServerBindingOptions) {
@@ -41,7 +41,7 @@ export default class ExpressBinding extends ServerBinding {
 
     // For the Nylas webhook endpoint, we should get the raw body to use for verification
     router.use(
-      DefaultRoutes.webhooks,
+      DefaultPaths.webhooks,
       bodyParser.raw({ inflate: true, type: 'application/json' })
     );
 
@@ -51,7 +51,7 @@ export default class ExpressBinding extends ServerBinding {
     );
 
     router.post<unknown, unknown, Record<string, unknown>>(
-      DefaultRoutes.webhooks,
+      DefaultPaths.webhooks,
       this.webhookVerificationMiddleware() as any,
       (req, res) => {
         const deltas = (req.body.deltas as Record<string, unknown>[]) || [];
@@ -60,7 +60,7 @@ export default class ExpressBinding extends ServerBinding {
       }
     );
 
-    router.post(DefaultRoutes.buildAuthUrl, async (req, res) => {
+    router.post(DefaultPaths.buildAuthUrl, async (req, res) => {
       let state = '';
       if (this.csrfTokenExchangeOpts) {
         state = await this.csrfTokenExchangeOpts.generateCsrfToken(req);
@@ -75,7 +75,7 @@ export default class ExpressBinding extends ServerBinding {
       res.status(200).send(authUrl);
     });
 
-    router.post(DefaultRoutes.exchangeCodeForToken, async (req, res) => {
+    router.post(DefaultPaths.exchangeCodeForToken, async (req, res) => {
       try {
         if (this.csrfTokenExchangeOpts) {
           const csrfToken = req.body.csrfToken;

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -2,7 +2,6 @@ import Nylas from '../nylas';
 import express, { RequestHandler, Response, Router } from 'express';
 import { ServerBindingOptions, ServerBinding } from './server-binding';
 import bodyParser from 'body-parser';
-import { WebhookDelta } from '../models/webhook-notification';
 import { DefaultRoutes } from '../services/routes';
 
 export default class ExpressBinding extends ServerBinding {

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -39,11 +39,10 @@ export default class ExpressBinding extends ServerBinding {
    */
   buildMiddleware(): Router {
     const router = express.Router();
-    const webhookRoute = '/webhook';
 
     // For the Nylas webhook endpoint, we should get the raw body to use for verification
     router.use(
-      webhookRoute,
+      DefaultRoutes.webhooks,
       bodyParser.raw({ inflate: true, type: 'application/json' })
     );
 
@@ -53,13 +52,11 @@ export default class ExpressBinding extends ServerBinding {
     );
 
     router.post<unknown, unknown, Record<string, unknown>>(
-      webhookRoute,
+      DefaultRoutes.webhooks,
       this.webhookVerificationMiddleware() as any,
       (req, res) => {
         const deltas = (req.body.deltas as Record<string, unknown>[]) || [];
-        deltas.forEach(d =>
-          this.handleDeltaEvent(new WebhookDelta().fromJSON(d))
-        );
+        this.emitDeltaEvents(deltas);
         res.status(200).send('ok');
       }
     );

--- a/src/server-bindings/express-binding.ts
+++ b/src/server-bindings/express-binding.ts
@@ -31,9 +31,9 @@ export default class ExpressBinding extends ServerBinding {
 
   /**
    * Build middleware for an Express app with routes for:
-   * 1. '/webhook': Receiving webhook events, verifying its authenticity, and emitting webhook objects
-   * 2. '/generate-auth-url': Building the URL for authenticating users to your application via Hosted Authentication
-   * 3. Exchange an authorization code for an access token
+   * 1. '/nylas/webhook': Receiving webhook events, verifying its authenticity, and emitting webhook objects
+   * 2. '/nylas/generate-auth-url': Building the URL for authenticating users to your application via Hosted Authentication
+   * 3. '/nylas/exchange-mailbox-token': Exchange an authorization code for an access token
    * @return The routes packaged as Express middleware
    */
   buildMiddleware(): Router {

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -85,9 +85,7 @@ export abstract class ServerBinding extends EventEmitter
    * @param deltas The list of delta JSON objects
    */
   emitDeltaEvents(deltas: Record<string, unknown>[]): void {
-    deltas.forEach(d =>
-      this.handleDeltaEvent(new WebhookDelta().fromJSON(d))
-    );
+    deltas.forEach(d => this.handleDeltaEvent(new WebhookDelta().fromJSON(d)));
   }
 
   /**

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -81,6 +81,16 @@ export abstract class ServerBinding extends EventEmitter
   ): boolean => this._untypedEmit(event, payload);
 
   /**
+   * Emit all incoming delta events
+   * @param deltas The list of delta JSON objects
+   */
+  emitDeltaEvents(deltas: Record<string, unknown>[]): void {
+    deltas.forEach(d =>
+      this.handleDeltaEvent(new WebhookDelta().fromJSON(d))
+    );
+  }
+
+  /**
    * Start a local development websocket to get webhook events
    * @param webhookTunnelConfig Optional configuration for setting region, triggers, and overriding callbacks
    * @return The webhook details response from the API

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -10,6 +10,7 @@ import {
   openWebhookTunnel,
   OpenWebhookTunnelOptions,
 } from '../services/tunnel';
+import { Routes } from '../services/routes';
 
 type Middleware = Router;
 type ServerRequest = Request;
@@ -42,6 +43,8 @@ export abstract class ServerBinding extends EventEmitter
   clientUri?: string;
 
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
+  protected buildAuthUrl = Routes().buildAuthUrl;
+  protected exchangeCodeForToken = Routes().exchangeCodeForToken;
   private _untypedOn = this.on;
   private _untypedEmit = this.emit;
 

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { Request, Response, Router } from 'express';
 import { Scope } from '../models/connect';
 import { EventEmitter } from 'events';
@@ -45,6 +44,7 @@ export abstract class ServerBinding extends EventEmitter
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
   protected buildAuthUrl = Routes().buildAuthUrl;
   protected exchangeCodeForToken = Routes().exchangeCodeForToken;
+  protected verifyWebhookSignature = Routes().verifyWebhookSignature;
   private _untypedOn = this.on;
   private _untypedEmit = this.emit;
 
@@ -69,20 +69,6 @@ export abstract class ServerBinding extends EventEmitter
     event: K,
     payload: WebhookDelta
   ): boolean => this._untypedEmit(event, payload);
-
-  /**
-   * Verify incoming webhook signature came from Nylas
-   * @param xNylasSignature The signature to verify
-   * @param rawBody The raw body from the payload
-   * @return true if the webhook signature was verified from Nylas
-   */
-  verifyWebhookSignature(xNylasSignature: string, rawBody: Buffer): boolean {
-    const digest = crypto
-      .createHmac('sha256', this.nylasClient.clientSecret)
-      .update(rawBody)
-      .digest('hex');
-    return digest === xNylasSignature;
-  }
 
   /**
    * Start a local development websocket to get webhook events

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -30,12 +30,18 @@ type CsrfTokenExchangeOptions = {
     req: ServerRequest
   ) => Promise<boolean>;
 };
+type OverridePaths = {
+  buildAuthUrl?: string;
+  exchangeCodeForToken?: string;
+  webhooks?: string;
+};
 
 export type ServerBindingOptions = {
   defaultScopes: Scope[];
   exchangeMailboxTokenCallback: ExchangeMailboxTokenCallback;
   csrfTokenExchangeOpts?: CsrfTokenExchangeOptions;
   clientUri?: string;
+  overridePaths?: OverridePaths;
 };
 
 export abstract class ServerBinding extends EventEmitter
@@ -45,6 +51,7 @@ export abstract class ServerBinding extends EventEmitter
   exchangeMailboxTokenCallback: ExchangeMailboxTokenCallback;
   csrfTokenExchangeOpts?: CsrfTokenExchangeOptions;
   clientUri?: string;
+  overridePaths?: OverridePaths;
 
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
   protected buildAuthUrl: BuildAuthUrl;
@@ -65,6 +72,7 @@ export abstract class ServerBinding extends EventEmitter
       exchangeCodeForToken: this.exchangeCodeForToken,
       verifyWebhookSignature: this.verifyWebhookSignature,
     } = Routes(nylasClient));
+    this.overridePaths = options.overridePaths;
   }
 
   abstract buildMiddleware(): Middleware;

--- a/src/server-bindings/server-binding.ts
+++ b/src/server-bindings/server-binding.ts
@@ -9,7 +9,12 @@ import {
   openWebhookTunnel,
   OpenWebhookTunnelOptions,
 } from '../services/tunnel';
-import { Routes } from '../services/routes';
+import {
+  BuildAuthUrl,
+  ExchangeCodeForToken,
+  Routes,
+  VerifyWebhookSignature,
+} from '../services/routes';
 
 type Middleware = Router;
 type ServerRequest = Request;
@@ -42,9 +47,9 @@ export abstract class ServerBinding extends EventEmitter
   clientUri?: string;
 
   static NYLAS_SIGNATURE_HEADER = 'x-nylas-signature';
-  protected buildAuthUrl = Routes().buildAuthUrl;
-  protected exchangeCodeForToken = Routes().exchangeCodeForToken;
-  protected verifyWebhookSignature = Routes().verifyWebhookSignature;
+  protected buildAuthUrl: BuildAuthUrl;
+  protected exchangeCodeForToken: ExchangeCodeForToken;
+  protected verifyWebhookSignature: VerifyWebhookSignature;
   private _untypedOn = this.on;
   private _untypedEmit = this.emit;
 
@@ -55,6 +60,11 @@ export abstract class ServerBinding extends EventEmitter
     this.exchangeMailboxTokenCallback = options.exchangeMailboxTokenCallback;
     this.csrfTokenExchangeOpts = options.csrfTokenExchangeOpts;
     this.clientUri = options.clientUri;
+    ({
+      buildAuthUrl: this.buildAuthUrl,
+      exchangeCodeForToken: this.exchangeCodeForToken,
+      verifyWebhookSignature: this.verifyWebhookSignature,
+    } = Routes(nylasClient));
   }
 
   abstract buildMiddleware(): Middleware;

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -4,10 +4,10 @@ import AccessToken from '../models/access-token';
 import crypto from 'crypto';
 import { ExchangeCodeForTokenCallback } from '../config';
 
-  buildAuthUrl = '/generate-auth-url',
-  exchangeCodeForToken = '/exchange-mailbox-token',
-  webhooks = '/webhook',
 export enum DefaultPaths {
+  buildAuthUrl = '/nylas/generate-auth-url',
+  exchangeCodeForToken = '/nylas/exchange-mailbox-token',
+  webhooks = '/nylas/webhook',
 }
 
 // Type aliases for the functions in Routes

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -4,10 +4,10 @@ import AccessToken from '../models/access-token';
 import crypto from 'crypto';
 import { ExchangeCodeForTokenCallback } from '../config';
 
-export enum DefaultRoutes {
   buildAuthUrl = '/generate-auth-url',
   exchangeCodeForToken = '/exchange-mailbox-token',
   webhooks = '/webhook',
+export enum DefaultPaths {
 }
 
 // Type aliases for the functions in Routes

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -35,6 +35,11 @@ type Routes = {
 };
 
 export const Routes = (nylasClient: Nylas): Routes => {
+  /**
+   * Build the URL for authenticating users to your application via Hosted Authentication
+   * @param options Configuration for the authentication process
+   * @return The URL for hosted authentication
+   */
   const buildAuthUrl = async (
     options: BuildAuthUrlOptions
   ): Promise<string> => {
@@ -48,6 +53,12 @@ export const Routes = (nylasClient: Nylas): Routes => {
     });
   };
 
+  /**
+   * Exchange an authorization code for an access token
+   * @param code One-time authorization code from Nylas
+   * @param callback Callback before returning the access token
+   * @return The {@link AccessToken} object containing the access token and other information
+   */
   const exchangeCodeForToken = async (
     code: string,
     callback?: ExchangeCodeForTokenCallback

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -2,6 +2,7 @@ import { Scope } from '../models/connect';
 import Nylas from '../nylas';
 import AccessToken from '../models/access-token';
 import crypto from 'crypto';
+import { ExchangeCodeForTokenCallback } from '../config';
 
 export enum DefaultRoutes {
   buildAuthUrl = '/generate-auth-url',
@@ -47,8 +48,11 @@ export const Routes = (nylasClient: Nylas): Routes => {
     });
   };
 
-  const exchangeCodeForToken = async (code: string): Promise<AccessToken> => {
-    return await nylasClient.exchangeCodeForToken(code);
+  const exchangeCodeForToken = async (
+    code: string,
+    callback?: ExchangeCodeForTokenCallback
+  ): Promise<AccessToken> => {
+    return await nylasClient.exchangeCodeForToken(code, callback);
   };
 
   /**

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -7,6 +7,7 @@ import { ExchangeCodeForTokenCallback } from '../config';
 export enum DefaultRoutes {
   buildAuthUrl = '/generate-auth-url',
   exchangeCodeForToken = '/exchange-mailbox-token',
+  webhooks = '/webhook',
 }
 
 // Type aliases for the functions in Routes

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -1,0 +1,54 @@
+import { Scope } from '../models/connect';
+import Nylas from '../nylas';
+import AccessToken from '../models/access-token';
+
+export enum DefaultRoutes {
+  buildAuthUrl = '/generate-auth-url',
+  exchangeCodeForToken = '/exchange-mailbox-token',
+}
+
+export type BuildAuthUrlOptions = {
+  scopes: Scope[];
+  emailAddress: string;
+  successUrl: string;
+  clientUri?: string;
+  state?: string;
+};
+
+type Routes = {
+  buildAuthUrl: (
+    nylasClient: Nylas,
+    options: BuildAuthUrlOptions
+  ) => Promise<string>;
+  exchangeCodeForToken: (
+    nylasClient: Nylas,
+    code: string
+  ) => Promise<AccessToken>;
+};
+
+export const Routes = (): Routes => {
+  const buildAuthUrl = async (
+    nylasClient: Nylas,
+    options: BuildAuthUrlOptions
+  ): Promise<string> => {
+    const { scopes, emailAddress, successUrl, clientUri, state } = options;
+
+    return nylasClient.urlForAuthentication({
+      loginHint: emailAddress,
+      redirectURI: (clientUri || '') + successUrl,
+      scopes,
+      state,
+    });
+  };
+
+  const exchangeCodeForToken = async (
+    nylasClient: Nylas,
+    code: string
+  ): Promise<AccessToken> => {
+    return await nylasClient.exchangeCodeForToken(code);
+  };
+
+  return { buildAuthUrl, exchangeCodeForToken };
+};
+
+export default Routes;

--- a/src/services/routes.ts
+++ b/src/services/routes.ts
@@ -8,6 +8,17 @@ export enum DefaultRoutes {
   exchangeCodeForToken = '/exchange-mailbox-token',
 }
 
+// Type aliases for the functions in Routes
+
+export type BuildAuthUrl = (options: BuildAuthUrlOptions) => Promise<string>;
+
+export type ExchangeCodeForToken = (code: string) => Promise<AccessToken>;
+
+export type VerifyWebhookSignature = (
+  nylasSignature: string,
+  rawBody: Buffer
+) => boolean;
+
 export type BuildAuthUrlOptions = {
   scopes: Scope[];
   emailAddress: string;
@@ -17,24 +28,13 @@ export type BuildAuthUrlOptions = {
 };
 
 type Routes = {
-  buildAuthUrl: (
-    nylasClient: Nylas,
-    options: BuildAuthUrlOptions
-  ) => Promise<string>;
-  exchangeCodeForToken: (
-    nylasClient: Nylas,
-    code: string
-  ) => Promise<AccessToken>;
-  verifyWebhookSignature: (
-    nylasClient: Nylas,
-    nylasSignature: string,
-    rawBody: Buffer
-  ) => boolean;
+  buildAuthUrl: BuildAuthUrl;
+  exchangeCodeForToken: ExchangeCodeForToken;
+  verifyWebhookSignature: VerifyWebhookSignature;
 };
 
-export const Routes = (): Routes => {
+export const Routes = (nylasClient: Nylas): Routes => {
   const buildAuthUrl = async (
-    nylasClient: Nylas,
     options: BuildAuthUrlOptions
   ): Promise<string> => {
     const { scopes, emailAddress, successUrl, clientUri, state } = options;
@@ -47,10 +47,7 @@ export const Routes = (): Routes => {
     });
   };
 
-  const exchangeCodeForToken = async (
-    nylasClient: Nylas,
-    code: string
-  ): Promise<AccessToken> => {
+  const exchangeCodeForToken = async (code: string): Promise<AccessToken> => {
     return await nylasClient.exchangeCodeForToken(code);
   };
 
@@ -61,7 +58,6 @@ export const Routes = (): Routes => {
    * @return true if the webhook signature was verified from Nylas
    */
   const verifyWebhookSignature = (
-    nylasClient: Nylas,
     nylasSignature: string,
     rawBody: Buffer
   ): boolean => {


### PR DESCRIPTION
# Description
This PR's main change is pulling out the underlying logic of the routes used in the middleware created for Express and moving it to `Routes`. This new module's purpose is to allow implementing clients that don't use one of the supported frameworks served by `ServerBindings` still an easy way to integrate Nylas into their code and pair it with our frontend SDKs we provide (@nylas/nylas-js, @nylas/nylas-react).

This code also brings forward a breaking change, the `Nylas.exchangeCodeForToken` now expects the optional callback parameter to anticipate a `AccessToken` object instead of a string for the `accessToken` parameter. 

# Usage
We're going to use `fastify` as we currently do not support this framework to demonstrate how using `Routes` can make  it easy to implement these routes:
```js
const fastify = require('fastify')
const cors = require('@fastify/cors')

const { v4: uuidv4 } = require("uuid");
const { mockDb } = require("./utils/mock-db");

const Nylas = require('nylas');
const { Scope } = require('nylas/lib/models/connect');
const { Routes: NylasRoutes }  = require('nylas/lib/services/routes');
const { DefaultPaths } = require('nylas/lib/services/routes')

// The port the express app will run on
const port = 9000;

// The uri for the frontend
const clientUri = 'http://localhost:3000';

// Nylas application credentials
const clientId = '$CLIENT_ID';
const clientSecret = '$CLIENT_SECRET';

// Initialize an instance of the Nylas SDK using the client credentials
const nylasClient = new Nylas({
    clientId: clientId,
    clientSecret: clientSecret,
});

// Use the routes provided by the Nylas Node SDK to quickly implement the authentication flow
const { buildAuthUrl, exchangeCodeForToken } = NylasRoutes(nylasClient);

// Init the fastify server
const app = fastify();

// Enable CORS
app.register(cors)

// Configure the Nylas routes using your flavour of backend framework, fastify in this case
app.post(DefaultPaths.buildAuthUrl, async (req, res) => {
  const authUrl = await buildAuthUrl({
    scopes: [
      Scope.EmailReadOnly,
    ],
    emailAddress: req.body.email_address,
    successUrl: req.body.success_url,
    clientUri,
  });
  res.status(200).send(authUrl);
});

app.post(DefaultPaths.exchangeCodeForToken, async (req, res) => {
  try {
    const { accessToken, emailAddress } = await exchangeCodeForToken(req.body.token);

    // Replace this mock code with your actual database operations
    const user = await mockDb.createOrUpdateUser(emailAddress, {
      accessToken,
      emailAddress,
    })
  
    // Return an authorization object to the user
    res.send({
      id: user.id,
      emailAddress: user.emailAddress,
    });
  } catch (e) {
    res.status(500).send((e).message);
  }
});

// Add some routes for the backend
app.get('/', (req, res) => res.status(200).send('Ok'));

// Start listening on port 9000
app.listen({ port }).then(() => console.log('App listening on port ' + port));
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.