### PR TITLE
Add return type for send RSVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ### Unreleased
+* Add response type to `sendRsvp`
 * Add support for adding custom headers to outgoing requests
 * Add support for custom headers field for drafts and messages
 * Rename incorrect `type` field in `When` models to `object`
+* Fix inaccuracy in `ReminderOverride` model
 
 ### 7.2.1 / 2024-03-05
 * Improved message sending and draft create/update performance

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,8 @@ const config = {
     },
   },
   clearMocks: true,
+  collectCoverage: true,
+  overageReporters: ['text', 'cobertura'],
 };
 
 module.exports = config;

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -1,5 +1,7 @@
 import { ListQueryParams } from './listQueryParams.js';
 import { Subset } from '../utils.js';
+import { NylasBaseResponse } from './response.js';
+import { NylasApiErrorResponseData } from './error.js';
 
 /**
  * Interface representing a Nylas Event object.
@@ -196,6 +198,14 @@ export type UpdateEventRequest = Subset<CreateEventRequest>;
 export type SendRsvpRequest = {
   status: RsvpStatus;
 };
+
+/**
+ * Interface representing the response from sending RSVP to an event.
+ * @property sendIcsError If the send-rsvp request succeeded but the ICS email could not be sent, this will contain the error.
+ */
+export interface SendRsvpResponse extends NylasBaseResponse {
+  sendIcsError?: NylasApiErrorResponseData;
+}
 
 /**
  * Interface representing the query parameters for listing events.

--- a/src/resources/events.ts
+++ b/src/resources/events.ts
@@ -8,6 +8,7 @@ import {
   ListEventQueryParams,
   SendRsvpQueryParams,
   SendRsvpRequest,
+  SendRsvpResponse,
   UpdateEventQueryParams,
   UpdateEventRequest,
 } from '../models/events.js';
@@ -191,7 +192,7 @@ export class Events extends Resource {
     requestBody,
     queryParams,
     overrides,
-  }: SendRsvpParams & Overrides): Promise<NylasBaseResponse> {
+  }: SendRsvpParams & Overrides): Promise<SendRsvpResponse> {
     return super._create({
       path: `/v3/grants/${identifier}/events/${eventId}/send-rsvp`,
       queryParams,


### PR DESCRIPTION
# Description
Send RSVP used to just return a `request_id` in the response, now it can return an error object in the event of a partial success where the send RSVP request is executed but the email was not sent.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.