### PR TITLE
Add support for calendar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for calendar colors (for Microsoft calendars)
+
 ### 6.5.1 / 2022-09-16
 * Add additional `Event` fields
 * Fix issue with `EventParticipant` not sending status on new event creation

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -33,6 +33,7 @@ describe('Calendar', () => {
       object: 'calendar',
       read_only: false,
       timezone: 'America/Los_Angeles',
+      color: 1,
     };
     jest.spyOn(testContext.connection, 'request');
 
@@ -69,10 +70,11 @@ describe('Calendar', () => {
     expect(calendar.timezone).toEqual('America/Los_Angeles');
     expect(calendar.readOnly).toEqual(false);
     expect(calendar.jobStatusId).toEqual('48pp6ijzrxpw9jors9ylnsxnf');
+    expect(calendar.color).toEqual(1);
   };
 
   test('[SAVE] should do a POST request if the calendar has no id', done => {
-    expect.assertions(13);
+    expect.assertions(14);
     testContext.calendar.id = undefined;
     testContext.calendar.save().then(calendar => {
       const options = testContext.connection.request.mock.calls[0][0];
@@ -91,7 +93,7 @@ describe('Calendar', () => {
   });
 
   test('[SAVE] should do a PUT request if the event has an id', done => {
-    expect.assertions(13);
+    expect.assertions(14);
     testContext.calendar.id = '8e570s302fdazx9zqwiuk9jqn';
     testContext.calendar.description = 'Updated description';
     testContext.calendar.metadata = {
@@ -119,7 +121,7 @@ describe('Calendar', () => {
   });
 
   test('[FIND] should use correct method and route', done => {
-    expect.assertions(12);
+    expect.assertions(13);
     testContext.connection.calendars
       .find('8e570s302fdazx9zqwiuk9jqn')
       .then(calendar => {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -13,6 +13,7 @@ export type CalendarProperties = {
   isPrimary?: boolean;
   jobStatusId?: string;
   metadata?: object;
+  color?: number;
 };
 
 export default class Calendar extends RestfulModel
@@ -25,6 +26,7 @@ export default class Calendar extends RestfulModel
   isPrimary?: boolean;
   jobStatusId?: string;
   metadata?: object;
+  color?: number;
   static collectionName = 'calendars';
   static attributes: Record<string, Attribute> = {
     ...RestfulModel.attributes,
@@ -57,6 +59,10 @@ export default class Calendar extends RestfulModel
     }),
     metadata: Attributes.Object({
       modelKey: 'metadata',
+    }),
+    color: Attributes.Number({
+      modelKey: 'color',
+      readOnly: true,
     }),
   };
 


### PR DESCRIPTION
# Description
This PR adds support for the new colors field in the Calendar model. Please note that this field is read only, and for Microsoft calendars only.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.