### PR TITLE
Add support for include_grant_scopes=false on auth url generation

### DIFF
--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -199,7 +199,7 @@ export class Auth extends Resource {
     if (config.loginHint) {
       url.searchParams.set('login_hint', config.loginHint);
     }
-    if (config.includeGrantScopes!==undefined) {
+    if (config.includeGrantScopes !== undefined) {
       url.searchParams.set(
         'include_grant_scopes',
         config.includeGrantScopes.toString()

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -198,7 +198,7 @@ export class Auth extends Resource {
     }
     if (config.loginHint) {
       url.searchParams.set('login_hint', config.loginHint);
-      if (config.includeGrantScopes) {
+      if (config.includeGrantScopes!==undefined) {
         url.searchParams.set(
           'include_grant_scopes',
           config.includeGrantScopes.toString()

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -198,12 +198,12 @@ export class Auth extends Resource {
     }
     if (config.loginHint) {
       url.searchParams.set('login_hint', config.loginHint);
-      if (config.includeGrantScopes!==undefined) {
-        url.searchParams.set(
-          'include_grant_scopes',
-          config.includeGrantScopes.toString()
-        );
-      }
+    }
+    if (config.includeGrantScopes!==undefined) {
+      url.searchParams.set(
+        'include_grant_scopes',
+        config.includeGrantScopes.toString()
+      );
     }
     if (config.scope) {
       url.searchParams.set('scope', config.scope.join(' '));

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -184,7 +184,7 @@ describe('Auth', () => {
         });
 
         expect(url).toBe(
-          'https://test.api.nylas.com/v3/connect/auth?client_id=clientId&redirect_uri=https%3A%2F%2Fredirect.uri%2Fpath&access_type=online&response_type=code&provider=google&scope=calendar'
+          'https://test.api.nylas.com/v3/connect/auth?client_id=clientId&redirect_uri=https%3A%2F%2Fredirect.uri%2Fpath&access_type=online&response_type=code&provider=google&include_grant_scopes=true&scope=calendar'
         );
       });
 
@@ -222,7 +222,7 @@ describe('Auth', () => {
         expect(pkce).toEqual({
           secret: 'nylas',
           secretHash: codeChallenge,
-          url: `https://test.api.nylas.com/v3/connect/auth?client_id=clientId&redirect_uri=https%3A%2F%2Fredirect.uri%2Fpath&access_type=online&response_type=code&provider=google&scope=calendar&code_challenge_method=s256&code_challenge=${codeChallenge}`,
+          url: `https://test.api.nylas.com/v3/connect/auth?client_id=clientId&redirect_uri=https%3A%2F%2Fredirect.uri%2Fpath&access_type=online&response_type=code&provider=google&include_grant_scopes=true&scope=calendar&code_challenge_method=s256&code_challenge=${codeChallenge}`,
         });
       });
     });


### PR DESCRIPTION
Add support for include_grant_scopes=false on auth url generation. Currently include grant scopes is true by default and is not set to false if the user sets the variable as false - This fix should enable the user to do so

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.