### PR TITLE
Fix issue where metadata was being incorrectly modified before being sent to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue where metadata was being incorrectly modified before being sent to the API
+
 ### 7.5.1 / 2024-07-09
 * Added collective availability method
 * Fix crash when timeout encountered

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -204,7 +204,7 @@ export default class APIClient {
 
     if (optionParams.body) {
       requestOptions.body = JSON.stringify(
-        objKeysToSnakeCase(optionParams.body)
+        objKeysToSnakeCase(optionParams.body, ['metadata']) // metadata should remain as is
       );
       requestOptions.headers['Content-Type'] = 'application/json';
     }

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -234,7 +234,7 @@ export default class APIClient {
 
     try {
       const responseJSON = JSON.parse(text);
-      return objKeysToCamelCase(responseJSON);
+      return objKeysToCamelCase(responseJSON, ['metadata']);
     } catch (e) {
       throw new Error(`Could not parse response from the server: ${text}`);
     }

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -118,6 +118,29 @@ describe('APIClient', () => {
           )
         );
       });
+
+      it('should not convert metadata object keys to snake_case', () => {
+        const metadata = {
+          key0: 'value',
+          key1: 'another',
+          camelCase: true,
+          snake_case: false,
+          normal: 'yes',
+        };
+        const expectedBody = JSON.stringify({
+          metadata: metadata,
+        });
+
+        const options = client.requestOptions({
+          path: '/test',
+          method: 'POST',
+          body: {
+            metadata: metadata,
+          },
+        });
+
+        expect(options.body).toEqual(expectedBody);
+      });
     });
 
     describe('newRequest', () => {


### PR DESCRIPTION
# Description
This PR fixes an issue where the SDK was incorrectly modifying metadata objects before being sent to the API, specifically the metadata keys were being converted to snake case when they should remain unmodified.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.