### PR TITLE
Changed `clientSecret` to optional for token exchange methods; defaults to API Key now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Changed `clientSecret` to optional for token exchange methods; defaults to API Key now
 * Fix missing `type` field in `Event` model
 
 ### 7.0.0-beta.4 / 2024-01-12

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -80,9 +80,9 @@ export interface CodeExchangeRequest {
    */
   clientId: string;
   /**
-   * Client secret of the application.
+   * Client secret of the application. If not provided, the API Key will be used instead.
    */
-  clientSecret: string;
+  clientSecret?: string;
   /**
    * The original plain text code verifier (code_challenge) used in the initial authorization request (PKCE).
    */
@@ -106,9 +106,9 @@ export interface TokenExchangeRequest {
    */
   clientId: string;
   /**
-   * Client secret of the application.
+   * Client secret of the application. If not provided, the API Key will be used instead.
    */
-  clientSecret: string;
+  clientSecret?: string;
 }
 
 /**

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -46,17 +46,17 @@ export class Auth extends Resource {
   public exchangeCodeForToken(
     request: CodeExchangeRequest
   ): Promise<CodeExchangeResponse> {
-    const body: Record<string, unknown> = {
-      ...request,
-      grantType: 'authorization_code',
-    };
-    if (request.codeVerifier) {
-      body.codeVerifier = request.codeVerifier;
+    if (!request.clientSecret) {
+      request.clientSecret = this.apiClient.apiKey;
     }
+
     return this.apiClient.request<CodeExchangeResponse>({
       method: 'POST',
       path: `/v3/connect/token`,
-      body,
+      body: {
+        ...request,
+        grantType: 'authorization_code',
+      },
     });
   }
 
@@ -68,6 +68,10 @@ export class Auth extends Resource {
   public refreshAccessToken(
     request: TokenExchangeRequest
   ): Promise<CodeExchangeResponse> {
+    if (!request.clientSecret) {
+      request.clientSecret = this.apiClient.apiKey;
+    }
+
     return this.apiClient.request<CodeExchangeResponse>({
       method: 'POST',
       path: `/v3/connect/token`,

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -45,6 +45,27 @@ describe('Auth', () => {
         });
       });
 
+      it('should default clientSecret to the API key', async () => {
+        const payload: CodeExchangeRequest = {
+          clientId: 'clientId',
+          redirectUri: 'https://redirect.uri/path',
+          code: 'code',
+        };
+        await auth.exchangeCodeForToken(payload);
+
+        expect(apiClient.request).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/v3/connect/token',
+          body: {
+            clientId: 'clientId',
+            clientSecret: 'apiKey',
+            redirectUri: 'https://redirect.uri/path',
+            code: 'code',
+            grantType: 'authorization_code',
+          },
+        });
+      });
+
       it('should set codeVerifier', async () => {
         const payload: CodeExchangeRequest = {
           clientId: 'clientId',
@@ -86,6 +107,27 @@ describe('Auth', () => {
           body: {
             clientId: 'clientId',
             clientSecret: 'clientSecret',
+            redirectUri: 'https://redirect.uri/path',
+            refreshToken: 'refreshToken',
+            grantType: 'refresh_token',
+          },
+        });
+      });
+
+      it('should default clientSecret to the API key', async () => {
+        const payload: TokenExchangeRequest = {
+          clientId: 'clientId',
+          redirectUri: 'https://redirect.uri/path',
+          refreshToken: 'refreshToken',
+        };
+        await auth.refreshAccessToken(payload);
+
+        expect(apiClient.request).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/v3/connect/token',
+          body: {
+            clientId: 'clientId',
+            clientSecret: 'apiKey',
             redirectUri: 'https://redirect.uri/path',
             refreshToken: 'refreshToken',
             grantType: 'refresh_token',


### PR DESCRIPTION
# Description
clientSecret is not required if the API Key used for the SDK and the clientId belong to the same application. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.