### PR TITLE
Fix calendar color implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Fix broken calendar color implementation
+* Fix calendar color implementation
 
 ### 6.6.0 / 2022-10-14
 * Add additional fields for job status webhook notifications

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fix broken calendar color implementation
+
 ### 6.6.0 / 2022-10-14
 * Add additional fields for job status webhook notifications
 * Add support for calendar colors (for Microsoft calendars)

--- a/__tests__/calendar-spec.js
+++ b/__tests__/calendar-spec.js
@@ -33,7 +33,7 @@ describe('Calendar', () => {
       object: 'calendar',
       read_only: false,
       timezone: 'America/Los_Angeles',
-      color: 1,
+      hex_color: '#0099EE',
     };
     jest.spyOn(testContext.connection, 'request');
 
@@ -70,7 +70,7 @@ describe('Calendar', () => {
     expect(calendar.timezone).toEqual('America/Los_Angeles');
     expect(calendar.readOnly).toEqual(false);
     expect(calendar.jobStatusId).toEqual('48pp6ijzrxpw9jors9ylnsxnf');
-    expect(calendar.color).toEqual(1);
+    expect(calendar.hexColor).toEqual('#0099EE');
   };
 
   test('[SAVE] should do a POST request if the calendar has no id', done => {

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -13,7 +13,7 @@ export type CalendarProperties = {
   isPrimary?: boolean;
   jobStatusId?: string;
   metadata?: object;
-  color?: number;
+  hexColor?: string;
 };
 
 export default class Calendar extends RestfulModel
@@ -26,7 +26,7 @@ export default class Calendar extends RestfulModel
   isPrimary?: boolean;
   jobStatusId?: string;
   metadata?: object;
-  color?: number;
+  hexColor?: string;
   static collectionName = 'calendars';
   static attributes: Record<string, Attribute> = {
     ...RestfulModel.attributes,
@@ -60,8 +60,9 @@ export default class Calendar extends RestfulModel
     metadata: Attributes.Object({
       modelKey: 'metadata',
     }),
-    color: Attributes.Number({
-      modelKey: 'color',
+    hexColor: Attributes.String({
+      modelKey: 'hexColor',
+      jsonKey: 'hex_color',
       readOnly: true,
     }),
   };


### PR DESCRIPTION
# Description
In #397 the implementation in the SDK was based off of an earlier implementation from the API, this PR adjusts the field name and type to reflect what's provided in the Nylas API.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.