### PR TITLE
Add Webhook support

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -124,9 +124,10 @@ export default class APIClient {
     // } else
 
     // TODO: function to set request body
-    // TODO: convert to snake case
     if (optionParams.body) {
-      requestOptions.body = JSON.stringify(optionParams.body);
+      requestOptions.body = JSON.stringify(
+        objKeysToSnakeCase(optionParams.body)
+      );
       requestOptions.headers['Content-Type'] = 'application/json';
     }
 

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -21,7 +21,6 @@ class Nylas {
       clientSecret: config.clientSecret,
     });
 
-    this.auth = new Auth(apiClient);
     this.calendars = new Calendars(apiClient);
     this.events = new Events(apiClient);
     this.auth = new Auth(apiClient);

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -3,6 +3,7 @@ import { NylasConfig, DEFAULT_SERVER_URL } from './config';
 import { Calendars } from './resources/calendars';
 import { Events } from './resources/events';
 import { Auth } from './resources/auth';
+import { Webhooks } from './resources/webhooks';
 
 class Nylas {
   // TODO: remove from config?
@@ -12,6 +13,7 @@ class Nylas {
   public calendars: Calendars;
   public events: Events;
   public auth: Auth;
+  public webhooks: Webhooks;
 
   constructor(config: NylasConfig) {
     const apiClient = new APIClient({
@@ -24,6 +26,7 @@ class Nylas {
     this.calendars = new Calendars(apiClient);
     this.events = new Events(apiClient);
     this.auth = new Auth(apiClient);
+    this.webhooks = new Webhooks(apiClient);
     // etc.
 
     return this;

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -8,6 +8,8 @@ import {
   WebhookIpAddressesResponseSchema,
   WebhookListResponseSchema,
   WebhookResponseSchema,
+  WebhookResponseWithSecretSchema,
+  WebhookWithSecret,
 } from '../schema/webhooks';
 
 interface CreateWebhookParams {
@@ -37,12 +39,14 @@ export class Webhooks extends BaseResource {
   public create({
     requestBody,
     overrides,
-  }: CreateWebhookParams & Overrides): Promise<ItemResponse<Webhook>> {
+  }: CreateWebhookParams & Overrides): Promise<
+    ItemResponse<WebhookWithSecret>
+  > {
     return super._create({
       path: `/v3/webhooks`,
       requestBody,
       overrides,
-      responseSchema: WebhookResponseSchema,
+      responseSchema: WebhookResponseWithSecretSchema,
     });
   }
 
@@ -77,7 +81,7 @@ export class Webhooks extends BaseResource {
       path: `/v3/webhooks/${webhookId}/rotate-secret`,
       requestBody: {},
       overrides,
-      responseSchema: WebhookResponseSchema,
+      responseSchema: WebhookResponseWithSecretSchema,
     });
   }
 

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -94,4 +94,13 @@ export class Webhooks extends BaseResource {
       responseSchema: WebhookIpAddressesResponseSchema,
     });
   }
+
+  public extractChallengeParameter(url: string): string {
+    const urlObject = new URL(url);
+    const challengeParameter = urlObject.searchParams.get('challenge');
+    if (!challengeParameter) {
+      throw new Error('Invalid URL or no challenge parameter found.');
+    }
+    return challengeParameter;
+  }
 }

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -26,6 +26,11 @@ interface DestroyWebhookParams {
 }
 
 export class Webhooks extends BaseResource {
+  /**
+   * List all webhook destinations for the application
+   * @param overrides Overrides for the request
+   * @returns The list of webhook destinations
+   */
   public list({ overrides }: Overrides = {}): AsyncListResponse<
     ListResponse<Webhook>
   > {
@@ -36,6 +41,12 @@ export class Webhooks extends BaseResource {
     });
   }
 
+  /**
+   * Create a webhook destination
+   * @param requestBody The webhook destination details
+   * @param overrides Overrides for the request
+   * @returns The created webhook destination
+   */
   public create({
     requestBody,
     overrides,
@@ -50,6 +61,13 @@ export class Webhooks extends BaseResource {
     });
   }
 
+  /**
+   * Update a webhook destination
+   * @param webhookId The ID of the webhook destination to update
+   * @param requestBody The updated webview destination details
+   * @param overrides Overrides for the request
+   * @returns The updated webhook destination
+   */
   public update({
     webhookId,
     requestBody,
@@ -63,6 +81,11 @@ export class Webhooks extends BaseResource {
     });
   }
 
+  /**
+   * Delete a webhook destination
+   * @param webhookId The ID of the webhook destination to delete
+   * @param overrides Overrides for the request
+   */
   public destroy({
     webhookId,
     overrides,
@@ -73,6 +96,12 @@ export class Webhooks extends BaseResource {
     });
   }
 
+  /**
+   * Update the webhook secret value for a destination
+   * @param webhookId The ID of the webhook destination to update
+   * @param overrides Overrides for the request
+   * @returns The updated webhook destination
+   */
   public rotateSecret({
     webhookId,
     overrides,
@@ -85,6 +114,11 @@ export class Webhooks extends BaseResource {
     });
   }
 
+  /**
+   * Get the current list of IP addresses that Nylas sends webhooks from
+   * @param overrides Overrides for the request
+   * @returns The list of IP addresses that Nylas sends webhooks from
+   */
   public ipAddresses({ overrides }: Overrides = {}): Promise<
     ItemResponse<WebhookIpAddresses>
   > {
@@ -95,6 +129,11 @@ export class Webhooks extends BaseResource {
     });
   }
 
+  /**
+   * Extract the challenge parameter from a URL
+   * @param url The URL sent by Nylas containing the challenge parameter
+   * @returns The challenge parameter
+   */
   public extractChallengeParameter(url: string): string {
     const urlObject = new URL(url);
     const challengeParameter = urlObject.searchParams.get('challenge');

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -4,6 +4,8 @@ import { ItemResponse, ListResponse } from '../schema/response';
 import {
   CreateWebhookRequestBody,
   Webhook,
+  WebhookIpAddresses,
+  WebhookIpAddressesResponseSchema,
   WebhookListResponseSchema,
   WebhookResponseSchema,
 } from '../schema/webhooks';
@@ -64,6 +66,28 @@ export class Webhooks extends BaseResource {
     return super._destroy({
       path: `/v3/webhooks/${webhookId}`,
       overrides,
+    });
+  }
+
+  public rotateSecret({
+    webhookId,
+    overrides,
+  }: DestroyWebhookParams & Overrides): Promise<ItemResponse<Webhook>> {
+    return super._update({
+      path: `/v3/webhooks/${webhookId}/rotate_secret`,
+      requestBody: {},
+      overrides,
+      responseSchema: WebhookResponseSchema,
+    });
+  }
+
+  public ipAddresses({ overrides }: Overrides = {}): Promise<
+    ItemResponse<WebhookIpAddresses>
+  > {
+    return super._find({
+      path: `/v3/webhooks/ip_addresses`,
+      overrides,
+      responseSchema: WebhookIpAddressesResponseSchema,
     });
   }
 }

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -74,7 +74,7 @@ export class Webhooks extends BaseResource {
     overrides,
   }: DestroyWebhookParams & Overrides): Promise<ItemResponse<Webhook>> {
     return super._update({
-      path: `/v3/webhooks/${webhookId}/rotate_secret`,
+      path: `/v3/webhooks/${webhookId}/rotate-secret`,
       requestBody: {},
       overrides,
       responseSchema: WebhookResponseSchema,
@@ -85,7 +85,7 @@ export class Webhooks extends BaseResource {
     ItemResponse<WebhookIpAddresses>
   > {
     return super._find({
-      path: `/v3/webhooks/ip_addresses`,
+      path: `/v3/webhooks/ip-addresses`,
       overrides,
       responseSchema: WebhookIpAddressesResponseSchema,
     });

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -1,0 +1,69 @@
+import { AsyncListResponse, BaseResource } from './baseResource';
+import { Overrides } from '../config';
+import { ItemResponse, ListResponse } from '../schema/response';
+import {
+  CreateWebhookRequestBody,
+  Webhook,
+  WebhookListResponseSchema,
+  WebhookResponseSchema,
+} from '../schema/webhooks';
+
+interface CreateWebhookParams {
+  requestBody: CreateWebhookRequestBody;
+}
+
+interface UpdateWebhookParams {
+  webhookId: string;
+  requestBody: CreateWebhookRequestBody;
+}
+
+interface DestroyWebhookParams {
+  webhookId: string;
+}
+
+export class Webhooks extends BaseResource {
+  public list({ overrides }: Overrides = {}): AsyncListResponse<
+    ListResponse<Webhook>
+  > {
+    return super._list<ListResponse<Webhook>>({
+      overrides,
+      path: `/v3/webhooks`,
+      responseSchema: WebhookListResponseSchema,
+    });
+  }
+
+  public create({
+    requestBody,
+    overrides,
+  }: CreateWebhookParams & Overrides): Promise<ItemResponse<Webhook>> {
+    return super._create({
+      path: `/v3/webhooks`,
+      requestBody,
+      overrides,
+      responseSchema: WebhookResponseSchema,
+    });
+  }
+
+  public update({
+    webhookId,
+    requestBody,
+    overrides,
+  }: UpdateWebhookParams & Overrides): Promise<ItemResponse<Webhook>> {
+    return super._update({
+      path: `/v3/webhooks/${webhookId}`,
+      requestBody,
+      overrides,
+      responseSchema: WebhookResponseSchema,
+    });
+  }
+
+  public destroy({
+    webhookId,
+    overrides,
+  }: DestroyWebhookParams & Overrides): Promise<void> {
+    return super._destroy({
+      path: `/v3/webhooks/${webhookId}`,
+      overrides,
+    });
+  }
+}

--- a/src/schema/webhooks.ts
+++ b/src/schema/webhooks.ts
@@ -28,9 +28,8 @@ export enum WebhookTriggers {
 const WebhookSchema = z.object({
   id: z.string(),
   description: z.string().optional(),
-  triggerTypes: z.array(z.nativeEnum(WebhookTriggers)).nonempty(),
+  triggerTypes: z.array(z.nativeEnum(WebhookTriggers)),
   callbackUrl: z.string(),
-  webhookSecret: z.string(),
   status: z.union([
     z.literal('active'),
     z.literal('failing'),
@@ -40,10 +39,17 @@ const WebhookSchema = z.object({
   notificationEmailAddress: z.string(),
   statusUpdatedAt: z.number(),
 });
+const WebhookWithSecretSchema = WebhookSchema.extend({
+  webhookSecret: z.string(),
+});
 
 export type Webhook = z.infer<typeof WebhookSchema>;
+export type WebhookWithSecret = z.infer<typeof WebhookWithSecretSchema>;
 export const WebhookResponseSchema = ItemResponseSchema.extend({
   data: WebhookSchema,
+});
+export const WebhookResponseWithSecretSchema = ItemResponseSchema.extend({
+  data: WebhookWithSecretSchema,
 });
 export const WebhookListResponseSchema = ListResponseSchema.extend({
   data: z.array(WebhookSchema),

--- a/src/schema/webhooks.ts
+++ b/src/schema/webhooks.ts
@@ -59,3 +59,12 @@ export const WebhookListResponseSchema = ListResponseSchema.extend({
   data: z.array(WebhookSchema),
 });
 export type WebhookList = z.infer<typeof WebhookListResponseSchema>;
+
+const WebhookIpAddressesSchema = z.object({
+  ipAddresses: z.array(z.string()),
+  updatedAt: z.number(),
+});
+export const WebhookIpAddressesResponseSchema = ItemResponseSchema.extend({
+  data: WebhookIpAddressesSchema,
+});
+export type WebhookIpAddresses = z.infer<typeof WebhookIpAddressesSchema>;

--- a/src/schema/webhooks.ts
+++ b/src/schema/webhooks.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { ItemResponseSchema, ListResponseSchema } from './response';
+
+export interface CreateWebhookRequestBody {
+  triggerTypes: WebhookTriggers[];
+  callbackUrl: string;
+  description?: string;
+  notificationEmailAddress?: string;
+}
+
+export type UpdateWebhookRequestBody = Partial<CreateWebhookRequestBody>;
+
+export enum WebhookTriggers {
+  AccountConnected = 'account.connected',
+  AccountRunning = 'account.running',
+  AccountStopped = 'account.stopped',
+  AccountInvalid = 'account.invalid',
+  AccountSyncError = 'account.sync_error',
+  MessageBounced = 'message.bounced',
+  MessageCreated = 'message.created',
+  MessageOpened = 'message.opened',
+  MessageUpdated = 'message.updated',
+  MessageLinkClicked = 'message.link_clicked',
+  ThreadReplied = 'thread.replied',
+  ContactCreated = 'contact.created',
+  ContactUpdated = 'contact.updated',
+  ContactDeleted = 'contact.deleted',
+  CalendarCreated = 'calendar.created',
+  CalendarUpdated = 'calendar.updated',
+  CalendarDeleted = 'calendar.deleted',
+  EventCreated = 'event.created',
+  EventUpdated = 'event.updated',
+  EventDeleted = 'event.deleted',
+  JobSuccessful = 'job.successful',
+  JobFailed = 'job.failed',
+}
+
+const WebhookSchema = z.object({
+  id: z.string(),
+  description: z.string().optional(),
+  triggerTypes: z.array(z.nativeEnum(WebhookTriggers)).nonempty(),
+  callbackUrl: z.string(),
+  webhookSecret: z.string(),
+  status: z.union([
+    z.literal('active'),
+    z.literal('failing'),
+    z.literal('failed'),
+    z.literal('pause'),
+  ]),
+  notificationEmailAddress: z.string(),
+  statusUpdatedAt: z.number(),
+});
+
+export type Webhook = z.infer<typeof WebhookSchema>;
+export const WebhookResponseSchema = ItemResponseSchema.extend({
+  data: WebhookSchema,
+});
+export const WebhookListResponseSchema = ListResponseSchema.extend({
+  data: z.array(WebhookSchema),
+});
+export type WebhookList = z.infer<typeof WebhookListResponseSchema>;

--- a/src/schema/webhooks.ts
+++ b/src/schema/webhooks.ts
@@ -11,28 +11,18 @@ export interface CreateWebhookRequestBody {
 export type UpdateWebhookRequestBody = Partial<CreateWebhookRequestBody>;
 
 export enum WebhookTriggers {
-  AccountConnected = 'account.connected',
-  AccountRunning = 'account.running',
-  AccountStopped = 'account.stopped',
-  AccountInvalid = 'account.invalid',
-  AccountSyncError = 'account.sync_error',
-  MessageBounced = 'message.bounced',
-  MessageCreated = 'message.created',
-  MessageOpened = 'message.opened',
-  MessageUpdated = 'message.updated',
-  MessageLinkClicked = 'message.link_clicked',
-  ThreadReplied = 'thread.replied',
-  ContactCreated = 'contact.created',
-  ContactUpdated = 'contact.updated',
-  ContactDeleted = 'contact.deleted',
   CalendarCreated = 'calendar.created',
   CalendarUpdated = 'calendar.updated',
   CalendarDeleted = 'calendar.deleted',
   EventCreated = 'event.created',
   EventUpdated = 'event.updated',
   EventDeleted = 'event.deleted',
-  JobSuccessful = 'job.successful',
-  JobFailed = 'job.failed',
+  GrantCreated = 'grant.created',
+  GrantUpdated = 'grant.updated',
+  GrantDeleted = 'grant.deleted',
+  GrantExpired = 'grant.expired',
+  MessageSendSuccess = 'message.send_success',
+  MessageSendFailed = 'message.send_failed',
 }
 
 const WebhookSchema = z.object({


### PR DESCRIPTION
# Description
This PR adds support for the Webhook schemas and models, enums for Webhook triggers, and all the Webhook API endpoints.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.