### PR TITLE
Added support for /v3/connect/tokeninfo endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Added support for `/v3/connect/tokeninfo` endpoint
 * Models can now directly be imported from the top-level `nylas` package
 
 ### 7.0.0 / 2024-02-05

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -206,3 +206,33 @@ export interface ProviderDetectResponse {
    */
   type?: string;
 }
+
+/**
+ * Interface representing a Nylas token information response.
+ */
+export interface TokenInfoResponse {
+  /**
+   * The issuer of the token.
+   */
+  iss: string;
+  /**
+   * The token's audience.
+   */
+  aud: string;
+  /**
+   * The time that the token was issued.
+   */
+  iat: number;
+  /**
+   * The time that the token expires.
+   */
+  exp: number;
+  /**
+   * The token's subject.
+   */
+  sub?: string;
+  /**
+   * The email address of the Grant belonging to the user's token.
+   */
+  email?: string;
+}

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -232,8 +232,8 @@ export class Auth extends Resource {
     params: Record<string, any>
   ): Promise<NylasResponse<TokenInfoResponse>> {
     return this.apiClient.request<NylasResponse<TokenInfoResponse>>({
-      method: 'POST',
-      path: `/v3/providers/detect`,
+      method: 'GET',
+      path: `/v3/connect/tokeninfo`,
       queryParams: params,
     });
   }

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -10,6 +10,7 @@ import {
   CodeExchangeResponse,
   ProviderDetectParams,
   ProviderDetectResponse,
+  TokenInfoResponse,
 } from '../models/auth.js';
 import { Overrides } from '../config.js';
 import { NylasResponse } from '../models/response.js';
@@ -161,6 +162,28 @@ export class Auth extends Resource {
     });
   }
 
+  /**
+   * Get info about an ID token
+   * @param idToken The ID token to query.
+   * @return The token information
+   */
+  public idTokenInfo(
+    idToken: string
+  ): Promise<NylasResponse<TokenInfoResponse>> {
+    return this.getTokenInfo({ id_token: idToken });
+  }
+
+  /**
+   * Get info about an access token
+   * @param accessToken The access token to query.
+   * @return The token information
+   */
+  public accessTokenInfo(
+    accessToken: string
+  ): Promise<NylasResponse<TokenInfoResponse>> {
+    return this.getTokenInfo({ access_token: accessToken });
+  }
+
   private urlAuthBuilder(config: Record<string, any>): URL {
     const url = new URL(`${this.apiClient.serverUrl}/v3/connect/auth`);
     url.searchParams.set('client_id', config.clientId);
@@ -203,5 +226,15 @@ export class Auth extends Resource {
     return Buffer.from(hash)
       .toString('base64')
       .replace(/=+$/, '');
+  }
+
+  private getTokenInfo(
+    params: Record<string, any>
+  ): Promise<NylasResponse<TokenInfoResponse>> {
+    return this.apiClient.request<NylasResponse<TokenInfoResponse>>({
+      method: 'POST',
+      path: `/v3/providers/detect`,
+      queryParams: params,
+    });
   }
 }

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -265,4 +265,33 @@ describe('Auth', () => {
       });
     });
   });
+  describe('token info', () => {
+    describe('idTokenInfo', () => {
+      it('should call getTokenInfo with the correct params', async () => {
+        await auth.idTokenInfo('idToken123');
+
+        expect(apiClient.request).toHaveBeenCalledWith({
+          method: 'GET',
+          path: '/v3/connect/tokeninfo',
+          queryParams: {
+            id_token: 'idToken123',
+          },
+        });
+      });
+    });
+
+    describe('accessTokenInfo', () => {
+      it('should call getTokenInfo with the correct params', async () => {
+        await auth.accessTokenInfo('accessToken123');
+
+        expect(apiClient.request).toHaveBeenCalledWith({
+          method: 'GET',
+          path: '/v3/connect/tokeninfo',
+          queryParams: {
+            access_token: 'accessToken123',
+          },
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description
This PR adds support for the /v3/connect/tokeninfo endpoint.

# Usage
There are two methods that are part of the `Auth` resource that allow you to get information on a token; one for the ID token (`idTokenInfo`) and one for the access token (`accessTokenInfo`).

```ts
import Nylas, { TokenInfoResponse } from "nylas";

const nylas = new Nylas({
  apiKey: 'nylas-api-key',
});

// Get information on an ID token
nylas.auth.idTokenInfo('idToken').then((response) => {
  const idTokenInfo: TokenInfoResponse = response.data;
  // ...
});

// Get information on an access token
nylas.auth.accessTokenInfo('accessToken').then((response) => {
  const accessTokenInfo: TokenInfoResponse = response.data;
  // ...
});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.