### PR TITLE
Fix parsing of Number arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix parsing of Number arrays
+
 ### 6.10.0 / 2023-04-04
 * Add support for verifying webhook signatures
 

--- a/__tests__/calendar-restful-model-collection-spec.js
+++ b/__tests__/calendar-restful-model-collection-spec.js
@@ -169,7 +169,7 @@ describe('CalendarRestfulModelCollection', () => {
         openHours: [
           {
             emails: ['swag@nylas.com'],
-            days: [Days.Sunday],
+            days: [Days.Sunday, Days.Thursday],
             timezone: 'America/Chicago',
             start: '10:00',
             end: '14:00',
@@ -200,7 +200,7 @@ describe('CalendarRestfulModelCollection', () => {
           open_hours: [
             {
               emails: ['swag@nylas.com'],
-              days: [0],
+              days: [6, 3],
               timezone: 'America/Chicago',
               start: '10:00',
               end: '14:00',
@@ -306,7 +306,7 @@ describe('CalendarRestfulModelCollection', () => {
             open_hours: [
               {
                 emails: ['jane@email.com', 'swag@nylas.com'],
-                days: [0],
+                days: [6],
                 timezone: 'America/Chicago',
                 start: '10:00',
                 end: '14:00',

--- a/src/models/attributes.ts
+++ b/src/models/attributes.ts
@@ -113,8 +113,8 @@ class AttributeNumberList extends Attribute {
     }
     const nums = [];
     for (const num in json) {
-      if (!isNaN(Number(num))) {
-        nums.push(Number(num));
+      if (!isNaN(Number(json[num]))) {
+        nums.push(Number(json[num]));
       }
     }
     return nums;


### PR DESCRIPTION
# Description
This PR closes #502. The parsing of number arrays was broken, setting the index instead of the value when desearializing. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.