### PR TITLE
Fix event and webhook models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Models can now directly be imported from the top-level `nylas` package
+* Fixed inaccuracies in event and webhook models
 
 ### 7.0.0 / 2024-02-05
 * **BREAKING CHANGE**: Node SDK v7 supports the Nylas API v3 exclusively, dropping support for any endpoints that are not available in v3.

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -30,14 +30,6 @@ export interface Event {
    */
   readOnly: boolean;
   /**
-   * Unix timestamp when the event was created.
-   */
-  createdAt: number;
-  /**
-   * Unix timestamp when the event was last updated.
-   */
-  updatedAt: number;
-  /**
    * List of participants invited to the event. Participants may also be rooms or resources.
    */
   participants: Participant[];
@@ -110,6 +102,14 @@ export interface Event {
    * Status of the event.
    */
   status?: Status;
+  /**
+   * Unix timestamp when the event was created.
+   */
+  createdAt?: number;
+  /**
+   * Unix timestamp when the event was last updated.
+   */
+  updatedAt?: number;
 }
 
 /**

--- a/src/models/webhooks.ts
+++ b/src/models/webhooks.ts
@@ -13,11 +13,11 @@ export interface Webhook {
   /**
    * The url to send webhooks to.
    */
-  callbackUrl: string;
+  webhookUrl: string;
   /**
    * The status of the new destination.
    */
-  status: 'active' | 'failing' | 'failed' | 'pause';
+  status: WebhookStatus;
   /**
    * The time the status field was last updated, represented as a Unix timestamp in seconds.
    */
@@ -37,7 +37,7 @@ export interface Webhook {
   /**
    * The email addresses that Nylas notifies when a webhook is down for a while.
    */
-  notificationEmailAddress?: string;
+  notificationEmailAddresses?: string[];
 }
 
 /**
@@ -94,7 +94,7 @@ export interface CreateWebhookRequest {
   /**
    * The url to send webhooks to.
    */
-  callbackUrl: string;
+  webhookUrl: string;
   /**
    * A human-readable description of the webhook destination.
    */
@@ -102,7 +102,7 @@ export interface CreateWebhookRequest {
   /**
    * The email addresses that Nylas notifies when a webhook is down for a while.
    */
-  notificationEmailAddress?: string;
+  notificationEmailAddresses?: string[];
 }
 
 /**
@@ -127,3 +127,8 @@ export enum WebhookTriggers {
   MessageSendSuccess = 'message.send_success',
   MessageSendFailed = 'message.send_failed',
 }
+
+/**
+ * Enum representing the available webhook statuses.
+ */
+export type WebhookStatus = 'active' | 'failing' | 'failed' | 'pause';

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -70,9 +70,9 @@ describe('Webhooks', () => {
       await webhooks.create({
         requestBody: {
           triggerTypes: [WebhookTriggers.CalendarCreated],
-          callbackUrl: 'https://test.callback.com',
+          webhookUrl: 'https://test.callback.com',
           description: "My Webhook's Description",
-          notificationEmailAddress: 'notification@example.com',
+          notificationEmailAddresses: ['notification@example.com'],
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
@@ -84,9 +84,9 @@ describe('Webhooks', () => {
         path: '/v3/webhooks',
         body: {
           triggerTypes: [WebhookTriggers.CalendarCreated],
-          callbackUrl: 'https://test.callback.com',
+          webhookUrl: 'https://test.callback.com',
           description: "My Webhook's Description",
-          notificationEmailAddress: 'notification@example.com',
+          notificationEmailAddresses: ['notification@example.com'],
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',


### PR DESCRIPTION
# Description
This PR brings a couple of changes to the SDK models:
- Event-related models: `createdAt` and `updatedAt` are now optional fields
- Webhook-related models: `callbackUrl` renamed to `webhookUrl` to maintain consistency with the API

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.