### PR TITLE
chore: change the type property of Date, Datespan, Time and Timespan to object

### DIFF
--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -511,7 +511,7 @@ export interface Datespan {
   /**
    * The type of 'when' object.
    */
-  type: WhenType.Datespan;
+  object: WhenType.Datespan;
 }
 
 /**

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -443,7 +443,7 @@ export interface Time {
   /**
    * The type of 'when' object.
    */
-  type: WhenType.Time;
+  object: WhenType.Time;
 }
 
 /**
@@ -474,7 +474,7 @@ export interface Timespan {
   /**
    * The type of 'when' object.
    */
-  type: WhenType.Timespan;
+  object: WhenType.Timespan;
 }
 
 /**
@@ -490,7 +490,7 @@ export interface Date {
   /**
    * The type of 'when' object.
    */
-  type: WhenType.Date;
+  object: WhenType.Date;
 }
 
 /**


### PR DESCRIPTION
This PR updates the `type` property of the Date, Datespan, Time and Timespan types (the WhenTypes) to
`object` which is what is returned by the latest version (v3) of the Nylas api

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Closes #550 