### PR TITLE
Add support for verifying webhook signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for verifying webhook signatures
+
 ### 6.9.0 / 2023-03-14
 * Add missing generic type in `RestfulModelCollection` for better type safety
 * Add 409 to error mapping

--- a/__tests__/webhook-notification-spec.js
+++ b/__tests__/webhook-notification-spec.js
@@ -205,9 +205,9 @@ describe('Webhook Notification', () => {
   describe('verifySignature', () => {
     test('Webhook verification should pass if the body matches the Nylas signature', () => {
       const isVerified = WebhookNotification.verifyWebhookSignature(
-        'myClientSecret',
         'ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c',
-        Buffer.from('test123', 'utf8')
+        Buffer.from('test123', 'utf8'),
+        'myClientSecret'
       );
 
       expect(isVerified).toBe(true);
@@ -215,9 +215,9 @@ describe('Webhook Notification', () => {
 
     test('Webhook verification should fail if the body does not match the Nylas signature', () => {
       const isVerified = WebhookNotification.verifyWebhookSignature(
-        'myClientSecret',
         'ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c',
-        Buffer.from('test12345', 'utf8')
+        Buffer.from('test12345', 'utf8'),
+        'myClientSecret'
       );
 
       expect(isVerified).toBe(false);

--- a/__tests__/webhook-notification-spec.js
+++ b/__tests__/webhook-notification-spec.js
@@ -203,25 +203,24 @@ describe('Webhook Notification', () => {
   });
 
   describe('verifySignature', () => {
-    test("Webhook verification should pass if the body matches the Nylas signature", () => {
+    test('Webhook verification should pass if the body matches the Nylas signature', () => {
       const isVerified = WebhookNotification.verifyWebhookSignature(
-        "myClientSecret",
-        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        'myClientSecret',
+        'ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c',
         Buffer.from('test123', 'utf8')
       );
 
       expect(isVerified).toBe(true);
     });
 
-    test("Webhook verification should fail if the body does not match the Nylas signature", () => {
+    test('Webhook verification should fail if the body does not match the Nylas signature', () => {
       const isVerified = WebhookNotification.verifyWebhookSignature(
-        "myClientSecret",
-        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        'myClientSecret',
+        'ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c',
         Buffer.from('test12345', 'utf8')
       );
 
       expect(isVerified).toBe(false);
     });
-  })
   });
 });

--- a/__tests__/webhook-notification-spec.js
+++ b/__tests__/webhook-notification-spec.js
@@ -201,4 +201,27 @@ describe('Webhook Notification', () => {
 
     done();
   });
+
+  describe('verifySignature', () => {
+    test("Webhook verification should pass if the body matches the Nylas signature", () => {
+      const isVerified = WebhookNotification.verifyWebhookSignature(
+        "myClientSecret",
+        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        Buffer.from('test123', 'utf8')
+      );
+
+      expect(isVerified).toBe(true);
+    });
+
+    test("Webhook verification should fail if the body does not match the Nylas signature", () => {
+      const isVerified = WebhookNotification.verifyWebhookSignature(
+        "myClientSecret",
+        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        Buffer.from('test12345', 'utf8')
+      );
+
+      expect(isVerified).toBe(false);
+    });
+  })
+  });
 });

--- a/src/models/webhook-notification.ts
+++ b/src/models/webhook-notification.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import Model from './model';
 import Attributes, { Attribute } from './attributes';
 
@@ -358,5 +359,24 @@ export default class WebhookNotification extends Model
   constructor(props?: WebhookNotificationProperties) {
     super();
     this.initAttributes(props);
+  }
+
+  /**
+   * Verify incoming webhook signature came from Nylas
+   * @param clientSecret The client secret of the app receiving the webhook
+   * @param xNylasSignature The signature to verify
+   * @param rawBody The raw body from the payload
+   * @return true if the webhook signature was verified from Nylas
+   */
+  static verifyWebhookSignature(
+    clientSecret: string,
+    xNylasSignature: string,
+    rawBody: Buffer
+  ): boolean {
+    const digest = crypto
+      .createHmac('sha256', clientSecret)
+      .update(rawBody)
+      .digest('hex');
+    return digest === xNylasSignature;
   }
 }

--- a/src/models/webhook-notification.ts
+++ b/src/models/webhook-notification.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import Model from './model';
 import Attributes, { Attribute } from './attributes';
+import * as config from '../config';
 
 export type LinkClickProperties = {
   id: number;
@@ -363,18 +364,23 @@ export default class WebhookNotification extends Model
 
   /**
    * Verify incoming webhook signature came from Nylas
-   * @param clientSecret The client secret of the app receiving the webhook
    * @param xNylasSignature The signature to verify
    * @param rawBody The raw body from the payload
+   * @param clientSecret Overriding client secret of the app receiving the webhook
    * @return true if the webhook signature was verified from Nylas
    */
   static verifyWebhookSignature(
-    clientSecret: string,
     xNylasSignature: string,
-    rawBody: Buffer
+    rawBody: Buffer,
+    clientSecret?: string
   ): boolean {
+    const clientSecretToUse = clientSecret || config.clientSecret;
+    if (!clientSecretToUse) {
+      throw new Error('Client secret is required to verify webhook signature');
+    }
+
     const digest = crypto
-      .createHmac('sha256', clientSecret)
+      .createHmac('sha256', clientSecretToUse)
       .update(rawBody)
       .digest('hex');
     return digest === xNylasSignature;


### PR DESCRIPTION
# Description
This PR adds support for verifying the webhook signature of inbound webhook notifications.

# Usage
```js
const Nylas = require('nylas');
const express = require('express');
const cors = require('cors');

const app = express();

// Enable CORS
app.use(cors());

// The port the express app will run on
const port = 9000;

// Nylas app credentials
const NYLAS_CLIENT_SECRET = process.env.NYLAS_CLIENT_SECRET;
if (!NYLAS_CLIENT_SECRET) {
  throw new Error('NYLAS_CLIENT_SECRET is required')
}

// Create a callback route for the Nylas Event Webhook
app.post('/', express.json(), async (req, res) => {
  // Verify the Nylas Event Webhook signature to ensure the request is coming from Nylas
  const signature =
    req.headers['x-nylas-signature'] || req.headers['X-Nylas-Signature'];
  if (
    !WebhookNotification.verifyWebhookSignature(
      NYLAS_CLIENT_SECRET,
      signature,
      JSON.stringify(req.body)
    )
  ) {
    res.status(403).send('Invalid signature');
  }

  const { body } = req;

  // Log the webhook event to the console
  console.log('Webhook event received: ', JSON.stringify(body, undefined, 2));

  // Send a 200 response to the Nylas Event Webhook
  res.status(200).send({ success: true });
});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.