### PR TITLE
Fix issue with `EventParticipant` not sending status on new event creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue with `EventParticipant` not sending status on create
+
 ### 6.5.0 / 2022-07-29
 * Add `metadata` field to `JobStatus`
 * Add `interval_minutes` field in Scheduler booking config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Unreleased
-* Fix issue with `EventParticipant` not sending status on create
+* Fix issue with `EventParticipant` not sending status on new event creation
 
 ### 6.5.0 / 2022-07-29
 * Add `metadata` field to `JobStatus`

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -724,7 +724,7 @@ describe('Event', () => {
             ],
           });
         });
-        testContext.event.id = "abc-123";
+        testContext.event.id = 'abc-123';
         testContext.event.save().then(() => {
           const options = testContext.connection.request.mock.calls[1][0];
           expect(options.body).toEqual({

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -698,7 +698,7 @@ describe('Event', () => {
         });
       });
 
-      test('should not send the status object within the participant object', done => {
+      test('should only send the status object within the participant object on create', done => {
         testContext.event.participants = [
           new EventParticipant({
             name: 'foo',
@@ -708,8 +708,25 @@ describe('Event', () => {
             phoneNumber: '416-000-0000',
           }),
         ];
-        return testContext.event.save().then(() => {
+        testContext.event.save().then(() => {
           const options = testContext.connection.request.mock.calls[0][0];
+          expect(options.body).toEqual({
+            calendar_id: '',
+            when: {},
+            participants: [
+              {
+                name: 'foo',
+                email: 'bar',
+                comment: 'This is a comment',
+                phone_number: '416-000-0000',
+                status: 'noreply',
+              },
+            ],
+          });
+        });
+        testContext.event.id = "abc-123";
+        testContext.event.save().then(() => {
+          const options = testContext.connection.request.mock.calls[1][0];
           expect(options.body).toEqual({
             calendar_id: '',
             when: {},

--- a/src/models/event-participant.ts
+++ b/src/models/event-participant.ts
@@ -32,7 +32,6 @@ export default class EventParticipant extends Model
     }),
     status: Attributes.String({
       modelKey: 'status',
-      readOnly: true,
     }),
   };
 

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -276,6 +276,10 @@ export default class Event extends RestfulModel {
     if (!this.notifications) {
       delete json.notifications;
     }
+    // Participant status cannot be updated
+    if (this.id && json.participants) {
+      (json.participants as Record<string, unknown>[]).forEach(participant => delete(participant.status));
+    }
 
     return json;
   }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -278,7 +278,9 @@ export default class Event extends RestfulModel {
     }
     // Participant status cannot be updated
     if (this.id && json.participants) {
-      (json.participants as Record<string, unknown>[]).forEach(participant => delete(participant.status));
+      (json.participants as Record<string, unknown>[]).forEach(
+        participant => delete participant.status
+      );
     }
 
     return json;


### PR DESCRIPTION
# Description
This PR ensures that on a create the event's participant status is sent.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.