### PR TITLE
Added new fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Added support for `roundTo` field in availability response model
 * Added support for `attributes` field in folder model
+* Added support for icloud as an auth provider
 
 ### 7.1.0 / 2024-02-12
 * Added support for `/v3/connect/tokeninfo` endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ### Unreleased
-* Added support for `roundTo` field in availability response
-* 
+* Added support for `roundTo` field in availability response model
+* Added support for `attributes` field in folder model
 
 ### 7.1.0 / 2024-02-12
 * Added support for `/v3/connect/tokeninfo` endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Added support for `roundTo` field in availability response
+* 
+
 ### 7.1.0 / 2024-02-12
 * Added support for `/v3/connect/tokeninfo` endpoint
 * Models can now directly be imported from the top-level `nylas` package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added support for `roundTo` field in availability response model
 * Added support for `attributes` field in folder model
 * Added support for icloud as an auth provider
+* Removed unnecessary `clientId` from detectProvider params
 
 ### 7.1.0 / 2024-02-12
 * Added support for `/v3/connect/tokeninfo` endpoint

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -6,7 +6,12 @@ type AccessType = 'online' | 'offline';
 /**
  * Type for the different OAuth providers Nylas supports.
  */
-export type Provider = 'google' | 'imap' | 'microsoft' | 'virtual-calendar';
+export type Provider =
+  | 'google'
+  | 'imap'
+  | 'microsoft'
+  | 'icloud'
+  | 'virtual-calendar';
 
 /**
  * Configuration for generating a URL for OAuth 2.0 authentication.

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -181,10 +181,6 @@ export interface ProviderDetectParams {
    */
   email: string;
   /**
-   * Client ID of the Nylas application.
-   */
-  clientId: string;
-  /**
    * Search by all providers regardless of created integrations. If unset, defaults to false.
    */
   allProviderTypes?: boolean;

--- a/src/models/availability.ts
+++ b/src/models/availability.ts
@@ -39,15 +39,24 @@ export interface GetAvailabilityRequest {
    * If you have a meeting starting at 9:59, the API returns times starting at 10:00. 10:00-10:30, 10:15-10:45.
    */
   intervalMinutes?: number;
+
   /**
-   * When set to true, the availability time slots will start at 30 minutes past or on the hour.
-   * For example, a free slot starting at 16:10 is considered available only from 16:30.
+   * The number of minutes to round the time slots to.
+   * This allows for rounding to any multiple of 5 minutes, up to a maximum of 60 minutes.
+   * The default value is set to 15 minutes.
+   * When this variable is assigned a value, it overrides the behavior of the {@link roundTo30Minutes} flag, if it was set.
    */
-  roundTo30Minutes?: boolean;
+  roundTo?: number;
   /**
    * The rules to apply when checking availability.
    */
   availabilityRules?: AvailabilityRules;
+  /**
+   * When set to true, the availability time slots will start at 30 minutes past or on the hour.
+   * For example, a free slot starting at 16:10 is considered available only from 16:30.
+   * @deprecated Use [roundTo] instead.
+   */
+  roundTo30Minutes?: boolean;
 }
 
 /**

--- a/src/models/folders.ts
+++ b/src/models/folders.ts
@@ -56,6 +56,14 @@ export interface Folder {
    * The number of unread items inside of a folder.
    */
   unreadCount?: number;
+
+  /**
+   * Common attribute descriptors shared by system folders across providers.
+   * For example, Sent email folders have the `["\\Sent"]` attribute.
+   * For IMAP grants, IMAP providers provide the attributes.
+   * For Google and Microsoft Graph, Nylas matches system folders to a set of common attributes.
+   */
+  attributes?: string[];
 }
 
 /**

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -247,7 +247,6 @@ describe('Auth', () => {
     it('should call apiClient.request with the correct params', async () => {
       await auth.detectProvider({
         email: 'email@example.com',
-        clientId: 'testClientId',
         allProviderTypes: true,
       });
     });

--- a/tests/resources/folders.spec.ts
+++ b/tests/resources/folders.spec.ts
@@ -1,5 +1,6 @@
 import APIClient from '../../src/apiClient';
 import { Folders } from '../../src/resources/folders';
+import { objKeysToCamelCase } from '../../src/utils';
 jest.mock('../../src/apiClient');
 
 describe('Folders', () => {
@@ -15,6 +16,41 @@ describe('Folders', () => {
 
     folders = new Folders(apiClient);
     apiClient.request.mockResolvedValue({});
+  });
+
+  describe('deserializing', () => {
+    it('should return a folder object as expected', () => {
+      const apiFolder = {
+        id: 'SENT',
+        grant_id: '41009df5-bf11-4c97-aa18-b285b5f2e386',
+        name: 'SENT',
+        system_folder: true,
+        object: 'folder',
+        unread_count: 0,
+        child_count: 0,
+        parent_id: 'ascsf21412',
+        background_color: '#039BE5',
+        text_color: '#039BE5',
+        total_count: 0,
+        attributes: ['\\SENT'],
+      };
+
+      const folder = objKeysToCamelCase(apiFolder);
+      expect(folder).toEqual({
+        id: 'SENT',
+        grantId: '41009df5-bf11-4c97-aa18-b285b5f2e386',
+        name: 'SENT',
+        systemFolder: true,
+        object: 'folder',
+        unreadCount: 0,
+        childCount: 0,
+        parentId: 'ascsf21412',
+        backgroundColor: '#039BE5',
+        textColor: '#039BE5',
+        totalCount: 0,
+        attributes: ['\\SENT'],
+      });
+    });
   });
 
   describe('list', () => {


### PR DESCRIPTION
# Description
* Added support for `roundTo` field in availability response model
* Added support for `attributes` field in folder model
* Added support for icloud as an auth provider
* Removed clientId from detectProvider

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.