### PR TITLE
Add clean messages support

### DIFF
--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -284,3 +284,43 @@ export interface FindMessageQueryParams {
    */
   fields?: MessageFields;
 }
+
+/**
+ * Interface representing the request to clean a message.
+ */
+export interface CleanMessagesRequest {
+  /**
+   * IDs of the email messages to clean.
+   */
+  messageId: string[];
+  /**
+   * If true, removes link-related tags (<a>) from the email message while keeping the text.
+   */
+  ignoreLinks?: boolean;
+  /**
+   * If true, removes images from the email message.
+   */
+  ignoreImages?: boolean;
+  /**
+   * If true, converts images in the email message to Markdown.
+   */
+  imagesAsMarkdown?: boolean;
+  /**
+   * If true, removes table-related tags (<table>, <th>, <td>, <tr>) from the email message while keeping rows.
+   */
+  ignoreTables?: boolean;
+  /**
+   * If true, removes phrases such as "Best" and "Regards" in the email message signature.
+   */
+  removeConclusionPhrases?: boolean;
+}
+
+/**
+ * Interface representing the response after cleaning a message.
+ */
+export interface CleanMessagesResponse extends Message {
+  /**
+   * The cleaned HTML message body.
+   */
+  conversation: string;
+}

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -1,5 +1,7 @@
 import { AsyncListResponse, Resource } from './resource.js';
 import {
+  CleanMessagesRequest,
+  CleanMessagesResponse,
   FindMessageQueryParams,
   ListMessagesQueryParams,
   Message,
@@ -102,6 +104,16 @@ export interface FindScheduledMessageParams {
  * @property scheduleId The id of the scheduled message to destroy.
  */
 export type StopScheduledMessageParams = FindScheduledMessageParams;
+
+/**
+ * The parameters for the {@link Messages.cleanMessages} method
+ * @property identifier The identifier of the grant to act upon
+ * @property requestBody The values to clean the message with
+ */
+export interface CleanMessagesParams {
+  identifier: string;
+  requestBody: CleanMessagesRequest;
+}
 
 /**
  * Nylas Messages API
@@ -262,6 +274,25 @@ export class Messages extends Resource {
   > {
     return super._destroy({
       path: `/v3/grants/${identifier}/messages/schedules/${scheduleId}`,
+      overrides,
+    });
+  }
+
+  /**
+   * Remove extra information from a list of messages
+   * @return The list of cleaned messages
+   */
+  public cleanMessages({
+    identifier,
+    requestBody,
+    overrides,
+  }: CleanMessagesParams & Overrides): Promise<
+    NylasListResponse<CleanMessagesResponse>
+  > {
+    return this.apiClient.request<NylasListResponse<CleanMessagesResponse>>({
+      method: 'PUT',
+      path: `/v3/grants/${identifier}/messages/clean`,
+      body: requestBody,
       overrides,
     });
   }

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -286,4 +286,41 @@ describe('Messages', () => {
       });
     });
   });
+
+  describe('cleanMessages', () => {
+    it('should call apiClient.request with the correct params', async () => {
+      await messages.cleanMessages({
+        identifier: 'id123',
+        requestBody: {
+          messageId: ['message123'],
+          ignoreImages: true,
+          ignoreLinks: true,
+          ignoreTables: true,
+          imagesAsMarkdown: true,
+          removeConclusionPhrases: true,
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'PUT',
+        path: '/v3/grants/id123/messages/clean',
+        body: {
+          messageId: ['message123'],
+          ignoreImages: true,
+          ignoreLinks: true,
+          ignoreTables: true,
+          imagesAsMarkdown: true,
+          removeConclusionPhrases: true,
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description
This PR adds support for the `/messages/clean` endpoint.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.