### PR TITLE
Improved message sending and draft create/update performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Improved message sending and draft create/update performance
+
 ### 7.2.0 / 2024-02-27
 * Added support for `roundTo` field in availability response model
 * Added support for `attributes` field in folder model

--- a/src/resources/drafts.ts
+++ b/src/resources/drafts.ts
@@ -151,12 +151,28 @@ export class Drafts extends Resource {
     requestBody,
     overrides,
   }: UpdateDraftParams & Overrides): Promise<NylasResponse<Draft>> {
-    const form = Messages._buildFormRequest(requestBody);
+    const path = `/v3/grants/${identifier}/drafts/${draftId}`;
 
-    return this.apiClient.request({
-      method: 'PUT',
-      path: `/v3/grants/${identifier}/drafts/${draftId}`,
-      form,
+    // Use form data only if the attachment size is greater than 3mb
+    const attachmentSize =
+      requestBody.attachments?.reduce(function(_, attachment) {
+        return attachment.size || 0;
+      }, 0) || 0;
+
+    if (attachmentSize >= Messages.FORM_DATA_ATTACHMENT_SIZE) {
+      const form = Messages._buildFormRequest(requestBody);
+
+      return this.apiClient.request({
+        method: 'PUT',
+        path,
+        form,
+        overrides,
+      });
+    }
+
+    return super._update({
+      path,
+      requestBody,
       overrides,
     });
   }

--- a/src/resources/drafts.ts
+++ b/src/resources/drafts.ts
@@ -13,7 +13,6 @@ import {
   NylasListResponse,
   NylasResponse,
 } from '../models/response.js';
-import { RequestOptionsParams } from '../apiClient';
 
 /**
  * The parameters for the {@link Drafts.list} method

--- a/src/resources/drafts.ts
+++ b/src/resources/drafts.ts
@@ -122,7 +122,7 @@ export class Drafts extends Resource {
         return attachment.size || 0;
       }, 0) || 0;
 
-    if (attachmentSize >= Messages.FORM_DATA_ATTACHMENT_SIZE) {
+    if (attachmentSize >= Messages.MAXIMUM_JSON_ATTACHMENT_SIZE) {
       const form = Messages._buildFormRequest(requestBody);
 
       return this.apiClient.request({
@@ -158,7 +158,7 @@ export class Drafts extends Resource {
         return attachment.size || 0;
       }, 0) || 0;
 
-    if (attachmentSize >= Messages.FORM_DATA_ATTACHMENT_SIZE) {
+    if (attachmentSize >= Messages.MAXIMUM_JSON_ATTACHMENT_SIZE) {
       const form = Messages._buildFormRequest(requestBody);
 
       return this.apiClient.request({

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -110,6 +110,7 @@ export type StopScheduledMessageParams = FindScheduledMessageParams;
  */
 export class Messages extends Resource {
   public smartCompose: SmartCompose;
+  static FORM_DATA_ATTACHMENT_SIZE = 3 * 1024 * 1024;
 
   constructor(apiClient: APIClient) {
     super(apiClient);

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -110,7 +110,8 @@ export type StopScheduledMessageParams = FindScheduledMessageParams;
  */
 export class Messages extends Resource {
   public smartCompose: SmartCompose;
-  static FORM_DATA_ATTACHMENT_SIZE = 3 * 1024 * 1024;
+  // The maximum size of an attachment that can be sent using json
+  static MAXIMUM_JSON_ATTACHMENT_SIZE = 3 * 1024 * 1024;
 
   constructor(apiClient: APIClient) {
     super(apiClient);
@@ -206,7 +207,7 @@ export class Messages extends Resource {
         return attachment.size || 0;
       }, 0) || 0;
 
-    if (attachmentSize >= Messages.FORM_DATA_ATTACHMENT_SIZE) {
+    if (attachmentSize >= Messages.MAXIMUM_JSON_ATTACHMENT_SIZE) {
       requestOptions.form = Messages._buildFormRequest(requestBody);
     } else {
       requestOptions.body = requestBody;

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -207,8 +207,7 @@ export class Messages extends Resource {
       }, 0) || 0;
 
     if (attachmentSize >= Messages.FORM_DATA_ATTACHMENT_SIZE) {
-      const form = Messages._buildFormRequest(requestBody);
-      requestOptions.form = form;
+      requestOptions.form = Messages._buildFormRequest(requestBody);
     } else {
       requestOptions.body = requestBody;
     }


### PR DESCRIPTION
# Description
This PR improves message send/draft create/update performance by always defaulting to application/json instead of multipart. Multipart will only be used for when a request contains a total attachments size of 3mb or higher.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.