### PR TITLE
TSDK-417 Adding Event Reminders to Event Object

### DIFF
--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -429,10 +429,6 @@ describe('Event', () => {
     test('should add reminder method and minutes if defined', done => {
       testContext.event.reminderMinutes = '[20]';
       testContext.event.reminderMethod = 'popup';
-      testContext.event.reminders = new EventReminder({
-        reminderMinutes: '[20]',
-        reminderMethod: 'popup',
-      });
       testContext.event.save().then(() => {
         const options = testContext.connection.request.mock.calls[0][0];
         expect(options.url.toString()).toEqual('https://api.nylas.com/events');
@@ -448,22 +444,9 @@ describe('Event', () => {
           notifications: undefined,
           reminder_method: 'popup',
           reminder_minutes: '[20]',
-          reminders: {
-            reminder_method: 'popup',
-            reminder_minutes: '[20]',
-          },
         });
         done();
       });
-    });
-
-    test('should throw an error if  reminder method and minutes is defined in PUT request', done => {
-      testContext.event.reminderMinutes = '[20]';
-      testContext.event.reminderMethod = 'popup';
-      testContext.event.id = 'reminder123';
-
-      expect(() => testContext.event.save()).toThrow();
-      done();
     });
 
     describe('conferencing', () => {

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 import When from '../src/models/when';
 import EventParticipant from '../src/models/event-participant';
 import { ICSMethod } from '../src/models/event';
+import { EventReminder } from '../src/models/event-reminder-method';
 
 jest.mock('node-fetch', () => {
   const { Request, Response } = jest.requireActual('node-fetch');
@@ -423,6 +424,46 @@ describe('Event', () => {
         });
         done();
       });
+    });
+
+    test('should add reminder method and minutes if defined', done => {
+      testContext.event.reminderMinutes = '[20]';
+      testContext.event.reminderMethod = 'popup';
+      testContext.event.reminders = new EventReminder({
+        reminderMinutes: '[20]',
+        reminderMethod: 'popup',
+      });
+      testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/events');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: '',
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: {},
+          participants: [],
+          notifications: undefined,
+          reminder_method: 'popup',
+          reminder_minutes: '[20]',
+          reminders: {
+            reminder_method: 'popup',
+            reminder_minutes: '[20]',
+          },
+        });
+        done();
+      });
+    });
+
+    test('should throw an error if  reminder method and minutes is defined in PUT request', done => {
+      testContext.event.reminderMinutes = '[20]';
+      testContext.event.reminderMethod = 'popup';
+      testContext.event.id = 'reminder123';
+
+      expect(() => testContext.event.save()).toThrow();
+      done();
     });
 
     describe('conferencing', () => {

--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -449,6 +449,35 @@ describe('Event', () => {
       });
     });
 
