### PR TITLE
Change default timeout to match API (90 seconds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Improved message sending and draft create/update performance
+* Change default timeout to match API (90 seconds)
 
 ### 7.2.0 / 2024-02-27
 * Added support for `roundTo` field in availability response model

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -89,7 +89,7 @@ export default class Nylas {
     this.apiClient = new APIClient({
       apiKey: config.apiKey,
       apiUri: config.apiUri || DEFAULT_SERVER_URL,
-      timeout: config.timeout || 30,
+      timeout: config.timeout || 90,
     });
 
     this.applications = new Applications(this.apiClient);

--- a/tests/nylas.spec.ts
+++ b/tests/nylas.spec.ts
@@ -42,7 +42,7 @@ describe('Nylas', () => {
       });
 
       expect(nylas.apiClient.serverUrl).toBe('https://api.us.nylas.com');
-      expect(nylas.apiClient.timeout).toBe(30000);
+      expect(nylas.apiClient.timeout).toBe(90000);
     });
   });
 });


### PR DESCRIPTION
# Description
The API's default timeout is 90 seconds, so it's best we match that. We have updated the default value to match this, user can still override the default.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.