### PR TITLE
Bump `node-fetch` to `v2.6.12`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Bump `node-fetch` dependency from 2.6.1 to 2.6.12
+
 ### 6.10.0 / 2023-04-04
 * Add support for verifying webhook signatures
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "backoff": "^2.5.0",
         "form-data": "^4.0.0",
         "JSONStream": "^1.3.5",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.12",
         "uuid": "^8.3.2",
         "websocket": "^1.0.34"
       },
@@ -7079,9 +7079,9 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -15504,9 +15504,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "backoff": "^2.5.0",
     "form-data": "^4.0.0",
     "JSONStream": "^1.3.5",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.12",
     "uuid": "^8.3.2",
     "websocket": "^1.0.34"
   },


### PR DESCRIPTION
# Description
This PR bumps node fetch to close #496. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.