### PR TITLE
Changed Event `visibility` field to be writeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Added support for rate limit errors
+* Changed Event `visibility` field to be writeable
 
 ## 6.6.1 / 2022-10-21
 * Fix calendar color implementation

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -215,7 +215,6 @@ export default class Event extends RestfulModel {
     }),
     visibility: Attributes.String({
       modelKey: 'visibility',
-      readOnly: true,
     }),
     customerEventId: Attributes.String({
       modelKey: 'customerEventId',


### PR DESCRIPTION
# Description
Changed the Event `visibility` field from being read-only to writable to have parity with the recent API changes.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.