### PR TITLE
Rename `confirmationEmailToHost` to `confirmationEmailsToHost` in `SchedulerBooking`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 7.0.0-canary.5 / TBD
+* **BREAKING CHANGE**: Rename `confirmationEmailToHost` to `confirmationEmailsToHost` in `SchedulerBooking`
+
 ### 7.0.0-canary.4 / 2022-08-15
 * Abstract out the middleware logic to a more generalized `Routes`
 * **BREAKING CHANGE**: `exchangeCodeForToken` callback returns the access token as a `AccessToken` type instead of a string

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -241,7 +241,7 @@ export type SchedulerBookingProperties = {
   calendarInviteToGuests?: boolean;
   cancellationPolicy?: string;
   confirmationEmailsToGuests?: boolean;
-  confirmationEmailToHost?: boolean;
+  confirmationEmailsToHost?: boolean;
   confirmationMethod?: string;
   minBookingNotice?: number;
   minBuffer?: number;
@@ -259,7 +259,7 @@ export class SchedulerBooking extends Model
   calendarInviteToGuests?: boolean;
   cancellationPolicy?: string;
   confirmationEmailsToGuests?: boolean;
-  confirmationEmailToHost?: boolean;
+  confirmationEmailsToHost?: boolean;
   confirmationMethod?: string;
   minBookingNotice?: number;
   minBuffer?: number;
@@ -293,9 +293,9 @@ export class SchedulerBooking extends Model
       modelKey: 'confirmationEmailsToGuests',
       jsonKey: 'confirmation_emails_to_guests',
     }),
-    confirmationEmailToHost: Attributes.Boolean({
-      modelKey: 'confirmationEmailToHost',
-      jsonKey: 'confirmation_email_to_host',
+    confirmationEmailsToHost: Attributes.Boolean({
+      modelKey: 'confirmationEmailsToHost',
+      jsonKey: 'confirmation_emails_to_host',
     }),
     confirmationMethod: Attributes.String({
       modelKey: 'confirmationMethod',


### PR DESCRIPTION
# Description
"Emails" should be pluralized to align with the API.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.