### PR TITLE
Adding support for `collective` availability

### DIFF
--- a/src/models/availability.ts
+++ b/src/models/availability.ts
@@ -172,4 +172,5 @@ export interface AvailabilityParticipant {
 export enum AvailabilityMethod {
   MaxFairness = 'max-fairness',
   MaxAvailability = 'max-availability',
+  Collective = 'collective',
 }

--- a/tests/resources/calendars.spec.ts
+++ b/tests/resources/calendars.spec.ts
@@ -210,4 +210,74 @@ describe('Calendars', () => {
       });
     });
   });
+  
+  describe('getCollectiveAvailability', () => {
+    it('should call apiClient.request with the correct params', async () => {
+      await calendars.getAvailability({
+        requestBody: {
+          startTime: 123,
+          endTime: 456,
+          participants: [],
+          durationMinutes: 30,
+          intervalMinutes: 15,
+          roundTo30Minutes: true,
+          availabilityRules: {
+            availabilityMethod: AvailabilityMethod.Collective,
+            buffer: {
+              before: 15,
+              after: 15,
+            },
+            defaultOpenHours: [
+              {
+                days: [0],
+                timezone: 'America/Toronto',
+                start: '09:00',
+                end: '17:00',
+                exdates: ['2020-01-01'],
+              },
+            ],
+            roundRobinEventId: 'event123',
+          },
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'POST',
+        path: '/v3/calendars/availability',
+        body: {
+          startTime: 123,
+          endTime: 456,
+          participants: [],
+          durationMinutes: 30,
+          intervalMinutes: 15,
+          roundTo30Minutes: true,
+          availabilityRules: {
+            availabilityMethod: AvailabilityMethod.Collective,
+            buffer: {
+              before: 15,
+              after: 15,
+            },
+            defaultOpenHours: [
+              {
+                days: [0],
+                timezone: 'America/Toronto',
+                start: '09:00',
+                end: '17:00',
+                exdates: ['2020-01-01'],
+              },
+            ],
+            roundRobinEventId: 'event123',
+          },
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+    });
+  });
 });

--- a/tests/resources/calendars.spec.ts
+++ b/tests/resources/calendars.spec.ts
@@ -210,7 +210,7 @@ describe('Calendars', () => {
       });
     });
   });
-  
+
   describe('getCollectiveAvailability', () => {
     it('should call apiClient.request with the correct params', async () => {
       await calendars.getAvailability({


### PR DESCRIPTION
- As per Nylas [documentation](https://developer.nylas.com/docs/api/v3/ecc/#post-/v3/calendars/availability), we support `collective` availability.
- In Node SDK we only support `max-availability` & `max-fairness` at this time.
- Add `collective` to `AvailabilityMethod`.
- Added unit test `getCollectiveAvailability`.


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.