### PR TITLE
CUST-1790: Make comment param in rsvp optional

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -360,7 +360,7 @@ export default class Event extends RestfulModel {
 
   rsvp(
     status: string,
-    comment: string,
+    comment?: string,
     callback?: (error: Error | null, data?: Event) => void
   ): Promise<Event> {
     return this.connection


### PR DESCRIPTION
For [CUST-1790](https://nylas.atlassian.net/browse/CUST-1790), [our POST /send-rsvp docs](https://developer.nylas.com/docs/api/v2/#post-/send-rsvp) explicitly say that the `comment` param is optional. This PR changes the `comment` param to be optional.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

[CUST-1790]: https://nylas.atlassian.net/browse/CUST-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