### PR TITLE
Include query params for message.find method

### DIFF
--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -139,12 +139,12 @@ export class Messages extends Resource {
     identifier,
     messageId,
     overrides,
-    queryParams
+    queryParams,
   }: FindMessageParams & Overrides): Promise<NylasResponse<Message>> {
     return super._find({
       path: `/v3/grants/${identifier}/messages/${messageId}`,
       overrides,
-      queryParams
+      queryParams,
     });
   }
 

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -139,10 +139,12 @@ export class Messages extends Resource {
     identifier,
     messageId,
     overrides,
+    queryParams
   }: FindMessageParams & Overrides): Promise<NylasResponse<Message>> {
     return super._find({
       path: `/v3/grants/${identifier}/messages/${messageId}`,
       overrides,
+      queryParams
     });
   }
 


### PR DESCRIPTION
# Description

This PR contains a small fix for including query params for message.find method, this allows message headers within the response.

https://nylas.atlassian.net/browse/TSDK-595?atlOrigin=eyJpIjoiOGUxOWZjYzRmOTYxNGMzMmE2NzdjMjcyMzNmYjcyNmEiLCJwIjoiaiJ9

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.