### PR TITLE
Add new attributes for Event webhook notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Added support for rate limit errors
 * Changed Event `visibility` field to be writeable
+* Add new attributes for Event webhook notifications
 
 ## 6.6.1 / 2022-10-21
 * Fix calendar color implementation

--- a/__tests__/webhook-notification-spec.js
+++ b/__tests__/webhook-notification-spec.js
@@ -137,4 +137,68 @@ describe('Webhook Notification', () => {
     expect(recents.linkIndex).toBe(0);
     done();
   });
+
+  test('Should deserialize an event notification from JSON properly', done => {
+    const webhookNotificationJSON = {
+      deltas: [
+        {
+          date: 1602623196,
+          object: 'event',
+          type: 'event.created',
+          object_data: {
+            namespace_id: 'aaz875kwuvxik6ku7pwkqp3ah',
+            account_id: 'aaz875kwuvxik6ku7pwkqp3ah',
+            object: 'event',
+            attributes: {
+              calendar_id: 'calendar-123',
+              created_before_account_connection: true,
+            },
+            id: '93mgpjynqqu5fohl2dvv6ray7',
+            metadata: {
+              test: 1234,
+            },
+          },
+        },
+      ],
+    };
+    const webhookNotification = new WebhookNotification().fromJSON(
+      webhookNotificationJSON
+    );
+    expect(webhookNotification.deltas.length).toBe(1);
+
+    const webhookDelta = webhookNotification.deltas[0];
+    expect(webhookDelta instanceof WebhookDelta).toBe(true);
+    expect(webhookDelta.date).toEqual(new Date(1602623196 * 1000));
+    expect(webhookDelta.object).toEqual('event');
+    expect(webhookDelta.type).toEqual(WebhookTriggers.EventCreated);
+
+    const webhookDeltaObjectData = webhookDelta.objectData;
+    expect(webhookDeltaObjectData instanceof WebhookObjectData).toBe(true);
+    expect(webhookDeltaObjectData.id).toEqual('93mgpjynqqu5fohl2dvv6ray7');
+    expect(webhookDeltaObjectData.accountId).toEqual(
+      'aaz875kwuvxik6ku7pwkqp3ah'
+    );
+    expect(webhookDeltaObjectData.namespaceId).toEqual(
+      'aaz875kwuvxik6ku7pwkqp3ah'
+    );
+    expect(webhookDeltaObjectData.object).toEqual('event');
+
+    const webhookDeltaObjectAttributes =
+      webhookDeltaObjectData.objectAttributes;
+    expect(
+      webhookDeltaObjectAttributes instanceof WebhookObjectAttributes
+    ).toBe(true);
+    expect(webhookDeltaObjectAttributes.calendarId).toEqual('calendar-123');
+    expect(webhookDeltaObjectAttributes.createdBeforeAccountConnection).toBe(
+      true
+    );
+
+    const metadata = webhookDeltaObjectData.metadata;
+    expect(metadata instanceof MessageTrackingData).toBe(false);
+    expect(metadata).toEqual({
+      test: 1234,
+    });
+
+    done();
+  });
 });

--- a/src/models/webhook-notification.ts
+++ b/src/models/webhook-notification.ts
@@ -238,7 +238,7 @@ export type WebhookObjectDataProperties = {
   accountId: string;
   namespaceId: string;
   object: string;
-  metadata?: MessageTrackingDataProperties | Record<string, object>;
+  metadata?: MessageTrackingDataProperties | Record<string, unknown>;
   objectAttributes?: WebhookObjectAttributesProperties;
 };
 
@@ -250,7 +250,7 @@ export class WebhookObjectData extends Model
   object = '';
 
   // Message specific field
-  metadata?: MessageTrackingData | Record<string, object>;
+  metadata?: MessageTrackingData | Record<string, unknown>;
 
   // Message and Job Status specific field
   objectAttributes?: WebhookObjectAttributes;

--- a/src/models/webhook-notification.ts
+++ b/src/models/webhook-notification.ts
@@ -189,6 +189,10 @@ export class WebhookObjectAttributes extends Model
   // Message specific fields
   threadId?: string;
   receivedDate?: Date;
+
+  // Event specific fields
+  calendarId?: string;
+  createdBeforeAccountConnection?: boolean;
   static attributes: Record<string, Attribute> = {
     action: Attributes.String({
       modelKey: 'action',
@@ -205,9 +209,17 @@ export class WebhookObjectAttributes extends Model
       modelKey: 'threadId',
       jsonKey: 'thread_id',
     }),
+    calendarId: Attributes.String({
+      modelKey: 'calendarId',
+      jsonKey: 'calendar_id',
+    }),
     receivedDate: Attributes.DateTime({
       modelKey: 'receivedDate',
       jsonKey: 'received_date',
+    }),
+    createdBeforeAccountConnection: Attributes.Boolean({
+      modelKey: 'createdBeforeAccountConnection',
+      jsonKey: 'created_before_account_connection',
     }),
     extras: Attributes.Object({
       modelKey: 'extras',
@@ -226,7 +238,7 @@ export type WebhookObjectDataProperties = {
   accountId: string;
   namespaceId: string;
   object: string;
-  metadata?: MessageTrackingDataProperties;
+  metadata?: MessageTrackingDataProperties | Record<string, object>;
   objectAttributes?: WebhookObjectAttributesProperties;
 };
 
@@ -238,7 +250,7 @@ export class WebhookObjectData extends Model
   object = '';
 
   // Message specific field
-  metadata?: MessageTrackingData;
+  metadata?: MessageTrackingData | Record<string, object>;
 
   // Message and Job Status specific field
   objectAttributes?: WebhookObjectAttributes;
@@ -259,7 +271,6 @@ export class WebhookObjectData extends Model
     }),
     metadata: Attributes.Object({
       modelKey: 'metadata',
-      itemClass: MessageTrackingData,
     }),
     objectAttributes: Attributes.Object({
       modelKey: 'objectAttributes',
@@ -271,6 +282,27 @@ export class WebhookObjectData extends Model
   constructor(props?: WebhookObjectDataProperties) {
     super();
     this.initAttributes(props);
+    if (
+      this.metadata &&
+      (this.object === 'message' || this.object === 'thread')
+    ) {
+      this.metadata = new MessageTrackingData(
+        this.metadata as MessageTrackingDataProperties
+      );
+    }
+  }
+
+  fromJSON(json: Record<string, unknown>): this {
+    const notification = super.fromJSON(json);
+    if (
+      notification.metadata &&
+      (notification.object === 'message' || notification.object === 'thread')
+    ) {
+      notification.metadata = new MessageTrackingData().fromJSON(
+        json['metadata'] as Record<string, unknown>
+      );
+    }
+    return notification;
   }
 }
 


### PR DESCRIPTION
# Description
This PR adds two new fields and expands the type of the metadata in WebhookNotification for `Event` objects. The following changes occurred:
- Added `calendarId` to `WebhookObjectAttributes`
- Added `createdBeforeAccountConnection` to `WebhookObjectAttributes`
- Expanded metadata to support `Record<string, unknown>`, will deserialize to `MessageTrackingDataProperties` if it's a message or thread object as it did before.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.