### PR TITLE
Added token validation

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,10 +1,11 @@
 import fetch, { Request, Response } from 'node-fetch';
 import { ZodType } from 'zod';
 import { NylasConfig, OverridableNylasConfig } from './config';
-import { NylasApiError, NylasAuthError } from './schema/error';
+import { NylasApiError, NylasAuthError, NylasTokenValidationError } from './schema/error';
 import {
   AuthErrorResponseSchema,
   ErrorResponseSchema,
+  TokenValidationErrorResponseSchema,
 } from './schema/response';
 import { objKeysToCamelCase, objKeysToSnakeCase } from './utils';
 // import { AppendOptions } from 'form-data';
@@ -158,7 +159,6 @@ export default class APIClient {
     const text = await response.text();
 
     const responseJSON = JSON.parse(text);
-
     // TODO: exclusion list for keys that should not be camelCased
     const camelCaseRes = objKeysToCamelCase(responseJSON);
 
@@ -191,18 +191,26 @@ export default class APIClient {
     if (response.status > 299) {
       const text = await response.text();
       const error = JSON.parse(text);
-
+      const camelCaseRes = objKeysToCamelCase(error);
       const authErrorResponse =
-        options.path.includes('connect/token') ||
-        options.path.includes('connect/revoke');
-
-      if (authErrorResponse) {
-        const testResponse = AuthErrorResponseSchema.safeParse(error);
+      options.path.includes('connect/token') ||
+      options.path.includes('connect/revoke');
+      const tokenErrorResponse =
+      options.path.includes('connect/tokeninfo')
+      if (authErrorResponse && !tokenErrorResponse) {
+        const testResponse = AuthErrorResponseSchema.safeParse(camelCaseRes);
         if (testResponse.success) {
           throw new NylasAuthError(testResponse.data);
         }
-      } else {
-        const testErrorResponse = ErrorResponseSchema.safeParse(error);
+      }else if (tokenErrorResponse){
+        const testResponse = TokenValidationErrorResponseSchema.safeParse(camelCaseRes);
+
+        if (testResponse.success) {
+          throw new NylasTokenValidationError(testResponse.data);
+        }
+      }
+       else {
+        const testErrorResponse = ErrorResponseSchema.safeParse(camelCaseRes);
         if (testErrorResponse.success) {
           throw new NylasApiError(testErrorResponse.data);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,13 @@
+const Nylas = require('../lib/nylas')
+
+const nylas = new Nylas({clientId: "47e9b294-afe7-4041-9a77-c6236187fef8", clientSecret:"9LqYvPpoj8LYOtm9"})
+
+function main(){
+  const tok = nylas.auth.validateAccessToken("eGK5GauMI7l0SWy7lAi4TRGgiMg0oXWADQS-i1U2JfHzVdPZQTdAtxnpp4P_mn9-SDcuYEbiLqm3tiGfjkTFCyCQ8Kf1bDQXv5TtaIlk-hapCj93QZFwPFotSpLyirvCwzHlEO7isYUW72UEQqQOx8XAgl5vokXBuQP0mGlgzKk")
+  console.log(tok)
+  tok.then(r => {
+    console.log(r)
+
+  })
+}
+main()

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -2,12 +2,15 @@ import APIClient from '../apiClient';
 import { BaseResource } from './baseResource';
 import { Grants } from './grants';
 import {
+  OpenID,
+  OpenIDResponseSchema,
   AuthConfig,
   AdminConsentAuth,
   CodeExchangeRequest,
   TokenExchangeRequest,
 } from '../schema/auth';
 import {
+  ItemResponse,
   ExchangeResponse,
   ExchangeResponseSchema,
   EmptyResponse,
@@ -85,6 +88,56 @@ export class Auth extends BaseResource {
 
     return res;
   }
+
+  /**
+   * Exchange a refresh token for an access token (and if rotation enabled refresh token as well)
+   * @param TokenExchangeRequest
+   * @return Information about the Nylas application
+   */
+  public validateIDToken(
+    token: string
+  ): Promise<ItemResponse<OpenID>> {
+    this.checkAuthCredentials();
+
+    return this.apiClient.request<ItemResponse<OpenID>>(
+      {
+        method: 'GET',
+        path: `/v3/connect/tokeninfo`,
+        queryParams: {
+          id_token: token
+        },
+      },
+      {
+        responseSchema: OpenIDResponseSchema,
+      }
+    );
+
+  }
+
+  /**
+   * Exchange a refresh token for an access token (and if rotation enabled refresh token as well)
+   * @param TokenExchangeRequest
+   * @return Information about the Nylas application
+   */
+  public async validateAccessToken(
+    token: string
+    ): Promise<ItemResponse<OpenID>> {
+      this.checkAuthCredentials();
+  
+      return this.apiClient.request<ItemResponse<OpenID>>(
+        {
+          method: 'GET',
+          path: `/v3/connect/tokeninfo`,
+          queryParams: {
+            access_token: token
+          },
+        },
+        {
+          responseSchema: OpenIDResponseSchema,
+        }
+      );
+  
+    }
 
   /**
    * Build the URL for authenticating users to your application via Hosted Authentication

--- a/src/schema/auth.ts
+++ b/src/schema/auth.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod';
+import { ItemResponseSchema } from './response';
+
 type AccessType = 'online' | 'offline';
 type Provider = 'google' | 'microsoft';
 
@@ -16,6 +19,25 @@ type SharedAuthParams = {
   loginHint?: string;
 };
 
+export const OpenIDSchema = z.object({
+	iss: z.string(), // Issuer
+	aud: z.string(), // Application Slug
+	sub: z.string().optional(), // ID
+	email: z.string().optional(),
+	emailVerified: z.boolean().optional(),
+	atHash: z.string().optional(),
+	iat: z.number(), // Issued At
+	exp: z.number(), // Expites At
+	// Profile
+	name: z.string().optional(),
+	givenName: z.string().optional(),
+	familyName: z.string().optional(),
+	nickName: z.string().optional(),
+	pictureURL: z.string().optional(),
+	gender: z.string().optional(),
+	locale: z.string().optional(),
+})
+
 export type AuthConfig = SharedAuthParams & {
   provider: Provider;
 };
@@ -29,3 +51,8 @@ export interface TokenExchangeRequest {
   redirectUri: string;
   refreshToken: string;
 }
+
+export type OpenID = z.infer<typeof OpenIDSchema>;
+export const OpenIDResponseSchema = ItemResponseSchema.extend({
+  data: OpenIDSchema,
+});

--- a/src/schema/error.ts
+++ b/src/schema/error.ts
@@ -1,4 +1,4 @@
-import { NylasErrorResponse, AuthErrorResponse } from './response';
+import { NylasErrorResponse, AuthErrorResponse, TokenValidationErrorResponse } from './response';
 
 /**
  * Extended Error class for errors returned from the Nylas API
@@ -35,6 +35,18 @@ export class NylasAuthError extends Error {
     this.type = apiError.error;
     this.requestId = apiError.requestId;
     this.providerError = apiError.errorDescription;
+  }
+}
+export class NylasTokenValidationError extends Error {
+  type: string;
+  requestId: string;
+  providerError: any;
+
+  constructor(apiError: TokenValidationErrorResponse) {
+    super(apiError.error.message);
+    this.type = apiError.error.type;
+    this.requestId = apiError.error.requestId;
+    this.providerError = apiError.error.message;
   }
 }
 

--- a/src/schema/response.ts
+++ b/src/schema/response.ts
@@ -20,6 +20,17 @@ export const AuthErrorResponseSchema = z.object({
   errorUri: z.string(),
 });
 
+export const TokenValidationErrorResponseSchema = z.object({
+  success: z.boolean(),
+  error: z.object({
+    httpCode: z.number(),
+    eventCode: z.number(),
+    type: z.string(),
+    message: z.string(),
+    requestId: z.string(),
+  })
+})
+
 export type NylasErrorResponse = z.infer<typeof ErrorResponseSchema>;
 
 export const ItemResponseSchema = z.object({
@@ -60,6 +71,7 @@ export interface ListResponse<T> {
 export type ExchangeResponse = z.infer<typeof ExchangeResponseSchema>;
 export type EmptyResponse = z.infer<typeof EmptyResponseSchema>;
 export type AuthErrorResponse = z.infer<typeof AuthErrorResponseSchema>;
+export type TokenValidationErrorResponse = z.infer<typeof TokenValidationErrorResponseSchema>;
 
 export type ListResponseInnerType<T> = T extends ListResponse<infer R>
   ? R


### PR DESCRIPTION
Added token validation for issued access tokens & also ID tokens, both of them is successful return an OpenID for the corresponding user, also needed to extend error handling because of new struct of error on that endpoint


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.