### PR TITLE
fix: application crash when timeout encountered

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -186,7 +186,7 @@ export default class APIClient {
 
       return response;
     } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
+      if (error instanceof Error && error.name === 'AbortError') {
         throw new NylasSdkTimeoutError(req.url, this.timeout);
       }
 

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -148,7 +148,6 @@ export default class APIClient {
     const controller: AbortController = new AbortController();
     const timeout = setTimeout(() => {
       controller.abort();
-      throw new NylasSdkTimeoutError(req.url, this.timeout);
     }, this.timeout);
 
     try {
@@ -187,6 +186,10 @@ export default class APIClient {
 
       return response;
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new NylasSdkTimeoutError(req.url, this.timeout);
+      }
+
       clearTimeout(timeout);
       throw error;
     }


### PR DESCRIPTION
I encountered occasional application crashes and traced them back to timeouts coming from the Nylas API. After reviewing the Nylas-SDK, I found the culprit in the `setTimeout` call used to abort the request. It's bad practice to throw an error from `setTimeout` as its `try...catch` blocks will not intercept the error. Instead, these errors will crash the application.

`node-fetch` will reject when `controller.abort()` is called, so we don't need to throw from the timeout anyway.

Reference: 
https://jaketrent.com/post/catch-error-thrown-settimeout/
https://nodejs.org/dist/latest-v7.x/docs/api/errors.html#errors_node_js_style_callbacks

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.