### PR TITLE
Include email value for CodeExchange response

### DIFF
--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -142,6 +142,10 @@ export interface CodeExchangeResponse {
    */
   grantId: string;
   /**
+   * Email address of the grant that is created.
+   */
+  email: string;
+  /**
    * The remaining lifetime of the access token in seconds.
    */
   expiresIn: number;

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -152,7 +152,7 @@ export class Auth extends Resource {
   ): Promise<ProviderDetectResponse> {
     return this.apiClient.request<ProviderDetectResponse>({
       method: 'POST',
-      path: `/v3/grants/providers/detect`,
+      path: `/v3/providers/detect`,
       queryParams: params,
     });
   }


### PR DESCRIPTION
<!-- Add information about your PR here -->

The code exchange response should include an email value as well.

Additionally, the provider detect endpoint was referencing the wrong path. Changed it to reflect the path mentioned here -> https://developer.nylas.com/docs/api/v3-beta/admin/#post-/v3/providers/detect


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.