### PR TITLE
Remove eslint-plugin-import from production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "license": "MIT",
   "dependencies": {
     "change-case": "^4.1.2",
-    "eslint-plugin-import": "^2.28.1",
     "form-data": "^4.0.0",
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.12",


### PR DESCRIPTION
This package is currently leaking the `eslint-plugin-import` dev dependency into the production dependencies, thus requiring consumers to have it installed as a dependency.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.