### PR TITLE
Add `startTimezone`, `endTimezone` and `timezone` fields to `When`

### DIFF
--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -5,7 +5,7 @@ export type WhenProperties = {
   startTime?: number;
   endTime?: number;
   startTimezone?: string;
-  endTimezone?: string
+  endTimezone?: string;
   time?: number;
   timezone?: string;
   startDate?: string;
@@ -18,7 +18,7 @@ export default class When extends Model implements WhenProperties {
   startTime?: number;
   endTime?: number;
   startTimezone?: string;
-  endTimezone?: string
+  endTimezone?: string;
   time?: number;
   timezone?: string;
   startDate?: string;

--- a/src/models/when.ts
+++ b/src/models/when.ts
@@ -4,7 +4,10 @@ import Attributes, { Attribute } from './attributes';
 export type WhenProperties = {
   startTime?: number;
   endTime?: number;
+  startTimezone?: string;
+  endTimezone?: string
   time?: number;
+  timezone?: string;
   startDate?: string;
   endDate?: string;
   date?: string;
@@ -14,7 +17,10 @@ export type WhenProperties = {
 export default class When extends Model implements WhenProperties {
   startTime?: number;
   endTime?: number;
+  startTimezone?: string;
+  endTimezone?: string
   time?: number;
+  timezone?: string;
   startDate?: string;
   endDate?: string;
   date?: string;
@@ -28,8 +34,19 @@ export default class When extends Model implements WhenProperties {
       modelKey: 'endTime',
       jsonKey: 'end_time',
     }),
+    startTimezone: Attributes.String({
+      modelKey: 'startTimezone',
+      jsonKey: 'start_timezone',
+    }),
+    endTimezone: Attributes.String({
+      modelKey: 'endTimezone',
+      jsonKey: 'end_timezone',
+    }),
     time: Attributes.Number({
       modelKey: 'time',
+    }),
+    timezone: Attributes.String({
+      modelKey: 'timezone',
     }),
     startDate: Attributes.String({
       modelKey: 'startDate',


### PR DESCRIPTION
As specified in [Nylas Docs](https://developer.nylas.com/docs/api/#tag--Events--event-subobjects), the `When` object within a `Event` API support the following fields:
- `start_timezone`
- `end_timezone`
- `timezone`

This PR adds the related fields to the `When` object

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.