### PR TITLE
v6.9.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-### Unreleased
+### 6.9.0 / 2023-03-14
+* Add missing generic type in `RestfulModelCollection` for better type safety
+* Add 409 to error mapping
+* Add `startTimezone`, `endTimezone` and `timezone` fields to `When`
 * Allow configurable timeout for API calls
+* Bump `minimist` sub-dependency from 1.2.0 to 1.2.6
+* Bump `mkdirp` sub-dependency from 0.5.1 to 0.5.6
 
 ### 6.8.0 / 2023-02-03
 * Local webhook testing support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.8.0",
+      "version": "6.9.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New Nylas Node SDK v6.9.0 contains the following additions:
* Add missing generic type in `RestfulModelCollection` for better type safety (#424)
* Add 409 to error mapping (#430)
* Add `startTimezone`, `endTimezone` and `timezone` fields to `When` (#429)
* Allow configurable timeout for API calls (#427)
* Bump `minimist` sub-dependency from 1.2.0 to 1.2.6 (#425)
* Bump `mkdirp` sub-dependency from 0.5.1 to 0.5.6 (#425)

# Usage
## Configuring request timeout
To set the timeout you can add it as part of the initial Nylas SDK config:
```js
const Nylas = require('nylas');


// Initialize an instance of the Nylas SDK using the client credentials and timeout
Nylas.config({
  clientId: "CLIENT_ID",
  clientSecret: "CLIENT_SECRET",
  timeout: 60 // 60 second timeout
});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.