### PR TITLE
Add additional Event fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add additional `Event` fields
+
 ### 6.5.0 / 2022-07-29
 * Add `metadata` field to `JobStatus`
 * Add `interval_minutes` field in Scheduler booking config

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -53,6 +53,10 @@ export type EventProperties = {
   roundRobinOrder?: string[];
   metadata?: object;
   jobStatusId?: string;
+  organizerEmail?: string;
+  organizerName?: string;
+  visibility?: string;
+  customerEventId?: string;
 };
 
 export default class Event extends RestfulModel {
@@ -82,6 +86,10 @@ export default class Event extends RestfulModel {
   roundRobinOrder?: string[];
   metadata?: object;
   jobStatusId?: string;
+  organizerEmail?: string;
+  organizerName?: string;
+  visibility?: string;
+  customerEventId?: string;
   static collectionName = 'events';
   static attributes: Record<string, Attribute> = {
     ...RestfulModel.attributes,
@@ -174,6 +182,24 @@ export default class Event extends RestfulModel {
       modelKey: 'jobStatusId',
       jsonKey: 'job_status_id',
       readOnly: true,
+    }),
+    organizerEmail: Attributes.String({
+      modelKey: 'organizerEmail',
+      jsonKey: 'organizer_email',
+      readOnly: true,
+    }),
+    organizerName: Attributes.String({
+      modelKey: 'organizerName',
+      jsonKey: 'organizer_name',
+      readOnly: true,
+    }),
+    visibility: Attributes.String({
+      modelKey: 'visibility',
+      readOnly: true,
+    }),
+    customerEventId: Attributes.String({
+      modelKey: 'customerEventId',
+      jsonKey: 'customer_event_id',
     }),
   };
 


### PR DESCRIPTION
# Description
Add the following fields to `Event`:
* customeEventId: string
* oragnizerEmail: string (read only)
* organizerName: string (read only)
* visibility: string (read only)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.