### PR TITLE
Nullify replyToMessageId if it's an empty string

### DIFF
--- a/src/models/draft.ts
+++ b/src/models/draft.ts
@@ -78,7 +78,11 @@ export default class Draft extends Message implements DraftProperties {
     if (this.rawMime) {
       throw Error('saveRequestBody() cannot be called for raw MIME drafts');
     }
-    return super.saveRequestBody();
+    const json = super.saveRequestBody();
+    if (this.replyToMessageId !== undefined && this.replyToMessageId === '') {
+      delete json.reply_to_message_id;
+    }
+    return json;
   }
 
   deleteRequestBody(


### PR DESCRIPTION
# Description
This PR fixes #484.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.