### PR TITLE
Added support for filtering by event type when listing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 * Added support for filtering by event type when listing events
+* Added support for filtering a list of folders
+* Fixed query parameters not being formatted properly
 
 ### 7.4.0 / 2024-05-01
 * Added support for `provider` field in code exchange response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added support for filtering by event type when listing events
+
 ### 7.4.0 / 2024-05-01
 * Added support for `provider` field in code exchange response
 * Added clean messages support

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -274,6 +274,11 @@ export interface ListEventQueryParams extends ListQueryParams {
    * This value should be taken from the {@link NylasListResponse.nextCursor} response field.
    */
   pageToken?: string;
+  /**
+   * (Google only) Filter events by event type.
+   * You can pass the query parameter multiple times to select or exclude multiple event types.
+   */
+  eventType?: EventType[];
 }
 
 /**
@@ -593,3 +598,12 @@ export interface EmailName {
    */
   name?: string;
 }
+
+/**
+ * Type representing the event type to filter by.
+ */
+export type EventType =
+  | 'default'
+  | 'outOfOffice'
+  | 'focusTime'
+  | 'workingLocation';

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -100,6 +100,24 @@ describe('APIClient', () => {
           )
         );
       });
+
+      it('should handle all the different types of query params', () => {
+        const options = client.requestOptions({
+          path: '/test',
+          method: 'GET',
+          queryParams: {
+            foo: 'bar',
+            list: ['a', 'b', 'c'],
+            map: { key1: 'value1', key2: 'value2' },
+          },
+        });
+
+        expect(options.url).toEqual(
+          new URL(
+            'https://api.us.nylas.com/test?foo=bar&list=a&list=b&list=c&map=key1%3Avalue1&map=key2%3Avalue2'
+          )
+        );
+      });
     });
 
     describe('newRequest', () => {


### PR DESCRIPTION
# Description
This PR adds support for filtering events by event type. Note that this feature is only for Google events.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.