### PR TITLE
Add support for filtering events by attendee email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for filtering events by attendee email
+
 ### 7.5.2 / 2024-07-12
 * Fix issue where metadata was being incorrectly modified before being sent to the API
 

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -279,6 +279,11 @@ export interface ListEventQueryParams extends ListQueryParams {
    * You can pass the query parameter multiple times to select or exclude multiple event types.
    */
   eventType?: EventType[];
+  /**
+   * Filter for events that include the specified attendees.
+   * Not supported for virtual calendars.
+   */
+  attendees?: string[];
 }
 
 /**


### PR DESCRIPTION
# Description
This PR adds the `attendees` field for filtering events.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.