### PR TITLE
Implement logger support

### DIFF
--- a/__tests__/nylas-api-spec.js
+++ b/__tests__/nylas-api-spec.js
@@ -41,6 +41,10 @@ describe('Nylas', () => {
         clientSecret: 'newSecret',
         apiServer: 'https://api-staging.nylas.com/',
         timeout: 5000,
+        logger: {
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
       };
 
       Nylas.config(newConfig);
@@ -48,6 +52,7 @@ describe('Nylas', () => {
       expect(Nylas.clientSecret).toBe(newConfig.clientSecret);
       expect(Nylas.apiServer).toBe(newConfig.apiServer);
       expect(Nylas.timeout).toBe(newConfig.timeout);
+      expect(Nylas.logger).toBe(newConfig.logger);
     });
 
     test('should not override existing values unless new values are provided', () => {
@@ -78,16 +83,22 @@ describe('Nylas', () => {
         clientId: 'id',
         clientSecret: 'secret',
       };
+      const logger = {
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
       Nylas.config(newConfig);
       Nylas.clientId = 'newId';
       Nylas.clientSecret = 'newSecret';
       Nylas.apiServer = 'https://new.api.nylas.com';
       Nylas.timeout = 5000;
+      Nylas.logger = logger;
 
       expect(Nylas.clientId).toBe('newId');
       expect(Nylas.clientSecret).toBe('newSecret');
       expect(Nylas.apiServer).toBe('https://new.api.nylas.com');
       expect(Nylas.timeout).toBe(5000);
+      expect(Nylas.logger).toBe(logger);
     });
   });
 

--- a/__tests__/nylas-connection-spec.js
+++ b/__tests__/nylas-connection-spec.js
@@ -1,10 +1,11 @@
 jest.mock('node-fetch');
 import fetch from 'node-fetch';
-const { Response } = jest.requireActual('node-fetch');
-
 import NylasConnection from '../src/nylas-connection';
 import * as config from '../src/config.ts';
 import PACKAGE_JSON from '../package.json';
+
+const { Response } = jest.requireActual('node-fetch');
+
 const SDK_VERSION = PACKAGE_JSON.version;
 
 describe('NylasConnection', () => {
@@ -157,7 +158,11 @@ describe('NylasConnection', () => {
         });
 
         test('Should handle timeout errors properly', done => {
-          console.warn = jest.fn();
+          config.logger = {
+            warn: jest.fn(),
+            error: jest.fn(),
+          };
+
           const err = new Error();
           err.name = 'AbortError';
           fetch.mockReturnValue(Promise.reject(err));
@@ -168,7 +173,9 @@ describe('NylasConnection', () => {
               method: 'GET',
             })
             .catch(err => {
-              expect(console.warn).toHaveBeenCalledWith('Request timed out');
+              expect(config.logger.warn).toHaveBeenCalledWith(
+                'Request timed out'
+              );
               expect(err.name).toEqual('AbortError');
               done();
             });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { WebhookTriggers } from './models/webhook';
+import LoggingInterface from './models/LoggingInterface';
 
 export let apiServer: string | null = null;
 export function setApiServer(newApiServer: string | null) {
@@ -15,6 +16,11 @@ export function setTimeout(newTimeout: number) {
   timeout = newTimeout;
 }
 
+export let logger: LoggingInterface | undefined = undefined;
+export function setLogger(newLogger?: LoggingInterface) {
+  logger = newLogger;
+}
+
 export type NylasConfig = {
   /** Nylas application client ID */
   clientId: string;
@@ -24,6 +30,8 @@ export type NylasConfig = {
   apiServer?: string;
   /** Timeout for outgoing API calls, in milliseconds */
   timeout?: number;
+  /** Logger to redirect log messages to your application. */
+  logger?: LoggingInterface;
 };
 
 export enum ResponseType {

--- a/src/models/LoggingInterface.ts
+++ b/src/models/LoggingInterface.ts
@@ -1,0 +1,16 @@
+/**
+ * Logging interface to redirect log messages to your application.
+ */
+export default interface LoggingInterface {
+  /**
+   * Log a warning message.
+   * @param message The message to log.
+   */
+  warn(message: string): void;
+
+  /**
+   * Log an error message.
+   * @param message The error message to log.
+   */
+  error(message: string): void;
+}

--- a/src/nylas-connection.ts
+++ b/src/nylas-connection.ts
@@ -26,6 +26,7 @@ import DeltaCollection from './models/delta-collection';
 import Outbox from './models/outbox';
 import JobStatusRestfulModelCollection from './models/job-status-restful-model-collection';
 import RateLimitError from './models/rate-limit-error';
+import { logger } from './config';
 
 const PACKAGE_JSON = require('../package.json');
 const SDK_VERSION = PACKAGE_JSON.version;
@@ -256,7 +257,7 @@ export default class NylasConnection {
             apiVersion
           );
           if (warning) {
-            console.warn(warning);
+            logger?.warn(warning);
           }
 
           if (response.status > 299) {
@@ -330,10 +331,10 @@ export default class NylasConnection {
         })
         .catch((err: Error) => {
           if (err && err.name && err.name === 'AbortError') {
-            console.warn('Request timed out');
+            logger?.warn('Request timed out');
             return reject(err);
           }
-          console.error(`Error encountered during request:\n${err.stack}`);
+          logger?.error(`Error encountered during request:\n${err.stack}`);
           return reject(err);
         })
         .then(() => {

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -14,6 +14,7 @@ import AccessToken from './models/access-token';
 import ApplicationDetails, {
   ApplicationDetailsProperties,
 } from './models/application-details';
+import LoggingInterface from './models/LoggingInterface';
 
 class Nylas {
   static clientId = '';
@@ -35,6 +36,13 @@ class Nylas {
   // Timeout for outgoing API calls, in milliseconds
   static set timeout(timeout: number) {
     config.setTimeout(timeout);
+  }
+  static get logger(): LoggingInterface | undefined {
+    return config.logger;
+  }
+  // Logger to redirect log messages to your application
+  static set logger(timeout: LoggingInterface | undefined) {
+    config.setLogger(timeout);
   }
   static accounts:
     | ManagementModelCollection<ManagementAccount>
@@ -61,6 +69,9 @@ class Nylas {
       this.apiServer = 'https://api.nylas.com';
     }
     this.timeout = config.timeout || 0;
+    if (config.logger) {
+      this.logger = config.logger;
+    }
 
     const conn = new NylasConnection(this.clientSecret, {
       clientId: this.clientId,


### PR DESCRIPTION
# Description
This PR adds in an option to pass in a logger instead of the SDK using `console` to log. Closes #456.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.