### PR TITLE
v6.10.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.10.0 / 2023-04-04
 * Add support for verifying webhook signatures
 
 ### 6.9.0 / 2023-03-14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.9.0",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Description
New Nylas Node SDK v6.10.0 contains the following additions:
* Add support for verifying webhook signatures (#442)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.