### PR TITLE
Add provider field to token exchange response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added support for `provider` field in code exchange response
+
 ### 7.3.0 / 2024-04-15
 * Add response type to `sendRsvp`
 * Add support for adding custom headers to outgoing requests

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -170,6 +170,10 @@ export interface CodeExchangeResponse {
    * Currently always Bearer.
    */
   tokenType?: string;
+  /**
+   * The provider that the code was exchanged with.
+   */
+  provider?: Provider;
 }
 
 /**


### PR DESCRIPTION
# Description
This PR adds the `provider` field to the `CodeExchangeResponse` model.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.