### PR TITLE
Fix issue where Graph events were returning 400 on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue where Graph events were returning 400 on update
+
 ### 6.11.0 / 2023-11-28
 * Add support for logging
 * Nullify replyToMessageId is an empty string

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -100,8 +100,9 @@ export default class Event extends RestfulModel {
   organizerEmail?: string;
   organizerName?: string;
   hideParticipants?: boolean;
-  visibility?: string;
   customerEventId?: string;
+  private _visibility?: string;
+  private visibilityIsDirty = false;
   static collectionName = 'events';
   static attributes: Record<string, Attribute> = {
     ...RestfulModel.attributes,
@@ -220,7 +221,8 @@ export default class Event extends RestfulModel {
       jsonKey: 'hide_participants',
     }),
     visibility: Attributes.String({
-      modelKey: 'visibility',
+      modelKey: '_visibility',
+      jsonKey: 'visibility',
     }),
     customerEventId: Attributes.String({
       modelKey: 'customerEventId',
@@ -231,6 +233,7 @@ export default class Event extends RestfulModel {
   constructor(connection: NylasConnection, props?: EventProperties) {
     super(connection, props);
     this.initAttributes(props);
+    this.visibilityIsDirty = false;
   }
 
   get start(): string | number | undefined {
@@ -307,6 +310,18 @@ export default class Event extends RestfulModel {
     }
   }
 
+  get visibility(): string | undefined {
+    return this._visibility;
+  }
+
+  set visibility(val: string | undefined) {
+    if (val !== this._visibility) {
+      this.visibilityIsDirty = true;
+    }
+
+    this._visibility = val;
+  }
+
   deleteRequestQueryString(
     params: Record<string, unknown> = {}
   ): Record<string, unknown> {
@@ -333,7 +348,10 @@ export default class Event extends RestfulModel {
         participant => delete participant.status
       );
     }
-    if (this.visibility !== undefined && this.visibility === '') {
+    if (
+      (this.visibility !== undefined && this.visibility === '') ||
+      !this.visibilityIsDirty
+    ) {
       delete json.visibility;
     }
 

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -420,6 +420,12 @@ export default class Event extends RestfulModel {
       });
   }
 
+  fromJSON(json: Record<string, unknown>): this {
+    const model = super.fromJSON(json);
+    model.visibilityIsDirty = false;
+    return model;
+  }
+
   private validate(): void {
     if (
       this.conferencing &&


### PR DESCRIPTION
# Description
This PR remedies the issue seen where Graph accounts were returning 400 on update due to visibility field being present in the PUT request. We now check to see if the visibility field was modified, and only then do we include it in the outgoing request.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.