### PR TITLE
Fix issue where crypto import was causing downstream Jest incompatibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue where crypto import was causing downstream Jest incompatibilities
+
 ### 7.5.2 / 2024-07-12
 * Fix issue where metadata was being incorrectly modified before being sent to the API
 

--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { createHash } from 'node:crypto';
+import { createHash } from 'crypto';
 import { Resource } from './resource.js';
 import {
   URLForAdminConsentConfig,


### PR DESCRIPTION
# Description
Using `node:crypto` rather than `crypto` causes downstream issues for Jest integrations.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.