### PR TITLE
Added responseType to AuthenticateUrlConfig

### DIFF
--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -261,6 +261,38 @@ describe('Nylas', () => {
         `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&scopes=${scopes[0]},${scopes[1]}`
       );
     });
+
+    test('should add response type when provided in the options', () => {
+      const loginHint = 'ben@nylas.com',
+        scopes = ['calendar', 'contacts'],
+        responseType = 'token';
+
+      const options = {
+        loginHint,
+        redirectURI,
+        scopes,
+        responseType,
+      };
+
+      expect(Nylas.urlForAuthentication(options)).toEqual(
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=token&login_hint=${loginHint}&redirect_uri=${redirectURI}&scopes=${scopes[0]},${scopes[1]}`
+      );
+    });
+
+    test('should default to response_type = code when not provided in the options', () => {
+      const loginHint = 'ben@nylas.com',
+        scopes = ['calendar', 'contacts'];
+
+      const options = {
+        loginHint,
+        redirectURI,
+        scopes,
+      };
+
+      expect(Nylas.urlForAuthentication(options)).toEqual(
+        `https://api.nylas.com/oauth/authorize?client_id=newId&response_type=code&login_hint=${loginHint}&redirect_uri=${redirectURI}&scopes=${scopes[0]},${scopes[1]}`
+      );
+    });
   });
 
   describe('application', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,11 @@ export type NylasConfig = {
   apiServer?: string;
 };
 
+export enum ResponseType {
+  CODE = 'code',
+  TOKEN = 'token',
+}
+
 export type AuthenticateUrlConfig = {
   redirectURI: string;
   redirectOnError?: boolean;
@@ -21,4 +26,5 @@ export type AuthenticateUrlConfig = {
   state?: string;
   provider?: string;
   scopes?: string[];
+  responseType?: ResponseType;
 };

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -9,7 +9,7 @@ import Connect from './models/connect';
 import RestfulModelCollection from './models/restful-model-collection';
 import ManagementModelCollection from './models/management-model-collection';
 import Webhook from './models/webhook';
-import { AuthenticateUrlConfig, NylasConfig } from './config';
+import { AuthenticateUrlConfig, NylasConfig, ResponseType } from './config';
 import AccessToken from './models/access-token';
 import ApplicationDetails, {
   ApplicationDetailsProperties,
@@ -173,7 +173,11 @@ class Nylas {
     if (!options.loginHint) {
       options.loginHint = '';
     }
-    let url = `${this.apiServer}/oauth/authorize?client_id=${this.clientId}&response_type=code&login_hint=${options.loginHint}&redirect_uri=${options.redirectURI}`;
+    let url = `${this.apiServer}/oauth/authorize?client_id=${
+      this.clientId
+    }&response_type=${options.responseType || ResponseType.CODE}&login_hint=${
+      options.loginHint
+    }&redirect_uri=${options.redirectURI}`;
     if (options.state != null) {
       url += `&state=${options.state}`;
     }


### PR DESCRIPTION
# Description

Our Hosted Authentication method doesn't give the ability to change the response_type query parameter. Added the functionality to do that. It will either be `token` or `code`. If none provided it will default to the `code` as expected.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.