### PR TITLE
Add buffer support for file attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for filtering events by attendee email
+* Add buffer support for file attachments
 * Fix issue where crypto import was causing downstream Jest incompatibilities
 
 ### 7.5.2 / 2024-07-12

--- a/src/models/attachments.ts
+++ b/src/models/attachments.ts
@@ -39,7 +39,9 @@ interface BaseAttachment {
 export interface CreateAttachmentRequest extends BaseAttachment {
   /**
    * Content of the attachment.
-   * It can either be a readable stream or a base64 encoded string.
+   * It can either be a readable stream, a base64 encoded string, or a buffer.
+   * For attachments less than 3MB, the content can be a readable stream, or a base64 encoded string.
+   * For attachments greater than 3MB, the content must be either a readable stream or a buffer.
    */
   content: NodeJS.ReadableStream | string | Buffer;
 }

--- a/src/models/attachments.ts
+++ b/src/models/attachments.ts
@@ -41,7 +41,7 @@ export interface CreateAttachmentRequest extends BaseAttachment {
    * Content of the attachment.
    * It can either be a readable stream or a base64 encoded string.
    */
-  content: NodeJS.ReadableStream | string;
+  content: NodeJS.ReadableStream | string | Buffer;
 }
 
 /**


### PR DESCRIPTION
# Description
This PR adds support for buffer type as a file attachment for attachments greater than 3MB and improves the messaging to the end user on when to use the different content types when attaching a file.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.