+    test('should not serialize reminder object is defined', done => {
+      testContext.event.reminders = new EventReminder({
+        reminderMinutes: '[20]',
+        reminderMethod: 'popup',
+      });
+      testContext.event.id = 'reminder123';
+
+      testContext.event.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual(
+          'https://api.nylas.com/events/reminder123'
+        );
+        expect(options.method).toEqual('PUT');
+        expect(JSON.parse(options.body)).toEqual({
+          calendar_id: '',
+          busy: undefined,
+          title: undefined,
+          description: undefined,
+          location: undefined,
+          when: {},
+          participants: [],
+          notifications: undefined,
+          reminder_method: undefined,
+          reminder_minutes: undefined,
+        });
+        done();
+      });
+    });
+
     describe('conferencing', () => {
       test('should create an event with conferencing details', done => {
         testContext.event.conferencing = new EventConferencing({

--- a/src/models/event-reminder-method.ts
+++ b/src/models/event-reminder-method.ts
@@ -1,0 +1,34 @@
+import Attributes, { Attribute } from './attributes';
+import Model from './model';
+
+export enum EventReminderMethod {
+  Email = 'email',
+  Popup = 'popup',
+  Display = 'display',
+  Sound = 'sound',
+}
+
+export type EventReminderProperties = {
+  reminderMinutes?: string;
+  reminderMethod?: EventReminderMethod;
+};
+
+export class EventReminder extends Model implements EventReminderProperties {
+  reminderMinutes?: string;
+  reminderMethod?: EventReminderMethod;
+  static attributes: Record<string, Attribute> = {
+    reminderMinutes: Attributes.String({
+      modelKey: 'reminderMinutes',
+      jsonKey: 'reminder_minutes',
+    }),
+    reminderMethod: Attributes.String({
+      modelKey: 'reminderMethod',
+      jsonKey: 'reminder_method',
+    }),
+  };
+
+  constructor(props?: EventReminderProperties) {
+    super();
+    this.initAttributes(props);
+  }
+}

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -11,6 +11,11 @@ import NylasConnection from '../nylas-connection';
 import EventNotification, {
   EventNotificationProperties,
 } from './event-notification';
+import {
+  EventReminder,
+  EventReminderMethod,
+  EventReminderProperties,
+} from './event-reminder-method';
 
 export enum ICSMethod {
   Request = 'request',
@@ -57,6 +62,9 @@ export type EventProperties = {
   organizerName?: string;
   visibility?: string;
   customerEventId?: string;
+  reminderMinutes?: string;
+  reminderMethod?: EventReminderMethod;
+  reminders?: EventReminderProperties;
 };
 
 export default class Event extends RestfulModel {
@@ -81,7 +89,9 @@ export default class Event extends RestfulModel {
   originalStartTime?: Date;
   capacity?: number;
   conferencing?: EventConferencing;
+  readonly reminders?: EventReminder;
   reminderMinutes?: string;
+  reminderMethod?: EventReminderMethod;
   notifications?: EventNotification[];
   roundRobinOrder?: string[];
   metadata?: object;
@@ -166,6 +176,15 @@ export default class Event extends RestfulModel {
     reminderMinutes: Attributes.String({
       modelKey: 'reminderMinutes',
       jsonKey: 'reminder_minutes',
+    }),
+    reminderMethod: Attributes.String({
+      modelKey: 'reminderMethod',
+      jsonKey: 'reminder_method',
+    }),
+    reminders: Attributes.Object({
+      modelKey: 'reminders',
+      jsonKey: 'reminders',
+      itemClass: EventReminder,
     }),
     notifications: Attributes.Collection({
       modelKey: 'notifications',
@@ -392,6 +411,18 @@ export default class Event extends RestfulModel {
     ) {
       throw new Error(
         'The number of participants in the event exceeds the set capacity.'
+      );
+    }
+
+    if (
+      this.id &&
+      ((this.reminders &&
+        (this.reminders.reminderMethod || this.reminders.reminderMinutes)) ||
+        this.reminderMethod ||
+        this.reminderMinutes)
+    ) {
+      throw new Error(
+        'reminder_minutes and reminderMethod is only Available for POST /events only'
       );
     }
   }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -185,7 +185,7 @@ export default class Event extends RestfulModel {
       modelKey: 'reminders',
       jsonKey: 'reminders',
       itemClass: EventReminder,
-      readOnly: true
+      readOnly: true,
     }),
     notifications: Attributes.Collection({
       modelKey: 'notifications',
@@ -412,16 +412,6 @@ export default class Event extends RestfulModel {
     ) {
       throw new Error(
         'The number of participants in the event exceeds the set capacity.'
-      );
-    }
-
-    if (
-      this.id &&
-        this.reminderMethod ||
-        this.reminderMinutes)
-    ) {
-      throw new Error(
-        'reminder_minutes and reminderMethod is only Available for POST /events only'
       );
     }
   }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -417,8 +417,6 @@ export default class Event extends RestfulModel {
 
     if (
       this.id &&
-      ((this.reminders &&
-        (this.reminders.reminderMethod || this.reminders.reminderMinutes)) ||
         this.reminderMethod ||
         this.reminderMinutes)
     ) {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -185,6 +185,7 @@ export default class Event extends RestfulModel {
       modelKey: 'reminders',
       jsonKey: 'reminders',
       itemClass: EventReminder,
+      readOnly: true
     }),
     notifications: Attributes.Collection({
       modelKey: 'notifications',


### PR DESCRIPTION
# Description

Adding Event Reminder method to the Event object. Just creating a PR to see if I am on the right track here. I can see that our Object Schema from our API and the response we get back differ. There is some duplication that needed to be done to get this working. However, in this.validate() I am adding some validations to make sure the request passes through.

Questions And Concerns

So I am making sure no reminders are set on PUT calls using the id field
I still need to add some tests to test out read and write for this property
Also when you get the response back we get a reminders object :( So Mapping is different, so I had to duplicate some value with how our fromJson and toJson behave. But the weird thing is reminder_minutes is a string in the post request but it is an integer in the response

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.