### PR TITLE
[v7] Introduce query params, improved typing, other DevEx improvements for

### DIFF
--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -8,7 +8,6 @@ import CalendarAvailability, {
   OpenHours,
   SingleAvailabilityQuery,
 } from './calendar-availability';
-import { SaveCallback } from './restful-model';
 import { MetadataQuery, RestfulQuery } from './model-collection';
 
 export interface CalendarQuery extends RestfulQuery {
@@ -25,6 +24,13 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
     super(Calendar, connection);
     this.connection = connection;
     this.modelClass = Calendar;
+  }
+
+  create(
+    props: CalendarProperties,
+    callback?: (error: Error | null, result?: Calendar) => void
+  ): Promise<Calendar> {
+    return new Calendar(this.connection, props).save(callback);
   }
 
   list(

--- a/src/models/calendar-restful-model-collection.ts
+++ b/src/models/calendar-restful-model-collection.ts
@@ -1,4 +1,4 @@
-import Calendar from './calendar';
+import Calendar, { CalendarProperties } from './calendar';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
 import FreeBusy, { FreeBusyCalendar, FreeBusyQuery } from './free-busy';
@@ -8,6 +8,12 @@ import CalendarAvailability, {
   OpenHours,
   SingleAvailabilityQuery,
 } from './calendar-availability';
+import { SaveCallback } from './restful-model';
+import { MetadataQuery, RestfulQuery } from './model-collection';
+
+export interface CalendarQuery extends RestfulQuery {
+  metadata?: MetadataQuery;
+}
 
 export default class CalendarRestfulModelCollection extends RestfulModelCollection<
   Calendar
@@ -19,6 +25,13 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
     super(Calendar, connection);
     this.connection = connection;
     this.modelClass = Calendar;
+  }
+
+  list(
+    params: CalendarQuery = {},
+    callback?: (error: Error | null, obj?: Calendar[]) => void
+  ): Promise<Calendar[]> {
+    return super.list(this.formatQuery(params), callback);
   }
 
   freeBusy(
@@ -182,5 +195,12 @@ export default class CalendarRestfulModelCollection extends RestfulModelCollecti
       throw new Error("Must set either 'emails' or 'calendars' in the query.");
     }
     return true;
+  }
+
+  protected formatQuery(query: CalendarQuery): Record<string, unknown> {
+    return {
+      ...super.formatQuery(query),
+      metadata: this.formatMetadataQuery(query.metadata),
+    };
   }
 }

--- a/src/models/component-restful-model-collection.ts
+++ b/src/models/component-restful-model-collection.ts
@@ -1,6 +1,6 @@
 import RestfulModelCollection from './restful-model-collection';
 import NylasConnection from '../nylas-connection';
-import Component from './component';
+import Component, { ComponentProperties } from './component';
 
 export default class ComponentRestfulModelCollection extends RestfulModelCollection<
   Component
@@ -12,6 +12,13 @@ export default class ComponentRestfulModelCollection extends RestfulModelCollect
     super(Component, connection);
     this.connection = connection;
     this.modelClass = Component;
+  }
+
+  create(
+    props: ComponentProperties,
+    callback?: (error: Error | null, result?: Component) => void
+  ): Promise<Component> {
+    return new Component(this.connection, props).save(callback);
   }
 
   path(): string {

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -27,6 +27,13 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
     this.modelClass = Contact;
   }
 
+  create(
+    props: ContactProperties,
+    callback?: (error: Error | null, obj?: Contact) => void
+  ): Promise<Contact> {
+    return new Contact(this.connection, props).save(callback);
+  }
+
   list(
     params: ContactQuery = {},
     callback?: (error: Error | null, obj?: Contact[]) => void

--- a/src/models/contact-restful-model-collection.ts
+++ b/src/models/contact-restful-model-collection.ts
@@ -1,6 +1,19 @@
-import Contact, { Group } from './contact';
+import Contact, { ContactProperties, Group } from './contact';
 import NylasConnection from '../nylas-connection';
 import RestfulModelCollection from './restful-model-collection';
+import { RestfulQuery } from './model-collection';
+
+export interface ContactQuery extends RestfulQuery {
+  email?: string;
+  phoneNumber?: string;
+  streetAddress?: string;
+  postalCode?: string;
+  state?: string;
+  country?: string;
+  source?: string;
+  groupId?: string;
+  recurse?: boolean;
+}
 
 export default class ContactRestfulModelCollection extends RestfulModelCollection<
   Contact
@@ -12,6 +25,13 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
     super(Contact, connection);
     this.connection = connection;
     this.modelClass = Contact;
+  }
+
+  list(
+    params: ContactQuery = {},
+    callback?: (error: Error | null, obj?: Contact[]) => void
+  ): Promise<Contact[]> {
+    return super.list(this.formatQuery(params), callback);
   }
 
   groups(
@@ -37,5 +57,19 @@ export default class ContactRestfulModelCollection extends RestfulModelCollectio
         }
         return Promise.reject(err);
       });
