### PR TITLE
Add HTTP status 409 to error mapping

### DIFF
--- a/src/models/nylas-api-error.ts
+++ b/src/models/nylas-api-error.ts
@@ -29,6 +29,7 @@ export default class NylasApiError extends Error {
     403: 'Forbidden',
     404: 'Not Found',
     405: 'Method Not Allowed',
+    409: 'Conflict',
     410: 'Gone',
     418: "I'm a Teapot",
     422: 'Sending Error',


### PR DESCRIPTION
We have occasionally seen API responses with an HTTP status of 409. That status is not mapped and causes an exception. This PR adds that mapping to correct that.

Additionally, [the API error documentation](https://developer.nylas.com/docs/api/errors) should also be updated to reflect the possibility of a 409 error.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.