### PR TITLE
Fixing an issue with Attirbute.Number transforming null values into 0

### DIFF
--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -146,7 +146,7 @@ describe('Scheduler', () => {
       });
     });
 
-    test('Should throw an error if SchedulerBooking.intervalMinutes is invalid', done => {
+    test('Should not convert null to 0 if SchedulerBooking.intervalMinutes is null', done => {
       // Cannot be set to 0
       testContext.scheduler.config = new SchedulerConfig({
         booking: {
@@ -156,18 +156,6 @@ describe('Scheduler', () => {
 
       const value = testContext.scheduler.config.toJSON();
       expect(value.booking.interval_minutes).toEqual(null);
-
-      // Cannot be negative
-      testContext.scheduler.config.booking.intervalMinutes = -1;
-      expect(() => testContext.scheduler.save()).toThrow();
-
-      // Has to be divisible by 5
-      testContext.scheduler.config.booking.intervalMinutes = 3;
-      expect(() => testContext.scheduler.save()).toThrow();
-
-      // If valid, don't throw
-      testContext.scheduler.config.booking.intervalMinutes = 15;
-      expect(() => testContext.scheduler.save()).not.toThrow();
 
       done();
     });

--- a/__tests__/scheduler-spec.js
+++ b/__tests__/scheduler-spec.js
@@ -150,6 +150,32 @@ describe('Scheduler', () => {
       // Cannot be set to 0
       testContext.scheduler.config = new SchedulerConfig({
         booking: {
+          intervalMinutes: null,
+        },
+      });
+
+      const value = testContext.scheduler.config.toJSON();
+      expect(value.booking.interval_minutes).toEqual(null);
+
+      // Cannot be negative
+      testContext.scheduler.config.booking.intervalMinutes = -1;
+      expect(() => testContext.scheduler.save()).toThrow();
+
+      // Has to be divisible by 5
+      testContext.scheduler.config.booking.intervalMinutes = 3;
+      expect(() => testContext.scheduler.save()).toThrow();
+
+      // If valid, don't throw
+      testContext.scheduler.config.booking.intervalMinutes = 15;
+      expect(() => testContext.scheduler.save()).not.toThrow();
+
+      done();
+    });
+
+    test('Should throw an error if SchedulerBooking.intervalMinutes is invalid', done => {
+      // Cannot be set to 0
+      testContext.scheduler.config = new SchedulerConfig({
+        booking: {
           intervalMinutes: 0,
         },
       });

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -95,11 +95,11 @@ class AttributeNumber extends Attribute {
     return val;
   }
   fromJSON(val: any): number | null {
-    if (!isNaN(Number(val))) {
-      return Number(val);
-    } else {
+    if (val === null || isNaN(Number(val))) {
       return null;
     }
+
+    return Number(val);
   }
 }
 


### PR DESCRIPTION
# Description
There was a bug that caused null values to return 0 for Attribute.Number. This will check if the value is null or not and return only if it's a valid Numbrer. This will avoid Number(null) returning 0.