### PR TITLE
Fixed issue where attachments < 3mb were not being encoded correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fixed issue where attachments < 3mb were not being encoded correctly
+
 ### 7.3.0 / 2024-04-15
 * Add response type to `sendRsvp`
 * Add support for adding custom headers to outgoing requests

--- a/src/models/attachments.ts
+++ b/src/models/attachments.ts
@@ -39,8 +39,9 @@ interface BaseAttachment {
 export interface CreateAttachmentRequest extends BaseAttachment {
   /**
    * Content of the attachment.
+   * It can either be a readable stream or a base64 encoded string.
    */
-  content: NodeJS.ReadableStream;
+  content: NodeJS.ReadableStream | string;
 }
 
 /**

--- a/src/resources/drafts.ts
+++ b/src/resources/drafts.ts
@@ -119,8 +119,8 @@ export class Drafts extends Resource {
 
     // Use form data only if the attachment size is greater than 3mb
     const attachmentSize =
-      requestBody.attachments?.reduce(function(_, attachment) {
-        return attachment.size || 0;
+      requestBody.attachments?.reduce((total, attachment) => {
+        return total + (attachment.size || 0);
       }, 0) || 0;
 
     if (attachmentSize >= Messages.MAXIMUM_JSON_ATTACHMENT_SIZE) {
@@ -164,8 +164,8 @@ export class Drafts extends Resource {
 
     // Use form data only if the attachment size is greater than 3mb
     const attachmentSize =
-      requestBody.attachments?.reduce(function(_, attachment) {
-        return attachment.size || 0;
+      requestBody.attachments?.reduce((total, attachment) => {
+        return total + (attachment.size || 0);
       }, 0) || 0;
 
     if (attachmentSize >= Messages.MAXIMUM_JSON_ATTACHMENT_SIZE) {

--- a/src/resources/drafts.ts
+++ b/src/resources/drafts.ts
@@ -13,6 +13,7 @@ import {
   NylasListResponse,
   NylasResponse,
 } from '../models/response.js';
+import { encodeAttachmentStreams } from '../utils.js';
 
 /**
  * The parameters for the {@link Drafts.list} method
@@ -109,7 +110,7 @@ export class Drafts extends Resource {
    * Return a Draft
    * @return The draft
    */
-  public create({
+  public async create({
     identifier,
     requestBody,
     overrides,
@@ -131,6 +132,15 @@ export class Drafts extends Resource {
         form,
         overrides,
       });
+    } else if (requestBody.attachments) {
+      const processedAttachments = await encodeAttachmentStreams(
+        requestBody.attachments
+      );
+
+      requestBody = {
+        ...requestBody,
+        attachments: processedAttachments,
+      };
     }
 
     return super._create({
@@ -144,7 +154,7 @@ export class Drafts extends Resource {
    * Update a Draft
    * @return The updated draft
    */
-  public update({
+  public async update({
     identifier,
     draftId,
     requestBody,
@@ -167,6 +177,15 @@ export class Drafts extends Resource {
         form,
         overrides,
       });
+    } else if (requestBody.attachments) {
+      const processedAttachments = await encodeAttachmentStreams(
+        requestBody.attachments
+      );
+
+      requestBody = {
+        ...requestBody,
+        attachments: processedAttachments,
+      };
     }
 
     return super._update({

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -203,8 +203,8 @@ export class Messages extends Resource {
 
     // Use form data only if the attachment size is greater than 3mb
     const attachmentSize =
-      requestBody.attachments?.reduce(function(_, attachment) {
-        return attachment.size || 0;
+      requestBody.attachments?.reduce((total, attachment) => {
+        return total + (attachment.size || 0);
       }, 0) || 0;
 
     if (attachmentSize >= Messages.MAXIMUM_JSON_ATTACHMENT_SIZE) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import { camelCase, snakeCase } from 'change-case';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as mime from 'mime-types';
+import { Readable } from 'stream';
 import { CreateAttachmentRequest } from './models/attachments.js';
 
 export function createFileRequestBuilder(
@@ -48,10 +49,13 @@ function streamToBase64(stream: NodeJS.ReadableStream): Promise<string> {
  */
 export async function encodeAttachmentStreams(
   attachments: CreateAttachmentRequest[]
-): Promise<unknown[]> {
+): Promise<CreateAttachmentRequest[]> {
   return await Promise.all(
     attachments.map(async attachment => {
-      const base64EncodedContent = await streamToBase64(attachment.content);
+      const base64EncodedContent =
+        attachment.content instanceof Readable
+          ? await streamToBase64(attachment.content)
+          : attachment.content;
       return { ...attachment, content: base64EncodedContent }; // Replace the stream with its base64 string
     })
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,43 @@ export function createFileRequestBuilder(
 }
 
 /**
+ * Converts a ReadableStream to a base64 encoded string.
+ * @param stream The ReadableStream containing the binary data.
+ * @returns The stream base64 encoded to a string.
+ */
+function streamToBase64(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    stream.on('end', () => {
+      const base64 = Buffer.concat(chunks).toString('base64');
+      resolve(base64);
+    });
+    stream.on('error', err => {
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Encodes the content of each attachment stream to base64.
+ * @param attachments The attachments to encode.
+ * @returns The attachments with their content encoded to base64.
+ */
+export async function encodeAttachmentStreams(
+  attachments: CreateAttachmentRequest[]
+): Promise<unknown[]> {
+  return await Promise.all(
+    attachments.map(async attachment => {
+      const base64EncodedContent = await streamToBase64(attachment.content);
+      return { ...attachment, content: base64EncodedContent }; // Replace the stream with its base64 string
+    })
+  );
+}
+
+/**
  * The type of function that converts a string to a different casing.
  * @ignore Not for public use.
  */

--- a/tests/resources/drafts.spec.ts
+++ b/tests/resources/drafts.spec.ts
@@ -197,15 +197,28 @@ describe('Drafts', () => {
     });
 
     it('should attach files less than 3mb', async () => {
-      const fileStream = createReadableStream('This is the text from file 1');
-      const jsonBody = {
+      const baseJson = {
         to: [{ name: 'Test', email: 'test@example.com' }],
         subject: 'This is my test email',
+      };
+      const jsonBody = {
+        ...baseJson,
         attachments: [
           {
             filename: 'file1.txt',
             contentType: 'text/plain',
-            content: fileStream,
+            content: createReadableStream('This is the text from file 1'),
+            size: 100,
+          },
+        ],
+      };
+      const expectedJson = {
+        ...baseJson,
+        attachments: [
+          {
+            filename: 'file1.txt',
+            contentType: 'text/plain',
+            content: 'VGhpcyBpcyB0aGUgdGV4dCBmcm9tIGZpbGUgMQ==',
             size: 100,
           },
         ],
@@ -222,7 +235,7 @@ describe('Drafts', () => {
       const capturedRequest = apiClient.request.mock.calls[0][0];
       expect(capturedRequest.method).toEqual('POST');
       expect(capturedRequest.path).toEqual('/v3/grants/id123/drafts');
-      expect(capturedRequest.body).toEqual(jsonBody);
+      expect(capturedRequest.body).toEqual(expectedJson);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
         headers: { override: 'bar' },

--- a/tests/resources/drafts.spec.ts
+++ b/tests/resources/drafts.spec.ts
@@ -282,14 +282,27 @@ describe('Drafts', () => {
 
   describe('update', () => {
     it('should call apiClient.request with the correct params', async () => {
-      const fileStream = createReadableStream('This is the text from file 1');
-      const jsonBody = {
+      const baseJson = {
         subject: 'updated subject',
+      };
+      const jsonBody = {
+        ...baseJson,
         attachments: [
           {
             filename: 'file1.txt',
             contentType: 'text/plain',
-            content: fileStream,
+            content: createReadableStream('This is the text from file 1'),
+            size: 100,
+          },
+        ],
+      };
+      const expectedJson = {
+        ...baseJson,
+        attachments: [
+          {
+            filename: 'file1.txt',
+            contentType: 'text/plain',
+            content: 'VGhpcyBpcyB0aGUgdGV4dCBmcm9tIGZpbGUgMQ==',
             size: 100,
           },
         ],
@@ -307,7 +320,7 @@ describe('Drafts', () => {
       const capturedRequest = apiClient.request.mock.calls[0][0];
       expect(capturedRequest.method).toEqual('PUT');
       expect(capturedRequest.path).toEqual('/v3/grants/id123/drafts/draft123');
-      expect(capturedRequest.body).toEqual(jsonBody);
+      expect(capturedRequest.body).toEqual(expectedJson);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
         headers: { override: 'bar' },

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -156,15 +156,28 @@ describe('Messages', () => {
     });
 
     it('should attach files less than 3mb', async () => {
-      const fileStream = createReadableStream('This is the text from file 1');
-      const jsonBody = {
+      const baseJson = {
         to: [{ name: 'Test', email: 'test@example.com' }],
         subject: 'This is my test email',
+      };
+      const jsonBody = {
+        ...baseJson,
         attachments: [
           {
             filename: 'file1.txt',
             contentType: 'text/plain',
-            content: fileStream,
+            content: createReadableStream('This is the text from file 1'),
+            size: 100,
+          },
+        ],
+      };
+      const expectedJson = {
+        ...baseJson,
+        attachments: [
+          {
+            filename: 'file1.txt',
+            contentType: 'text/plain',
+            content: 'VGhpcyBpcyB0aGUgdGV4dCBmcm9tIGZpbGUgMQ==',
             size: 100,
           },
         ],
@@ -181,7 +194,7 @@ describe('Messages', () => {
       const capturedRequest = apiClient.request.mock.calls[0][0];
       expect(capturedRequest.method).toEqual('POST');
       expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
-      expect(capturedRequest.body).toEqual(jsonBody);
+      expect(capturedRequest.body).toEqual(expectedJson);
       expect(capturedRequest.overrides).toEqual({
         apiUri: 'https://test.api.nylas.com',
         headers: { override: 'bar' },


### PR DESCRIPTION
# Description
This PR fixes an issue where we were not encoding attachments less than 3mb properly. Furthermore, for `CreateAttachmentRequest` you may now provide your own base64 encoded string if you prefer to not have the SDK encode it.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.