### PR TITLE
Gracefully handle error on webhook deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 7.0.0-canary.5 / TBD
 * **BREAKING CHANGE**: Rename `confirmationEmailToHost` to `confirmationEmailsToHost` in `SchedulerBooking`
+* Gracefully handle error on webhook deletion
 
 ### 7.0.0-canary.4 / 2022-08-15
 * Abstract out the middleware logic to a more generalized `Routes`

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -22,10 +22,18 @@ const deleteTunnelWebhook = (
   if (nylasWebhook && nylasWebhook.id) {
     /* eslint-disable no-console */
     console.log(
-      'Shutting down the webhook tunnel and deleting id: ' + nylasWebhook.id
+      `Shutting down the webhook tunnel and deleting id: ${nylasWebhook.id}`
     );
     /* eslint-enable no-console */
-    nylasClient.webhooks.delete(nylasWebhook).then(() => process.exit());
+    nylasClient.webhooks
+      .delete(nylasWebhook)
+      .then(() => process.exit())
+      .catch((err: Error) => {
+        console.warn(
+          `Error while trying to deregister the webhook ${nylasWebhook.id}: ${err.message}`
+        );
+        process.exit();
+      });
   }
 };
 


### PR DESCRIPTION
# Description
This PR adds error handling when deleting a webhook. Sometimes if a webhook is terminated via the dashboard or API before the SDK handles it, the SDK throws an error when attempting to delete the webhook. Now, it will warn the user but it won't cause a fatal error anymore.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.