### PR TITLE
Add support for the detect provider endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for the detect provider endpoint
+
 ### 6.11.1 / 2024-02-09
 * Fix issue where Graph events were returning 400 on update
 * Make comment param in rsvp optional

--- a/src/models/detect-provider-response.ts
+++ b/src/models/detect-provider-response.ts
@@ -1,0 +1,44 @@
+import Model from './model';
+import Attributes, { Attribute } from './attributes';
+
+export type DetectProviderResponseProperties = {
+  authName: string;
+  emailAddress: string;
+  detected: boolean;
+  providerName?: string;
+  isImap?: boolean;
+};
+
+export default class DetectProviderResponse extends Model
+  implements DetectProviderResponseProperties {
+  authName = '';
+  emailAddress = '';
+  detected = false;
+  provider?: string;
+  isImap?: boolean;
+  static attributes: Record<string, Attribute> = {
+    authName: Attributes.String({
+      modelKey: 'authName',
+      jsonKey: 'auth_name',
+    }),
+    emailAddress: Attributes.String({
+      modelKey: 'emailAddress',
+      jsonKey: 'email_address',
+    }),
+    detected: Attributes.Boolean({
+      modelKey: 'detected',
+    }),
+    provider: Attributes.String({
+      modelKey: 'provider',
+    }),
+    isImap: Attributes.Boolean({
+      modelKey: 'isImap',
+      jsonKey: 'is_imap',
+    }),
+  };
+
+  constructor(props?: DetectProviderResponseProperties) {
+    super();
+    this.initAttributes(props);
+  }
+}

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -15,6 +15,7 @@ import ApplicationDetails, {
   ApplicationDetailsProperties,
 } from './models/application-details';
 import LoggingInterface from './models/LoggingInterface';
+import DetectProviderResponse from './models/detect-provider-response';
 
 class Nylas {
   static clientId = '';
@@ -210,6 +211,30 @@ class Nylas {
       url += '&redirect_on_error=true';
     }
     return url;
+  }
+
+  /**
+   * Detect the provider for a given email address
+   * @param email The email address you want to check
+   * @return The response from the API containing the provider, if found
+   */
+  static detectProvider(email: string): Promise<DetectProviderResponse> {
+    const connection = new NylasConnection(null, { clientId: this.clientId });
+
+    return connection
+      .request({
+        method: 'POST',
+        path: '/connect/detect-provider',
+        body: {
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          email_address: email,
+        },
+      })
+      .then(res => {
+        return new DetectProviderResponse().fromJSON(res);
+      })
+      .catch(err => Promise.reject(err));
   }
 
   /**


### PR DESCRIPTION
# Description
This PR adds support for the `/connect/detect_provider` endpint.

# Usage
To get the provider:

```javascript
const Nylas = require('nylas');

// Initialize an instance of the Nylas SDK using the client credentials
Nylas.config({
  clientId: "CLIENT_ID",
  clientSecret: "CLIENT_SECRET",
});

// Pass the email to the detect provider function
const detectProviderRes = await Nylas.detectProvider("example@email.com");
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.