### PR TITLE
Add ews as a provider

### DIFF
--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -11,7 +11,8 @@ export type Provider =
   | 'imap'
   | 'microsoft'
   | 'icloud'
-  | 'virtual-calendar';
+  | 'virtual-calendar'
+  | 'ews';
 
 /**
  * Configuration for generating a URL for OAuth 2.0 authentication.


### PR DESCRIPTION
<!-- Add information about your PR here -->
Since we support EWS as a provider for Custom Auth and Hosted Auth adding this value to our `Provider` type

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.