### PR TITLE
v6.5.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.5.0 / 2022-07-29
 * Add `metadata` field to `JobStatus`
 * Add `interval_minutes` field in Scheduler booking config
 * Fixed `Event.originalStartTime` type to be `Date`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.4.2",
+      "version": "6.5.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v6.5.0 release provides the following changes:
* Add `metadata` field to `JobStatus` (#379)
* Add `interval_minutes` field in Scheduler booking config (#378)
* Fixed `Event.originalStartTime` type to be `Date` (#381, #380) 
* Fixed `SchedulerBookingOpeningHours.accountId` deserialization (#381)
* Fixed json value for `confirmationEmailToHost` in `SchedulerBooking` (#377)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.