+  }
+
+  protected formatQuery(query: ContactQuery): Record<string, unknown> {
+    return {
+      ...super.formatQuery(query),
+      email: query.email,
+      phone_number: query.phoneNumber,
+      postal_code: query.postalCode,
+      state: query.state,
+      country: query.country,
+      source: query.source,
+      group_id: query.groupId,
+      recurse: query.recurse,
+    };
   }
 }

--- a/src/models/draft-restful-model-collection.ts
+++ b/src/models/draft-restful-model-collection.ts
@@ -1,0 +1,45 @@
+import RestfulModelCollection from './restful-model-collection';
+import Draft, { DraftProperties, SendOptions } from './draft';
+import NylasConnection from '../nylas-connection';
+import { SaveCallback } from './model';
+import Message from './message';
+import MessageRestfulModelCollection, {
+  MessageQuery,
+} from './message-restful-model-collection';
+
+export default class DraftRestfulModelCollection extends RestfulModelCollection<
+  Draft
+> {
+  constructor(connection: NylasConnection) {
+    super(Draft, connection);
+  }
+
+  send(props: DraftProperties, callback?: SendOptions): Promise<Message> {
+    return new Draft(this.connection, props).send(callback);
+  }
+
+  list(
+    params: MessageQuery,
+    callback?: (error: Error | null, obj?: Draft[]) => void
+  ): Promise<Draft[]> {
+    return super.list(params, callback);
+  }
+
+  protected formatQuery(query: MessageQuery): Record<string, unknown> {
+    const receivedBefore = RestfulModelCollection.formatTimestampQuery(
+      query.receivedBefore
+    );
+    const receivedAfter = RestfulModelCollection.formatTimestampQuery(
+      query.receivedAfter
+    );
+
+    return {
+      ...super.formatQuery(query),
+      ...MessageRestfulModelCollection.formatBaseMessageQuery(query),
+      thread_id: query.threadId,
+      has_attachment: query.hasAttachment,
+      received_before: receivedBefore,
+      received_after: receivedAfter,
+    };
+  }
+}

--- a/src/models/draft-restful-model-collection.ts
+++ b/src/models/draft-restful-model-collection.ts
@@ -1,7 +1,6 @@
 import RestfulModelCollection from './restful-model-collection';
 import Draft, { DraftProperties, SendOptions } from './draft';
 import NylasConnection from '../nylas-connection';
