### PR TITLE
v6.11.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 6.10.0 / 2023-11-28
+### 6.11.0 / 2023-11-28
 * Add support for logging
 * Nullify replyToMessageId is an empty string
 * Nullify visibility if visibility is an empty string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### Unreleased
+### 6.10.0 / 2023-11-28
+* Add support for logging
+* Nullify replyToMessageId is an empty string
+* Nullify visibility if visibility is an empty string
+* Fix numbers defaulting to 0 instead of null
 * Fix parsing of Number arrays
 * Fix configured timeout not being used
 * Bump `node-fetch` dependency from 2.6.1 to 2.6.12

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ For more information about how to use the Nylas Node SDK, [take a look at our qu
 
 Please refer to [Contributing](Contributing.md) for information about how to make contributions to this project. We welcome questions, bug reports, and pull requests.
 
-Taking part in Hacktoberfest 2023 (i.e. issue is tagged with `hacktoberfest`)? Read our [Nylas Hacktoberfest 2023 contribution guidelines](https://github.com/nylas-samples/nylas-hacktoberfest-2023/blob/main/readme.md).
-
 ## 📝 License
 
 This project is licensed under the terms of the MIT license. Please refer to [LICENSE](LICENSE.txt) for the full terms. 

--- a/__tests__/draft-spec.js
+++ b/__tests__/draft-spec.js
@@ -364,6 +364,37 @@ describe('Draft', () => {
         });
       });
     });
+
+    test('should set reply_to_message_id to undefined if set to an empty string', done => {
+      testContext.draft.replyToMessageId = '';
+      return testContext.draft.save().then(() => {
+        const options = testContext.connection.request.mock.calls[0][0];
+        expect(options.url.toString()).toEqual('https://api.nylas.com/drafts');
+        expect(options.method).toEqual('POST');
+        expect(JSON.parse(options.body)).toEqual({
+          to: [],
+          cc: [],
+          bcc: [],
+          from: [],
+          date: null,
+          body: undefined,
+          events: [],
+          unread: undefined,
+          snippet: undefined,
+          thread_id: undefined,
+          subject: undefined,
+          version: undefined,
+          folder: undefined,
+          starred: undefined,
+          labels: [],
+          file_ids: [],
+          headers: undefined,
+          reply_to: [],
+          reply_to_message_id: undefined,
+        });
+        done();
+      });
+    });
   });
 
   describe('send', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nylas",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nylas",
-      "version": "6.10.0",
+      "version": "6.11.0",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nylas",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",


### PR DESCRIPTION
# Changelog
* Add support for logging (#508, #456)
* Nullify replyToMessageId is an empty string (#484, #509)
* Nullify visibility if visibility is an empty string (#507, #470)
* Fix numbers defaulting to 0 instead of null (#469)
* Fix parsing of Number arrays (#503, #502)
* Fix configured timeout not being used (#506, #489)
* Bump `node-fetch` dependency from 2.6.1 to 2.6.12 (#504, #496)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.