### PR TITLE
Fix issue with form-data not importing correctly for ESM projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 7.0.0-beta.4 / TBD
+* Fix issue with form-data not importing correctly for ESM projects
+
 ### 7.0.0-beta.3 / 2023-10-23
 * Added support for the messages, drafts, and threads endpoints
 * Added support for the free-busy endpoint

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -250,7 +250,13 @@ export class Messages extends Resource {
   static _buildFormRequest(
     requestBody: BaseCreateMessage | UpdateDraftRequest
   ): FormData {
-    const form = new FormData();
+    let form: FormData;
+    // FormData imports are funky, cjs needs to use .default, es6 doesn't
+    if (typeof (FormData as any).default !== 'undefined') {
+      form = new (FormData as any).default();
+    } else {
+      form = new FormData();
+    }
 
     // Split out the message payload from the attachments
     const messagePayload = {


### PR DESCRIPTION
# Description
The npm package `form-data` has an issue with importing compatibility between CJS and ESM. Using `import * as FormData` or `import FormData` works only on cjs while `import { default as FormData }` works only on esm. We work around this now by checking if `default` exists on the importing object, and using it if it does, otherwise just use `FormData`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.