### PR TITLE
[v7] Add defaults for Content-Type and Aceept headers for outgoing API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.0.0-canary.5 / TBD
 * **BREAKING CHANGE**: Rename `confirmationEmailToHost` to `confirmationEmailsToHost` in `SchedulerBooking`
 * Gracefully handle error on webhook deletion
+* Add defaults for Content-Type and Aceept headers for outgoing API requests
 
 ### 7.0.0-canary.4 / 2022-08-15
 * Abstract out the middleware logic to a more generalized `Routes`

--- a/src/models/neural-categorizer.ts
+++ b/src/models/neural-categorizer.ts
@@ -68,9 +68,6 @@ export default class NeuralCategorizer extends Message
         method: 'POST',
         path: '/neural/categorize/feedback',
         body: { message_id: this.id, category: category },
-        headers: {
-          'Content-Type': 'application/json',
-        },
       })
       .then(async json => {
         const categorizeResponse = await this.connection.neural.categorize([

--- a/src/models/neural.ts
+++ b/src/models/neural.ts
@@ -159,9 +159,6 @@ export default class Neural extends RestfulModel {
       method: 'PUT',
       path: `/neural/${path}`,
       body: body,
-      headers: {
-        'Content-Type': 'application/json',
-      },
     });
   }
 }

--- a/src/models/outbox.ts
+++ b/src/models/outbox.ts
@@ -130,17 +130,10 @@ export default class Outbox {
     path: string;
     body?: Record<string, unknown>;
   }): Promise<any> {
-    let header;
-    if (options.body) {
-      header = {
-        'Content-Type': 'application/json',
-      };
-    }
     return this.connection.request({
       method: options.method,
       path: `${this.path}${options.path}`,
       body: options.body,
-      headers: header,
       authMethod: AuthMethod.BEARER,
     });
   }

--- a/src/models/scheduler-restful-model-collection.ts
+++ b/src/models/scheduler-restful-model-collection.ts
@@ -35,9 +35,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
     return this.connection.request({
       method: 'GET',
       path: '/schedule/availability/google',
-      headers: {
-        'Content-Type': 'application/json',
-      },
       baseUrl: this.baseUrl,
     });
   }
@@ -46,9 +43,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
     return this.connection.request({
       method: 'GET',
       path: '/schedule/availability/o365',
-      headers: {
-        'Content-Type': 'application/json',
-      },
       baseUrl: this.baseUrl,
     });
   }
@@ -58,9 +52,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
       .request({
         method: 'GET',
         path: `/schedule/${slug}/info`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
         baseUrl: this.baseUrl,
       })
       .then(json => {
@@ -73,9 +64,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
       .request({
         method: 'GET',
         path: `/schedule/${slug}/timeslots`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
         baseUrl: this.baseUrl,
       })
       .then(json => {
@@ -96,9 +84,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
       .request({
         method: 'POST',
         path: `/schedule/${slug}/timeslots`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
         body: bookingRequest.toJSON(),
         baseUrl: this.baseUrl,
       })
@@ -118,9 +103,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
       .request({
         method: 'POST',
         path: `/schedule/${slug}/${editHash}/cancel`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
         body: {
           reason: reason,
         },
@@ -139,9 +121,6 @@ export default class SchedulerRestfulModelCollection extends RestfulModelCollect
       .request({
         method: 'POST',
         path: `/schedule/${slug}/${editHash}/confirm`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
         body: {},
         baseUrl: this.baseUrl,
       })

--- a/src/models/scheduler.ts
+++ b/src/models/scheduler.ts
@@ -567,9 +567,6 @@ export default class Scheduler extends RestfulModel
       .request({
         method: 'GET',
         path: `/manage/pages/${this.id}/calendars`,
-        headers: {
-          'Content-Type': 'application/json',
-        },
         baseUrl: this.baseUrl,
       })
       .then((json: Record<string, unknown>[]) => {
@@ -593,9 +590,6 @@ export default class Scheduler extends RestfulModel
     return this.connection.request({
       method: 'PUT',
       path: `/manage/pages/${this.id}/upload-image`,
-      headers: {
-        'Content-Type': 'application/json',
-      },
       body: {
         contentType: contentType,
         objectName: objectName,

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -148,6 +148,9 @@ export default class NylasConnection {
 
     const headers: Record<string, string> = {
       Accept: 'application/json',
+      'User-Agent': `Nylas Node SDK v${SDK_VERSION}`,
+      'Nylas-API-Version': SUPPORTED_API_VERSION,
+      'Nylas-SDK-API-Version': SUPPORTED_API_VERSION,
       ...options.headers,
     };
     const user =
@@ -164,11 +167,6 @@ export default class NylasConnection {
       }
     }
 
-    if (!headers['User-Agent']) {
-      headers['User-Agent'] = `Nylas Node SDK v${SDK_VERSION}`;
-    }
-    headers['Nylas-API-Version'] = SUPPORTED_API_VERSION;
-    headers['Nylas-SDK-API-Version'] = SUPPORTED_API_VERSION;
     if (this.clientId != null) {
       headers['X-Nylas-Client-Id'] = this.clientId;
     }

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -146,7 +146,10 @@ export default class NylasConnection {
     }
     options.url = url;
 
-    const headers: Record<string, string> = { ...options.headers };
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...options.headers,
+    };
     const user =
       options.path.substr(0, 3) === '/a/' || options.path.includes('/component')
         ? config.clientSecret
@@ -181,8 +184,10 @@ export default class NylasConnection {
         }
       }
       options.body = fd;
+      headers['Content-Type'] = 'multipart/form-data';
     } else if (options.body && options.json !== false) {
       options.body = JSON.stringify(options.body);
+      headers['Content-Type'] = 'application/json';
     }
 
     return options;


### PR DESCRIPTION
# Description
This PR adds a default values for both the `Content-Type` and `Accept` headers for all outgoing connections to the Nylas API.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.