-import { SaveCallback } from './model';
 import Message from './message';
 import MessageRestfulModelCollection, {
   MessageQuery,
@@ -12,6 +11,13 @@ export default class DraftRestfulModelCollection extends RestfulModelCollection<
 > {
   constructor(connection: NylasConnection) {
     super(Draft, connection);
+  }
+
+  create(
+    props: DraftProperties,
+    callback?: (error: Error | null, result?: Draft) => void
+  ): Promise<Draft> {
+    return new Draft(this.connection, props).save(callback);
   }
 
   send(props: DraftProperties, callback?: SendOptions): Promise<Message> {

--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -15,6 +15,18 @@ export type DraftProperties = MessageProperties & {
   fileIdsToAttach?: string[];
 };
 
+interface MessageTracking {
+  links?: boolean;
+  opens?: boolean;
+  threadReplies?: boolean;
+  payload?: string;
+}
+
+export interface SendOptions {
+  tracking?: MessageTracking;
+  callback?: SendCallback;
+}
+
 export default class Draft extends Message implements DraftProperties {
   rawMime?: string;
   replyToMessageId?: string;
@@ -98,23 +110,9 @@ export default class Draft extends Message implements DraftProperties {
     return super.toString();
   }
 
-  send(
-    trackingArg?: Record<string, any> | SendCallback | null,
-    callbackArg?: SendCallback | Record<string, any> | null
-  ): Promise<Message> {
+  send(options: SendOptions = {}): Promise<Message> {
     // callback used to be the first argument, and tracking was the second
-    let callback: SendCallback | undefined;
-    if (typeof callbackArg === 'function') {
-      callback = callbackArg as SendCallback;
-    } else if (typeof trackingArg === 'function') {
-      callback = trackingArg as SendCallback;
-    }
-    let tracking: Record<string, any> | undefined;
-    if (trackingArg && typeof trackingArg === 'object') {
-      tracking = trackingArg;
-    } else if (callbackArg && typeof callbackArg === 'object') {
-      tracking = callbackArg;
-    }
+    const { tracking, callback } = options;
 
     let body: any = this.rawMime,
       headers: Record<string, string> = { 'Content-Type': 'message/rfc822' },

--- a/src/models/event-restful-model-collection.ts
+++ b/src/models/event-restful-model-collection.ts
@@ -27,6 +27,13 @@ export class EventRestfulModelCollection extends RestfulModelCollection<Event> {
     super(Event, connection);
   }
 
+  create(
+    props: EventProperties,
+    callback?: (error: Error | null, result?: Event) => void
+  ): Promise<Event> {
+    return new Event(this.connection, props).save(callback);
+  }
+
   list(
     params: EventQuery,
     callback?: (error: Error | null, obj?: Event[]) => void

--- a/src/models/event-restful-model-collection.ts
+++ b/src/models/event-restful-model-collection.ts
@@ -1,0 +1,68 @@
+import RestfulModelCollection from './restful-model-collection';
+import Event, { EventProperties } from './event';
+import NylasConnection from '../nylas-connection';
+import { MetadataQuery, RestfulQuery } from './model-collection';
+
+export interface EventQuery extends RestfulQuery {
+  eventId?: string;
+  calendarId?: string;
+  title?: string;
+  description?: string;
+  location?: string;
+  participants?: string;
+  startsBefore?: Date | number;
+  startsAfter?: Date | number;
+  endsBefore?: Date | number;
+  endsAfter?: Date | number;
+  updatedAtBefore?: Date | number;
+  updatedAtAfter?: Date | number;
+  expandRecurring?: boolean;
+  busy?: boolean;
+  showCancelled?: boolean;
+  metadata?: MetadataQuery;
+}
+
+export class EventRestfulModelCollection extends RestfulModelCollection<Event> {
+  constructor(connection: NylasConnection) {
+    super(Event, connection);
+  }
+
+  list(
+    params: EventQuery,
+    callback?: (error: Error | null, obj?: Event[]) => void
+  ): Promise<Event[]> {
+    return super.list(params, callback);
+  }
+
+  protected formatQuery(query: EventQuery): Record<string, unknown> {
+    return {
+      ...super.formatQuery(query),
+      event_id: query.eventId,
+      calendar_id: query.calendarId,
+      title: query.title,
+      description: query.description,
+      location: query.location,
+      participants: query.participants,
+      starts_before: RestfulModelCollection.formatTimestampQuery(
+        query.startsBefore
+      ),
+      starts_after: RestfulModelCollection.formatTimestampQuery(
+        query.startsAfter
+      ),
+      ends_before: RestfulModelCollection.formatTimestampQuery(
+        query.endsBefore
+      ),
+      ends_after: RestfulModelCollection.formatTimestampQuery(query.endsAfter),
+      updatedAtBefore: RestfulModelCollection.formatTimestampQuery(
+        query.updatedAtBefore
+      ),
+      updatedAtAfter: RestfulModelCollection.formatTimestampQuery(
+        query.updatedAtAfter
+      ),
+      expand_recurring: query.expandRecurring,
+      busy: query.busy,
+      show_cancelled: query.showCancelled,
+      metadata: this.formatMetadataQuery(query.metadata),
+    };
+  }
+}

--- a/src/models/file-restful-model-collection.ts
+++ b/src/models/file-restful-model-collection.ts
@@ -1,0 +1,34 @@
+import RestfulModelCollection from './restful-model-collection';
+import File, { FileProperties } from './file';
+import NylasConnection from '../nylas-connection';
+import { RestfulQuery } from './model-collection';
+
+export interface FileQuery extends RestfulQuery {
+  filename?: string;
+  messageId?: string;
+  contentType?: string;
+}
+
+export default class FileRestfulModelCollection extends RestfulModelCollection<
+  File
+> {
+  constructor(connection: NylasConnection) {
+    super(File, connection);
+  }
+
+  list(
+    params: FileQuery,
+    callback?: (error: Error | null, obj?: any[]) => void
+  ): Promise<any[]> {
+    return super.list(params, callback);
+  }
+
+  protected formatQuery(query: FileQuery): Record<string, unknown> {
+    return {
+      ...super.formatQuery(query),
+      filename: query.filename,
+      message_id: query.messageId,
+      content_type: query.contentType,
+    };
+  }
+}

--- a/src/models/file-restful-model-collection.ts
+++ b/src/models/file-restful-model-collection.ts
@@ -16,6 +16,13 @@ export default class FileRestfulModelCollection extends RestfulModelCollection<
     super(File, connection);
   }
 
+  create(
+    props: FileProperties,
+    callback?: (error: Error | null, result?: File) => void
+  ): Promise<File> {
+    return new File(this.connection, props).upload(callback);
+  }
+
   list(
     params: FileQuery,
     callback?: (error: Error | null, obj?: any[]) => void

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -1,6 +1,6 @@
 import Attributes, { Attribute } from './attributes';
 import RestfulModel from './restful-model';
-import NylasConnection from '../nylas-connection';
+import NylasConnection, { FileDownloadDetails } from '../nylas-connection';
 
 export type FileProperties = {
   contentType?: string;
@@ -117,7 +117,7 @@ export default class File extends RestfulModel implements FileProperties {
       error: Error | null,
       file?: { body: any; [key: string]: any }
     ) => void
-  ): Promise<any> {
+  ): Promise<FileDownloadDetails> {
     if (!this.id) {
       throw new Error('Please provide a File id');
     }
@@ -127,7 +127,7 @@ export default class File extends RestfulModel implements FileProperties {
         path: `/files/${this.id}/download`,
         downloadRequest: true,
       })
-      .then(file => {
+      .then((file: FileDownloadDetails) => {
         if (callback) {
           callback(null, file);
         }

--- a/src/models/folder-restful-model-collection.ts
+++ b/src/models/folder-restful-model-collection.ts
@@ -1,0 +1,19 @@
+import RestfulModelCollection from './restful-model-collection';
+import Folder, { FolderProperties } from './folder';
+import NylasConnection from '../nylas-connection';
+import { RestfulQuery } from './model-collection';
+
+export default class FolderRestfulModelCollection extends RestfulModelCollection<
+  Folder
+> {
+  constructor(connection: NylasConnection) {
+    super(Folder, connection);
+  }
+
+  list(
+    params: RestfulQuery,
+    callback?: (error: Error | null, obj?: Folder[]) => void
+  ): Promise<Folder[]> {
+    return super.list(params, callback);
+  }
+}

--- a/src/models/folder-restful-model-collection.ts
+++ b/src/models/folder-restful-model-collection.ts
@@ -10,6 +10,13 @@ export default class FolderRestfulModelCollection extends RestfulModelCollection
     super(Folder, connection);
   }
 
+  create(
+    props: FolderProperties,
+    callback?: (error: Error | null, result?: Folder) => void
+  ): Promise<Folder> {
+    return new Folder(this.connection, props).save(callback);
+  }
+
   list(
     params: RestfulQuery,
     callback?: (error: Error | null, obj?: Folder[]) => void

--- a/src/models/job-status-restful-model-collection.ts
+++ b/src/models/job-status-restful-model-collection.ts
@@ -2,6 +2,7 @@ import RestfulModelCollection from './restful-model-collection';
 import JobStatus from './job-status';
 import NylasConnection from '../nylas-connection';
 import OutboxJobStatus from './outbox-job-status';
+import { RestfulQuery } from './model-collection';
 
 export default class JobStatusRestfulModelCollection extends RestfulModelCollection<
   JobStatus
@@ -13,6 +14,13 @@ export default class JobStatusRestfulModelCollection extends RestfulModelCollect
     super(JobStatus, connection);
     this.connection = connection;
     this.modelClass = JobStatus;
+  }
+
+  list(
+    params: RestfulQuery,
+    callback?: (error: Error | null, obj?: JobStatus[]) => void
+  ): Promise<JobStatus[]> {
+    return super.list(params, callback);
   }
 
   protected createModel(json: Record<string, unknown>): JobStatus {

--- a/src/models/label-restful-model-collection.ts
+++ b/src/models/label-restful-model-collection.ts
@@ -10,6 +10,13 @@ export default class LabelRestfulModelCollection extends RestfulModelCollection<
     super(Label, connection);
   }
 
+  create(
+    props: FolderProperties,
+    callback?: (error: Error | null, result?: Label) => void
+  ): Promise<Label> {
+    return new Label(this.connection, props).save(callback);
+  }
+
   list(
     params: RestfulQuery,
     callback?: (error: Error | null, obj?: Label[]) => void

--- a/src/models/label-restful-model-collection.ts
+++ b/src/models/label-restful-model-collection.ts
@@ -1,0 +1,19 @@
+import RestfulModelCollection from './restful-model-collection';
+import { FolderProperties, Label } from './folder';
+import NylasConnection from '../nylas-connection';
+import { RestfulQuery } from './model-collection';
+
+export default class LabelRestfulModelCollection extends RestfulModelCollection<
+  Label
+> {
+  constructor(connection: NylasConnection) {
+    super(Label, connection);
+  }
+
+  list(
+    params: RestfulQuery,
+    callback?: (error: Error | null, obj?: Label[]) => void
+  ): Promise<Label[]> {
+    return super.list(params, callback);
+  }
+}

--- a/src/models/resource-restful-model-collection.ts
+++ b/src/models/resource-restful-model-collection.ts
@@ -1,0 +1,19 @@
+import RestfulModelCollection from './restful-model-collection';
+import Resource from './resource';
+import NylasConnection from '../nylas-connection';
+import { RestfulQuery } from './model-collection';
+
+export default class ResourceRestfulModelCollection extends RestfulModelCollection<
+  Resource
+> {
+  constructor(connection: NylasConnection) {
+    super(Resource, connection);
+  }
+
+  list(
+    params: RestfulQuery,
+    callback?: (error: Error | null, obj?: Resource[]) => void
+  ): Promise<Resource[]> {
+    return super.list(params, callback);
+  }
+}

--- a/src/models/scheduler-restful-model-collection.ts
+++ b/src/models/scheduler-restful-model-collection.ts
@@ -1,10 +1,12 @@
 import RestfulModelCollection from './restful-model-collection';
 import NylasConnection from '../nylas-connection';
-import Scheduler from './scheduler';
+import Scheduler, { SchedulerProperties } from './scheduler';
 import SchedulerTimeSlot from './scheduler-time-slot';
 import SchedulerBookingRequest, {
   SchedulerBookingConfirmation,
 } from './scheduler-booking-request';
+import { SaveCallback } from './restful-model';
+import { RestfulQuery } from './model-collection';
 
 export type ProviderAvailability = {
   busy: [
@@ -29,6 +31,13 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
     this.baseUrl = 'https://api.schedule.nylas.com';
     this.connection = connection;
     this.modelClass = Scheduler;
+  }
+
+  list(
+    params: RestfulQuery,
+    callback?: (error: Error | null, obj?: Scheduler[]) => void
+  ): Promise<Scheduler[]> {
+    return super.list(params, callback);
   }
 
   getGoogleAvailability(): Promise<ProviderAvailability> {

--- a/src/models/scheduler-restful-model-collection.ts
+++ b/src/models/scheduler-restful-model-collection.ts
@@ -5,7 +5,6 @@ import SchedulerTimeSlot from './scheduler-time-slot';
 import SchedulerBookingRequest, {
   SchedulerBookingConfirmation,
 } from './scheduler-booking-request';
-import { SaveCallback } from './restful-model';
 import { RestfulQuery } from './model-collection';
 
 export type ProviderAvailability = {
@@ -31,6 +30,13 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
     this.baseUrl = 'https://api.schedule.nylas.com';
     this.connection = connection;
     this.modelClass = Scheduler;
+  }
+
+  create(
+    props: SchedulerProperties,
+    callback?: (error: Error | null, result?: Scheduler) => void
+  ): Promise<Scheduler> {
+    return new Scheduler(this.connection, props).save(callback);
   }
 
   list(

--- a/src/models/thread-restful-model-collection.ts
+++ b/src/models/thread-restful-model-collection.ts
@@ -1,0 +1,68 @@
+import RestfulModelCollection from './restful-model-collection';
+import Thread from './thread';
+import NylasConnection from '../nylas-connection';
+import MessageRestfulModelCollection, {
+  BaseMessageQuery,
+  MessageQuery,
+} from './message-restful-model-collection';
+
+export interface ThreadQuery extends BaseMessageQuery {
+  lastMessageBefore?: Date | number;
+  lastMessageAfter?: Date | number;
+  startedBefore?: Date | number;
+  startedAfter?: Date | number;
+  lastUpdatedBefore?: Date | number;
+  lastUpdatedAfter?: Date | number;
+  lastUpdatedTimestamp?: Date | number;
+}
+
+export default class ThreadRestfulModelCollection extends RestfulModelCollection<
+  Thread
+> {
+  constructor(connection: NylasConnection) {
+    super(Thread, connection);
+  }
+
+  list(
+    params: MessageQuery = {},
+    callback?: (error: Error | null, obj?: any[]) => void
+  ): Promise<Thread[]> {
+    return super.list(params, callback);
+  }
+
+  protected formatQuery(query: ThreadQuery): Record<string, unknown> {
+    const lastMessageBefore = RestfulModelCollection.formatTimestampQuery(
+      query.lastMessageBefore
+    );
+    const lastMessageAfter = RestfulModelCollection.formatTimestampQuery(
+      query.lastMessageAfter
+    );
+    const startedBefore = RestfulModelCollection.formatTimestampQuery(
+      query.startedBefore
+    );
+    const startedAfter = RestfulModelCollection.formatTimestampQuery(
+      query.startedAfter
+    );
+    const lastUpdatedBefore = RestfulModelCollection.formatTimestampQuery(
+      query.lastUpdatedBefore
+    );
+    const lastUpdatedAfter = RestfulModelCollection.formatTimestampQuery(
+      query.lastUpdatedAfter
+    );
+    const lastUpdatedTimestamp = RestfulModelCollection.formatTimestampQuery(
+      query.lastUpdatedTimestamp
+    );
+
+    return {
+      ...super.formatQuery(query),
+      ...MessageRestfulModelCollection.formatBaseMessageQuery(query),
+      last_message_before: lastMessageBefore,
+      last_message_after: lastMessageAfter,
+      started_before: startedBefore,
+      started_after: startedAfter,
+      last_updated_before: lastUpdatedBefore,
+      last_updated_after: lastUpdatedAfter,
+      last_updated_timestamp: lastUpdatedTimestamp,
+    };
+  }
+}

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -51,6 +51,11 @@ export type FormDataType = {
   options?: Record<string, unknown> | AppendOptions;
 };
 
+export interface FileDownloadDetails {
+  body: Buffer;
+  [key: string]: unknown;
+}
+
 export default class NylasConnection {
   accessToken: string | null | undefined;
   clientId: string | null | undefined;
@@ -265,11 +270,12 @@ export default class NylasConnection {
                 .buffer()
                 .then(buffer => {
                   // Return an object with the headers and the body as a buffer
-                  const fileDetails: Record<string, any> = {};
+                  const fileDetails: FileDownloadDetails = {
+                    body: buffer,
+                  };
                   response.headers.forEach((v, k) => {
                     fileDetails[k] = v;
                   });
-                  fileDetails['body'] = buffer;
                   return resolve(fileDetails);
                 })
                 .catch(e => {

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -78,7 +78,9 @@ export default class NylasConnection {
   );
   deltas = new DeltaCollection(this);
   labels: LabelRestfulModelCollection = new LabelRestfulModelCollection(this);
-  folders: FolderRestfulModelCollection = new FolderRestfulModelCollection(this);
+  folders: FolderRestfulModelCollection = new FolderRestfulModelCollection(
+    this
+  );
   //TODO::Look into improving account?
   account: RestfulModelInstance<Account> = new RestfulModelInstance(
     Account,

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -2,17 +2,10 @@
 import { URL } from 'url';
 import fetch, { Request } from 'node-fetch';
 import * as config from './config';
-import RestfulModelCollection from './models/restful-model-collection';
 import CalendarRestfulModelCollection from './models/calendar-restful-model-collection';
 import ContactRestfulModelCollection from './models/contact-restful-model-collection';
 import RestfulModelInstance from './models/restful-model-instance';
 import Account from './models/account';
-import Thread from './models/thread';
-import Draft from './models/draft';
-import File from './models/file';
-import Event from './models/event';
-import Resource from './models/resource';
-import Folder, { Label } from './models/folder';
 import FormData, { AppendOptions } from 'form-data';
 import Neural from './models/neural';
 import NylasApiError from './models/nylas-api-error';
@@ -22,6 +15,13 @@ import MessageRestfulModelCollection from './models/message-restful-model-collec
 import DeltaCollection from './models/delta-collection';
 import Outbox from './models/outbox';
 import JobStatusRestfulModelCollection from './models/job-status-restful-model-collection';
+import ThreadRestfulModelCollection from './models/thread-restful-model-collection';
+import DraftRestfulModelCollection from './models/draft-restful-model-collection';
+import FileRestfulModelCollection from './models/file-restful-model-collection';
+import { EventRestfulModelCollection } from './models/event-restful-model-collection';
+import ResourceRestfulModelCollection from './models/resource-restful-model-collection';
+import LabelRestfulModelCollection from './models/label-restful-model-collection';
+import FolderRestfulModelCollection from './models/folder-restful-model-collection';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -55,8 +55,7 @@ export default class NylasConnection {
   accessToken: string | null | undefined;
   clientId: string | null | undefined;
 
-  threads: RestfulModelCollection<Thread> = new RestfulModelCollection(
-    Thread,
+  threads: ThreadRestfulModelCollection = new ThreadRestfulModelCollection(
     this
   );
   contacts: ContactRestfulModelCollection = new ContactRestfulModelCollection(
@@ -65,34 +64,22 @@ export default class NylasConnection {
   messages: MessageRestfulModelCollection = new MessageRestfulModelCollection(
     this
   );
-  drafts: RestfulModelCollection<Draft> = new RestfulModelCollection(
-    Draft,
-    this
-  );
-  files: RestfulModelCollection<File> = new RestfulModelCollection(File, this);
+  drafts: DraftRestfulModelCollection = new DraftRestfulModelCollection(this);
+  files: FileRestfulModelCollection = new FileRestfulModelCollection(this);
   calendars: CalendarRestfulModelCollection = new CalendarRestfulModelCollection(
     this
   );
   jobStatuses: JobStatusRestfulModelCollection = new JobStatusRestfulModelCollection(
     this
   );
-  events: RestfulModelCollection<Event> = new RestfulModelCollection(
-    Event,
-    this
-  );
-  resources: RestfulModelCollection<Resource> = new RestfulModelCollection(
-    Resource,
+  events: EventRestfulModelCollection = new EventRestfulModelCollection(this);
+  resources: ResourceRestfulModelCollection = new ResourceRestfulModelCollection(
     this
   );
   deltas = new DeltaCollection(this);
-  labels: RestfulModelCollection<Label> = new RestfulModelCollection(
-    Label,
-    this
-  );
-  folders: RestfulModelCollection<Folder> = new RestfulModelCollection(
-    Folder,
-    this
-  );
+  labels: LabelRestfulModelCollection = new LabelRestfulModelCollection(this);
+  folders: FolderRestfulModelCollection = new FolderRestfulModelCollection(this);
+  //TODO::Look into improving account?
   account: RestfulModelInstance<Account> = new RestfulModelInstance(
     Account,
     this


### PR DESCRIPTION
# Description
### ⚠️ Still a WIP

This PR holds new changes coming to the Node SDK v7 where we aim to further improve the developer experience of using restful model collections in this SDK. Currently this PR specifically brings:
* Query parameter support. Now we have a reference of all the query parameters each collection supports, eliminating the need to check the API Reference docs and reduces the chance of errors using unsupported parameters.
* Improved typing. Reduced the reliance on generics as generics don't translate to good type hinting in IDEs (they end up being `any` which we'd like to avoid), so we have started re-defining methods that use generics such as `list` with specific types.
* Reducing import statements. The number one feedback we got from v6 was that import statements can be a little confusing and hard to track. So we've introduced a new `create` method for all collections that support creating new resources, that eliminate the need for importing the parent class as well as it saves it to the API without needing an extra step. Creating a new object in the API can now be reduced to one line with no additional imports.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.