### PR TITLE
v6.6.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-### Unreleased
+### 6.6.0 / 2022-10-14
 * Add additional fields for job status webhook notifications
 * Add support for calendar colors (for Microsoft calendars)
+* Add support for event reminders
+* Fix typo in `SchedulerBooking.calendarInviteToGuests` attribute
+* Bump `minimist` sub-dependency from 1.2.5 to 1.2.6
 
 ### 6.5.1 / 2022-09-16
 * Add additional `Event` fields

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.5.1",
+      "version": "6.6.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New `nylas` v6.6.0 release provides the following changes:
* Add additional fields for job status webhook notifications (#398)
* Add support for calendar colors (for Microsoft calendars) (#397)
* Add support for event reminders (#399)
* Fix typo in `SchedulerBooking.calendarInviteToGuests` attribute (#393)
* Bump `minimist` sub-dependency from 1.2.5 to 1.2.6 (#389)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.