### PR TITLE
Update restful-model-collection.ts

### DIFF
--- a/src/models/restful-model-collection.ts
+++ b/src/models/restful-model-collection.ts
@@ -8,7 +8,7 @@ export type GetCallback = (error: Error | null, result?: RestfulModel) => void;
 
 export default class RestfulModelCollection<
   T extends RestfulModel
-> extends ModelCollection<any> {
+> extends ModelCollection<T> {
   modelClass: typeof RestfulModel;
 
   constructor(modelClass: typeof RestfulModel, connection: NylasConnection) {


### PR DESCRIPTION
Forward the generic type to allow for better type safety in the child models.

I assume this was just overlooked.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.