### PR TITLE
Add Node engine entry to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added engine entry to `package.json` for minimum Node 14
+
 ### 7.0.0-canary.5 / TBD
 * **BREAKING CHANGE**: Rename `confirmationEmailToHost` to `confirmationEmailsToHost` in `SchedulerBooking`
 * Gracefully handle error on webhook deletion

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "files": [
     "lib"
   ],
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "test": "jest",
     "test:coverage": "npm run test -- --coverage",


### PR DESCRIPTION
# Description
This PR adds an engine entry to the `package.json` targeting Node 14 and above. It's a best practice to outright define an engine entry in `package.json` and we've chosen the lowest currently supported Node version. Compatibility was verified using `ls-engine`. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.