### PR TITLE
Add support for passing in headers to outgoing calls

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -65,11 +65,16 @@ export default class APIClient {
    * The timeout for requests to the Nylas API, in seconds
    */
   timeout: number;
+  /**
+   * Additional headers to send with outgoing requests
+   */
+  headers: Record<string, string>;
 
-  constructor({ apiKey, apiUri, timeout }: Required<NylasConfig>) {
+  constructor({ apiKey, apiUri, timeout, headers }: Required<NylasConfig>) {
     this.apiKey = apiKey;
     this.serverUrl = apiUri;
     this.timeout = timeout * 1000; // fetch timeout uses milliseconds
+    this.headers = headers;
   }
 
   private setRequestUrl({
@@ -114,6 +119,7 @@ export default class APIClient {
   }: RequestOptionsParams): Record<string, string> {
     const mergedHeaders: Record<string, string> = {
       ...headers,
+      ...this.headers,
       ...overrides?.headers,
     };
 

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -112,11 +112,16 @@ export default class APIClient {
     headers,
     overrides,
   }: RequestOptionsParams): Record<string, string> {
+    const mergedHeaders: Record<string, string> = {
+      ...headers,
+      ...overrides?.headers,
+    };
+
     return {
       Accept: 'application/json',
       'User-Agent': `Nylas Node SDK v${SDK_VERSION}`,
       Authorization: `Bearer ${overrides?.apiKey || this.apiKey}`,
-      ...headers,
+      ...mergedHeaders,
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,9 +11,11 @@ export type NylasConfig = {
 };
 
 /**
- * The options that can override the default Nylas API client configuration.
+ * The options that can override defaults for outgoing calls, including the Nylas configuration and headers.
  */
-export type OverridableNylasConfig = Partial<NylasConfig>;
+export type OverridableNylasConfig = Partial<NylasConfig> & {
+  headers?: Record<string, string>;
+};
 
 /**
  * An object that can be used to override the default Nylas API client configuration on a per-request basis.

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,19 +3,19 @@
  * @property apiKey The Nylas API key to use for authentication
  * @property apiUri The URL to use for communicating with the Nylas API
  * @property timeout The timeout for requests to the Nylas API, in seconds
+ * @property headers Additional headers to send with outgoing requests
  */
 export type NylasConfig = {
   apiKey: string;
   apiUri?: string;
   timeout?: number;
+  headers?: Record<string, string>;
 };
 
 /**
- * The options that can override defaults for outgoing calls, including the Nylas configuration and headers.
+ * The options that can override the default Nylas API client configuration.
  */
-export type OverridableNylasConfig = Partial<NylasConfig> & {
-  headers?: Record<string, string>;
-};
+export type OverridableNylasConfig = Partial<NylasConfig>;
 
 /**
  * An object that can be used to override the default Nylas API client configuration on a per-request basis.

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -354,10 +354,10 @@ type When = Time | Timespan | Date | Datespan;
  * Type representing the different objects representing time and duration when creating events.
  */
 type CreateWhen =
-  | Omit<Time, 'type'>
-  | Omit<Timespan, 'type'>
-  | Omit<Date, 'type'>
-  | Omit<Datespan, 'type'>;
+  | Omit<Time, 'object'>
+  | Omit<Timespan, 'object'>
+  | Omit<Date, 'object'>
+  | Omit<Datespan, 'object'>;
 
 /**
  * Enum representing the different types of when objects.

--- a/src/nylas.ts
+++ b/src/nylas.ts
@@ -90,6 +90,7 @@ export default class Nylas {
       apiKey: config.apiKey,
       apiUri: config.apiUri || DEFAULT_SERVER_URL,
       timeout: config.timeout || 90,
+      headers: config.headers || {},
     });
 
     this.applications = new Applications(this.apiClient);

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -104,13 +104,20 @@ describe('APIClient', () => {
 
     describe('newRequest', () => {
       it('should set all the fields properly', () => {
+        client.headers = {
+          'global-header': 'global-value',
+        };
+
         const options: RequestOptionsParams = {
           path: '/test',
           method: 'POST',
           headers: { 'X-SDK-Test-Header': 'This is a test' },
           queryParams: { param: 'value' },
           body: { id: 'abc123' },
-          overrides: { apiUri: 'https://override.api.nylas.com' },
+          overrides: {
+            apiUri: 'https://override.api.nylas.com',
+            headers: { override: 'bar' },
+          },
         };
         const newRequest = client.newRequest(options);
 
@@ -121,6 +128,8 @@ describe('APIClient', () => {
           'Content-Type': ['application/json'],
           'User-Agent': [`Nylas Node SDK v${SDK_VERSION}`],
           'X-SDK-Test-Header': ['This is a test'],
+          'global-header': ['global-value'],
+          override: ['bar'],
         });
         expect(newRequest.url).toEqual(
           'https://override.api.nylas.com/test?param=value'

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -18,11 +18,17 @@ describe('APIClient', () => {
         apiKey: 'test',
         apiUri: 'https://test.api.nylas.com',
         timeout: 30,
+        headers: {
+          'X-SDK-Test-Header': 'This is a test',
+        },
       });
 
       expect(client.apiKey).toBe('test');
       expect(client.serverUrl).toBe('https://test.api.nylas.com');
       expect(client.timeout).toBe(30000);
+      expect(client.headers).toEqual({
+        'X-SDK-Test-Header': 'This is a test',
+      });
     });
   });
 
@@ -34,6 +40,7 @@ describe('APIClient', () => {
         apiKey: 'testApiKey',
         apiUri: 'https://api.us.nylas.com',
         timeout: 30,
+        headers: {},
       });
     });
 

--- a/tests/resources/applications.spec.ts
+++ b/tests/resources/applications.spec.ts
@@ -11,6 +11,7 @@ describe('Applications', () => {
       apiKey: 'apiKey',
       apiUri: 'https://api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     applications = new Applications(apiClient);

--- a/tests/resources/applications.spec.ts
+++ b/tests/resources/applications.spec.ts
@@ -23,6 +23,7 @@ describe('Applications', () => {
       await applications.getDetails({
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -31,6 +32,7 @@ describe('Applications', () => {
         path: '/v3/applications',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/attachments.spec.ts
+++ b/tests/resources/attachments.spec.ts
@@ -33,6 +33,7 @@ describe('Attachments', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -44,6 +45,7 @@ describe('Attachments', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -59,6 +61,7 @@ describe('Attachments', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -70,6 +73,7 @@ describe('Attachments', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -85,6 +89,7 @@ describe('Attachments', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -96,6 +101,7 @@ describe('Attachments', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/attachments.spec.ts
+++ b/tests/resources/attachments.spec.ts
@@ -12,6 +12,7 @@ describe('Attachments', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     attachments = new Attachments(apiClient);

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -150,6 +150,7 @@ describe('Auth', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -166,6 +167,7 @@ describe('Auth', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -15,6 +15,7 @@ describe('Auth', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     });
 
     auth = new Auth(apiClient);

--- a/tests/resources/calendars.spec.ts
+++ b/tests/resources/calendars.spec.ts
@@ -25,6 +25,7 @@ describe('Calendars', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -33,6 +34,7 @@ describe('Calendars', () => {
         path: '/v3/grants/id123/calendars',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -45,6 +47,7 @@ describe('Calendars', () => {
         calendarId: 'calendar123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -53,6 +56,7 @@ describe('Calendars', () => {
         path: '/v3/grants/id123/calendars/calendar123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -68,6 +72,7 @@ describe('Calendars', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -80,6 +85,7 @@ describe('Calendars', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -95,6 +101,7 @@ describe('Calendars', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -106,6 +113,7 @@ describe('Calendars', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -118,6 +126,7 @@ describe('Calendars', () => {
         calendarId: 'calendar123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -126,6 +135,7 @@ describe('Calendars', () => {
         path: '/v3/grants/id123/calendars/calendar123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -161,6 +171,7 @@ describe('Calendars', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -194,6 +205,7 @@ describe('Calendars', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/calendars.spec.ts
+++ b/tests/resources/calendars.spec.ts
@@ -12,6 +12,7 @@ describe('Calendars', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     calendars = new Calendars(apiClient);

--- a/tests/resources/contacts.spec.ts
+++ b/tests/resources/contacts.spec.ts
@@ -11,6 +11,7 @@ describe('Contacts', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     contacts = new Contacts(apiClient);

--- a/tests/resources/contacts.spec.ts
+++ b/tests/resources/contacts.spec.ts
@@ -27,6 +27,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -38,6 +39,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -60,6 +62,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
       apiClient.request.mockResolvedValueOnce({
@@ -83,6 +86,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -104,6 +108,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
       apiClient.request.mockResolvedValueOnce({
@@ -133,6 +138,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -144,6 +150,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -167,6 +174,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -187,6 +195,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -202,6 +211,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -213,6 +223,7 @@ describe('Contacts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -225,6 +236,7 @@ describe('Contacts', () => {
         contactId: 'contact123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -233,6 +245,7 @@ describe('Contacts', () => {
         path: '/v3/grants/id123/contacts/contact123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -244,6 +257,7 @@ describe('Contacts', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -252,6 +266,7 @@ describe('Contacts', () => {
         path: '/v3/grants/id123/contacts/groups',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/drafts.spec.ts
+++ b/tests/resources/drafts.spec.ts
@@ -26,6 +26,7 @@ describe('Drafts', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     drafts = new Drafts(apiClient);

--- a/tests/resources/drafts.spec.ts
+++ b/tests/resources/drafts.spec.ts
@@ -39,6 +39,7 @@ describe('Drafts', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -47,6 +48,7 @@ describe('Drafts', () => {
         path: '/v3/grants/id123/drafts',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -59,6 +61,7 @@ describe('Drafts', () => {
         draftId: 'draft123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -67,6 +70,7 @@ describe('Drafts', () => {
         path: '/v3/grants/id123/drafts/draft123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -83,6 +87,7 @@ describe('Drafts', () => {
         requestBody: jsonBody,
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -92,6 +97,7 @@ describe('Drafts', () => {
       expect(capturedRequest.body).toEqual(jsonBody);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
 
@@ -114,6 +120,7 @@ describe('Drafts', () => {
         requestBody: jsonBody,
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -123,6 +130,7 @@ describe('Drafts', () => {
       expect(capturedRequest.body).toEqual(jsonBody);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
 
@@ -147,6 +155,7 @@ describe('Drafts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -158,6 +167,7 @@ describe('Drafts', () => {
       expect(capturedRequest.path).toEqual('/v3/grants/id123/drafts');
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
   });
@@ -182,6 +192,7 @@ describe('Drafts', () => {
         requestBody: jsonBody,
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -191,6 +202,7 @@ describe('Drafts', () => {
       expect(capturedRequest.body).toEqual(jsonBody);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
 
@@ -216,6 +228,7 @@ describe('Drafts', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -227,6 +240,7 @@ describe('Drafts', () => {
       expect(capturedRequest.path).toEqual('/v3/grants/id123/drafts/draft123');
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
   });
@@ -238,6 +252,7 @@ describe('Drafts', () => {
         draftId: 'draft123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -246,6 +261,7 @@ describe('Drafts', () => {
         path: '/v3/grants/id123/drafts/draft123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -258,6 +274,7 @@ describe('Drafts', () => {
         draftId: 'draft123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -267,6 +284,7 @@ describe('Drafts', () => {
         body: {},
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/events.spec.ts
+++ b/tests/resources/events.spec.ts
@@ -11,6 +11,7 @@ describe('Events', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     events = new Events(apiClient);

--- a/tests/resources/events.spec.ts
+++ b/tests/resources/events.spec.ts
@@ -27,6 +27,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -38,6 +39,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -60,6 +62,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
       apiClient.request.mockResolvedValueOnce({
@@ -83,6 +86,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -104,6 +108,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
       apiClient.request.mockResolvedValueOnce({
@@ -133,6 +138,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -144,6 +150,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -164,6 +171,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -181,6 +189,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -202,6 +211,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -219,6 +229,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -234,6 +245,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -245,6 +257,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -263,6 +276,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -277,6 +291,7 @@ describe('Events', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/folders.spec.ts
+++ b/tests/resources/folders.spec.ts
@@ -12,6 +12,7 @@ describe('Folders', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     folders = new Folders(apiClient);

--- a/tests/resources/folders.spec.ts
+++ b/tests/resources/folders.spec.ts
@@ -60,6 +60,7 @@ describe('Folders', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -68,6 +69,7 @@ describe('Folders', () => {
         path: '/v3/grants/id123/folders',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -80,6 +82,7 @@ describe('Folders', () => {
         folderId: 'folder123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -88,6 +91,7 @@ describe('Folders', () => {
         path: '/v3/grants/id123/folders/folder123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -102,6 +106,7 @@ describe('Folders', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -113,6 +118,7 @@ describe('Folders', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -128,6 +134,7 @@ describe('Folders', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -139,6 +146,7 @@ describe('Folders', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -151,6 +159,7 @@ describe('Folders', () => {
         folderId: 'folder123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -159,6 +168,7 @@ describe('Folders', () => {
         path: '/v3/grants/id123/folders/folder123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/grants.spec.ts
+++ b/tests/resources/grants.spec.ts
@@ -11,6 +11,7 @@ describe('Grants', () => {
       apiKey: 'apiKey',
       apiUri: 'https://api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     grants = new Grants(apiClient);

--- a/tests/resources/grants.spec.ts
+++ b/tests/resources/grants.spec.ts
@@ -23,6 +23,7 @@ describe('Grants', () => {
       await grants.list({
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -31,6 +32,7 @@ describe('Grants', () => {
         path: '/v3/grants',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -51,6 +53,7 @@ describe('Grants', () => {
         grantId: 'grant123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -59,6 +62,7 @@ describe('Grants', () => {
         path: '/v3/grants/grant123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -76,6 +80,7 @@ describe('Grants', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -90,6 +95,7 @@ describe('Grants', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -101,6 +107,7 @@ describe('Grants', () => {
         grantId: 'grant123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -109,6 +116,7 @@ describe('Grants', () => {
         path: '/v3/grants/grant123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -26,6 +26,7 @@ describe('Messages', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     messages = new Messages(apiClient);

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -39,6 +39,7 @@ describe('Messages', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -47,6 +48,7 @@ describe('Messages', () => {
         path: '/v3/grants/id123/messages',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -59,6 +61,7 @@ describe('Messages', () => {
         messageId: 'message123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -67,6 +70,7 @@ describe('Messages', () => {
         path: '/v3/grants/id123/messages/message123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -84,6 +88,7 @@ describe('Messages', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -97,6 +102,7 @@ describe('Messages', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -109,6 +115,7 @@ describe('Messages', () => {
         messageId: 'message123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -117,6 +124,7 @@ describe('Messages', () => {
         path: '/v3/grants/id123/messages/message123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -133,6 +141,7 @@ describe('Messages', () => {
         requestBody: jsonBody,
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -142,6 +151,7 @@ describe('Messages', () => {
       expect(capturedRequest.body).toEqual(jsonBody);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
 
@@ -164,6 +174,7 @@ describe('Messages', () => {
         requestBody: jsonBody,
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -173,6 +184,7 @@ describe('Messages', () => {
       expect(capturedRequest.body).toEqual(jsonBody);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
 
@@ -197,6 +209,7 @@ describe('Messages', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -208,6 +221,7 @@ describe('Messages', () => {
       expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
+        headers: { override: 'bar' },
       });
     });
   });
@@ -218,6 +232,7 @@ describe('Messages', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -226,6 +241,7 @@ describe('Messages', () => {
         path: '/v3/grants/id123/messages/schedules',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -236,6 +252,7 @@ describe('Messages', () => {
         scheduleId: 'schedule123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -244,6 +261,7 @@ describe('Messages', () => {
         path: '/v3/grants/id123/messages/schedules/schedule123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -254,6 +272,7 @@ describe('Messages', () => {
         scheduleId: 'schedule123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -262,6 +281,7 @@ describe('Messages', () => {
         path: '/v3/grants/id123/messages/schedules/schedule123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/redirectUris.spec.ts
+++ b/tests/resources/redirectUris.spec.ts
@@ -11,6 +11,7 @@ describe('RedirectUris', () => {
       apiKey: 'apiKey',
       apiUri: 'https://api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     redirectUris = new RedirectUris(apiClient);

--- a/tests/resources/redirectUris.spec.ts
+++ b/tests/resources/redirectUris.spec.ts
@@ -23,6 +23,7 @@ describe('RedirectUris', () => {
       await redirectUris.list({
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -31,6 +32,7 @@ describe('RedirectUris', () => {
         path: '/v3/applications/redirect-uris',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -51,6 +53,7 @@ describe('RedirectUris', () => {
         redirectUriId: 'redirect123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -59,6 +62,7 @@ describe('RedirectUris', () => {
         path: '/v3/applications/redirect-uris/redirect123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -81,6 +85,7 @@ describe('RedirectUris', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -101,6 +106,7 @@ describe('RedirectUris', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -124,6 +130,7 @@ describe('RedirectUris', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -144,6 +151,7 @@ describe('RedirectUris', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -155,6 +163,7 @@ describe('RedirectUris', () => {
         redirectUriId: 'redirect123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -163,6 +172,7 @@ describe('RedirectUris', () => {
         path: '/v3/applications/redirect-uris/redirect123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/smartCompose.spec.ts
+++ b/tests/resources/smartCompose.spec.ts
@@ -11,6 +11,7 @@ describe('SmartCompose', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     smartCompose = new SmartCompose(apiClient);

--- a/tests/resources/smartCompose.spec.ts
+++ b/tests/resources/smartCompose.spec.ts
@@ -27,6 +27,7 @@ describe('SmartCompose', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -38,6 +39,7 @@ describe('SmartCompose', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -53,6 +55,7 @@ describe('SmartCompose', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -64,6 +67,7 @@ describe('SmartCompose', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/threads.spec.ts
+++ b/tests/resources/threads.spec.ts
@@ -11,6 +11,7 @@ describe('Threads', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     threads = new Threads(apiClient);

--- a/tests/resources/threads.spec.ts
+++ b/tests/resources/threads.spec.ts
@@ -24,6 +24,7 @@ describe('Threads', () => {
         identifier: 'id123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -32,6 +33,7 @@ describe('Threads', () => {
         path: '/v3/grants/id123/threads',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -44,6 +46,7 @@ describe('Threads', () => {
         threadId: 'thread123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -52,6 +55,7 @@ describe('Threads', () => {
         path: '/v3/grants/id123/threads/thread123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -69,6 +73,7 @@ describe('Threads', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -82,6 +87,7 @@ describe('Threads', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -94,6 +100,7 @@ describe('Threads', () => {
         threadId: 'thread123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -102,6 +109,7 @@ describe('Threads', () => {
         path: '/v3/grants/id123/threads/thread123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -34,6 +34,7 @@ describe('Webhooks', () => {
       await webhooks.list({
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -42,6 +43,7 @@ describe('Webhooks', () => {
         path: '/v3/webhooks',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -53,6 +55,7 @@ describe('Webhooks', () => {
         webhookId: 'webhook123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -61,6 +64,7 @@ describe('Webhooks', () => {
         path: '/v3/webhooks/webhook123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -77,6 +81,7 @@ describe('Webhooks', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -91,6 +96,7 @@ describe('Webhooks', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -105,6 +111,7 @@ describe('Webhooks', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -116,6 +123,7 @@ describe('Webhooks', () => {
         },
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -127,6 +135,7 @@ describe('Webhooks', () => {
         webhookId: 'webhook123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -135,6 +144,7 @@ describe('Webhooks', () => {
         path: '/v3/webhooks/webhook123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -146,6 +156,7 @@ describe('Webhooks', () => {
         webhookId: 'webhook123',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -155,6 +166,7 @@ describe('Webhooks', () => {
         body: {},
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });
@@ -175,6 +187,7 @@ describe('Webhooks', () => {
       await webhooks.ipAddresses({
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
 
@@ -184,6 +197,7 @@ describe('Webhooks', () => {
         body: undefined,
         overrides: {
           apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
         },
       });
     });

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -13,6 +13,7 @@ describe('Webhooks', () => {
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
       timeout: 30,
+      headers: {},
     }) as jest.Mocked<APIClient>;
 
     webhooks = new Webhooks(apiClient);


### PR DESCRIPTION
# Description
This PR allows you to pass in a map of additional, custom headers that can be sent to the Node SDK.

# Usage
This can be used one of two ways, for all outgoing calls or on a per-call-basis.

### All Calls
For all outgoing calls, you can set headers when initializing the Nylas SDK:
```js
const nylas = new Nylas({
  apiKey: "NYLAS_API_KEY",
  headers: {
    foo: "bar"
  },
});

messages = await nylas.messages.list({
  "identifier",
}); // Will be sent with 'foo: bar' header

calendars = await nylas.calendars.list({
  "identifier",
}); // Will be sent with 'foo: bar' header
```

### Per-call basis
For all calls to the API, we have an `override` object. This object is now extended to include a `headers` field.
```js
const nylas = new Nylas({
  apiKey: "NYLAS_API_KEY",
});

messages = await nylas.messages.list({
  "identifier",
  overrides: {
    headers: {
      foo: "bar"
    }
  }
}); // Will be sent with 'foo: bar' header

calendars = await nylas.calendars.list({
  "identifier",
}); // Will not be sent with 'foo: bar' header
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.