### PR TITLE
Fix configured timeout not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix parsing of Number arrays
+* Fix configured timeout not being used
 * Bump `node-fetch` dependency from 2.6.1 to 2.6.12
 
 ### 6.10.0 / 2023-04-04

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -237,7 +237,7 @@ export default class NylasConnection {
       controller = new AbortController();
       timeout = setTimeout(() => {
         controller.abort();
-      }, 150);
+      }, config.timeout);
     }
 
     return new Promise<any>((resolve, reject) => {


### PR DESCRIPTION
# Description
Timeout now respects the value given. Closes #489.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.