### PR TITLE
Nullify visibility if visibility is an empty string

### DIFF
--- a/__tests__/event-spec.js
+++ b/__tests__/event-spec.js
@@ -556,6 +556,20 @@ describe('Event', () => {
           done();
         });
       });
+
+      test('should set visibility to undefined if set to an empty string', done => {
+        testContext.event.visibility = '';
+        return testContext.event.save().then(() => {
+          const options = testContext.connection.request.mock.calls[0][0];
+          expect(JSON.parse(options.body)).toEqual({
+            visibility: undefined,
+            calendar_id: '',
+            when: {},
+            participants: [],
+          });
+          done();
+        });
+      });
     });
 
     describe('notification', () => {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -333,6 +333,9 @@ export default class Event extends RestfulModel {
         participant => delete participant.status
       );
     }
+    if (this.visibility !== undefined && this.visibility === '') {
+      delete json.visibility;
+    }
 
     return json;
   }
@@ -418,9 +421,6 @@ export default class Event extends RestfulModel {
       throw new Error(
         'The number of participants in the event exceeds the set capacity.'
       );
-    }
-    if (this.visibility && this.visibility === '') {
-      this.visibility = undefined;
     }
   }
 }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -419,5 +419,8 @@ export default class Event extends RestfulModel {
         'The number of participants in the event exceeds the set capacity.'
       );
     }
+    if (this.visibility && this.visibility === '') {
+      this.visibility = undefined;
+    }
   }
 }


### PR DESCRIPTION
# Description
Closes #470, fixes the issue "Bad Request: Visibility cannot have the value ''".

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.