### PR TITLE
Add Rate Limit error support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added support for rate limit errors
+
 ## 6.6.1 / 2022-10-21
 * Fix calendar color implementation
 

--- a/src/models/rate-limit-error.ts
+++ b/src/models/rate-limit-error.ts
@@ -1,12 +1,23 @@
 import NylasApiError from './nylas-api-error';
 import { Headers } from 'node-fetch';
 
+/**
+ * This error class represents a 429 error response, with details on the rate limit
+ */
+
 export default class RateLimitError extends NylasApiError {
   static RATE_LIMIT_STATUS_CODE = 429;
   static RATE_LIMIT_LIMIT_HEADER = 'X-RateLimit-Limit';
   static RATE_LIMIT_RESET_HEADER = 'X-RateLimit-Reset';
 
+  /**
+   * The rate limit
+   */
   rateLimit?: number;
+
+  /**
+   * The rate limit expiration time, in seconds
+   */
   rateLimitReset?: number;
 
   constructor(
@@ -20,6 +31,12 @@ export default class RateLimitError extends NylasApiError {
     this.rateLimitReset = rateLimitReset;
   }
 
+  /**
+   * Parses an API response and generates a 429 error with details filled in
+   * @param parsedApiError The response parsed as a JSON
+   * @param headers The response headers
+   * @return The error with the rate limit details filled in
+   */
   static parseErrorResponse(
     parsedApiError: Record<string, string>,
     headers: Headers

--- a/src/models/rate-limit-error.ts
+++ b/src/models/rate-limit-error.ts
@@ -1,0 +1,23 @@
+import NylasApiError from './nylas-api-error';
+import { Headers } from 'node-fetch';
+
+export default class RateLimitError extends NylasApiError {
+  static RATE_LIMIT_STATUS_CODE = 429;
+  static RATE_LIMIT_LIMIT_HEADER = 'X-RateLimit-Limit';
+  static RATE_LIMIT_RESET_HEADER = 'X-RateLimit-Reset';
+
+  rateLimit?: number;
+  rateLimitReset?: number;
+
+  constructor(
+    type: string,
+    message: string,
+    rateLimit?: number,
+    rateLimitReset?: number
+  ) {
+    super(RateLimitError.RATE_LIMIT_STATUS_CODE, type, message);
+    this.rateLimit = rateLimit;
+    this.rateLimitReset = rateLimitReset;
+  }
+  }
+}

--- a/src/models/rate-limit-error.ts
+++ b/src/models/rate-limit-error.ts
@@ -41,15 +41,11 @@ export default class RateLimitError extends NylasApiError {
     parsedApiError: Record<string, string>,
     headers: Headers
   ): RateLimitError {
-    const rateLimitString = headers.get(this.RATE_LIMIT_LIMIT_HEADER);
-    const rateLimitResetString = headers.get(this.RATE_LIMIT_RESET_HEADER);
+    const rateLimit =
+      Number(headers.get(this.RATE_LIMIT_LIMIT_HEADER)) || undefined;
+    const rateLimitReset =
+      Number(headers.get(this.RATE_LIMIT_RESET_HEADER)) || undefined;
 
-    const rateLimit = !isNaN(Number(rateLimitString))
-      ? Number(rateLimitString)
-      : undefined;
-    const rateLimitReset = !isNaN(Number(rateLimitResetString))
-      ? Number(rateLimitResetString)
-      : undefined;
     return new RateLimitError(
       parsedApiError.type,
       parsedApiError.message,

--- a/src/models/rate-limit-error.ts
+++ b/src/models/rate-limit-error.ts
@@ -19,5 +19,25 @@ export default class RateLimitError extends NylasApiError {
     this.rateLimit = rateLimit;
     this.rateLimitReset = rateLimitReset;
   }
+
+  static parseErrorResponse(
+    parsedApiError: Record<string, string>,
+    headers: Headers
+  ): RateLimitError {
+    const rateLimitString = headers.get(this.RATE_LIMIT_LIMIT_HEADER);
+    const rateLimitResetString = headers.get(this.RATE_LIMIT_RESET_HEADER);
+
+    const rateLimit = !isNaN(Number(rateLimitString))
+      ? Number(rateLimitString)
+      : undefined;
+    const rateLimitReset = !isNaN(Number(rateLimitResetString))
+      ? Number(rateLimitResetString)
+      : undefined;
+    return new RateLimitError(
+      parsedApiError.type,
+      parsedApiError.message,
+      rateLimit,
+      rateLimitReset
+    );
   }
 }


### PR DESCRIPTION
# Description
This PR adds support for rate limit 429 headers from the API.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.