### PR TITLE
Fixed serialization/deserialization of keys with numbers in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Improved message sending and draft create/update performance
 * Change default timeout to match API (90 seconds)
+* Fixed serialization/deserialization of keys with numbers in them
 
 ### 7.2.0 / 2024-02-27
 * Added support for `roundTo` field in availability response model

--- a/src/models/availability.ts
+++ b/src/models/availability.ts
@@ -54,7 +54,7 @@ export interface GetAvailabilityRequest {
   /**
    * When set to true, the availability time slots will start at 30 minutes past or on the hour.
    * For example, a free slot starting at 16:10 is considered available only from 16:30.
-   * @deprecated Use [roundTo] instead.
+   * @deprecated Use {@link roundTo} instead.
    */
   roundTo30Minutes?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,22 @@ export function createFileRequestBuilder(
 type CasingFunction = (input: string, options?: any) => string;
 
 /**
+ * Applies the casing function and ensures numeric parts are preceded by underscores in snake_case.
+ * @param casingFunction The original casing function.
+ * @param input The string to convert.
+ * @returns The converted string.
+ */
+function applyCasing(casingFunction: CasingFunction, input: string): string {
+  const transformed = casingFunction(input);
+
+  if (casingFunction === snakeCase) {
+    return transformed.replace(/(\d+)/g, '_$1');
+  } else {
+    return transformed.replace(/_+(\d+)/g, (match, p1) => p1);
+  }
+}
+
+/**
  * A utility function that recursively converts all keys in an object to a given case.
  * @param obj The object to convert
  * @param casingFunction The function to use to convert the keys
@@ -44,20 +60,22 @@ function convertCase(
     if (excludeKeys?.includes(key)) {
       newObj[key] = obj[key];
     } else if (Array.isArray(obj[key])) {
-      newObj[casingFunction(key)] = (obj[key] as any[]).map(item => {
-        if (typeof item === 'object') {
-          return convertCase(item, casingFunction);
-        } else {
-          return item;
+      newObj[applyCasing(casingFunction, key)] = (obj[key] as any[]).map(
+        item => {
+          if (typeof item === 'object') {
+            return convertCase(item, casingFunction);
+          } else {
+            return item;
+          }
         }
-      });
+      );
     } else if (typeof obj[key] === 'object' && obj[key] !== null) {
-      newObj[casingFunction(key)] = convertCase(
+      newObj[applyCasing(casingFunction, key)] = convertCase(
         obj[key] as Record<string, unknown>,
         casingFunction
       );
     } else {
-      newObj[casingFunction(key)] = obj[key];
+      newObj[applyCasing(casingFunction, key)] = obj[key];
     }
   }
   return newObj;

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -156,4 +156,22 @@ describe('convertCase', () => {
       user_age: undefined,
     });
   });
+
+  it('should handle numerical key names in snake_case conversion', () => {
+    const obj = { firstName: 'John', current2024Status: 'confirmed' };
+    const result = objKeysToSnakeCase(obj);
+    expect(result).toEqual({
+      first_name: 'John',
+      current_2024_status: 'confirmed',
+    });
+  });
+
+  it('should handle numerical key names in camelCase conversion', () => {
+    const obj = { first_name: 'John', current_2024_status: 'confirmed' };
+    const result = objKeysToCamelCase(obj);
+    expect(result).toEqual({
+      firstName: 'John',
+      current2024Status: 'confirmed',
+    });
+  });
 });


### PR DESCRIPTION
# Description
We were not handling keys with digits in them well. Example; `roundTo30Minutes` was being converted to `round_to30_minutes` as opposed to `round_to_30_minutes` as expected.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.