### PR TITLE
Add additional fields for job status webhook notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add additional fields for job status webhook notifications
+
 ### 6.5.1 / 2022-09-16
 * Add additional `Event` fields
 * Fix issue with `EventParticipant` not sending status on new event creation

--- a/__tests__/webhook-notification-spec.js
+++ b/__tests__/webhook-notification-spec.js
@@ -24,8 +24,15 @@ describe('Webhook Notification', () => {
               action: 'save_draft',
               job_status_id: 'abc1234',
               thread_id: '2u152dt4tnq9j61j8seg26ni6',
+              message_id: '1hhg2m8bagpkeddtrsg6t4xav',
               received_date: 1602623166,
+              extras: {
+                reason: 'testing',
+                send_at: 1602623166,
+                original_send_at: 1602623166,
+              },
             },
+
             id: '93mgpjynqqu5fohl2dvv6ray7',
             metadata: {
               sender_app_id: 64280,
@@ -85,7 +92,17 @@ describe('Webhook Notification', () => {
     expect(webhookDeltaObjectAttributes.threadId).toEqual(
       '2u152dt4tnq9j61j8seg26ni6'
     );
+    expect(webhookDeltaObjectAttributes.messageId).toEqual(
+      '1hhg2m8bagpkeddtrsg6t4xav'
+    );
     expect(webhookDeltaObjectAttributes.receivedDate).toEqual(
+      new Date(1602623166 * 1000)
+    );
+
+    const webhookObjectExtras = webhookDeltaObjectAttributes.extras;
+    expect(webhookObjectExtras.reason).toEqual('testing');
+    expect(webhookObjectExtras.sendAt).toEqual(new Date(1602623166 * 1000));
+    expect(webhookObjectExtras.originalSendAt).toEqual(
       new Date(1602623166 * 1000)
     );
 

--- a/src/models/webhook-notification.ts
+++ b/src/models/webhook-notification.ts
@@ -183,6 +183,8 @@ export class WebhookObjectAttributes extends Model
   // Job Status specific fields
   action?: string;
   jobStatusId?: string;
+  messageId?: string;
+  extras?: WebhookObjectExtrasProperties;
 
   // Message specific fields
   threadId?: string;
@@ -195,6 +197,10 @@ export class WebhookObjectAttributes extends Model
       modelKey: 'jobStatusId',
       jsonKey: 'job_status_id',
     }),
+    messageId: Attributes.String({
+      modelKey: 'messageId',
+      jsonKey: 'message_id',
+    }),
     threadId: Attributes.String({
       modelKey: 'threadId',
       jsonKey: 'thread_id',
@@ -202,6 +208,10 @@ export class WebhookObjectAttributes extends Model
     receivedDate: Attributes.DateTime({
       modelKey: 'receivedDate',
       jsonKey: 'received_date',
+    }),
+    extras: Attributes.Object({
+      modelKey: 'extras',
+      itemClass: WebhookObjectExtras,
     }),
   };
 

--- a/src/models/webhook-notification.ts
+++ b/src/models/webhook-notification.ts
@@ -144,6 +144,33 @@ export class MessageTrackingData extends Model
   }
 }
 
+export type WebhookObjectExtrasProperties = {
+  reason?: string;
+  sendAt?: Date;
+  originalSendAt?: Date;
+};
+
+export class WebhookObjectExtras extends Model
+  implements WebhookObjectExtrasProperties {
+  reason?: string;
+  sendAt?: Date;
+  originalSendAt?: Date;
+
+  static attributes: Record<string, Attribute> = {
+    reason: Attributes.String({
+      modelKey: 'reason',
+    }),
+    sendAt: Attributes.DateTime({
+      modelKey: 'sendAt',
+      jsonKey: 'send_at',
+    }),
+    originalSendAt: Attributes.DateTime({
+      modelKey: 'originalSendAt',
+      jsonKey: 'original_send_at',
+    }),
+  };
+}
+
 export type WebhookObjectAttributesProperties = {
   action?: string;
   jobStatusId?: string;


### PR DESCRIPTION
# Description
This PR adds additional fields for the webhook notification class. There's also a new model, `WebhookObjectExtras` for extra fields that can appear for job status notifications.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.