### PR TITLE
Change rotate secret endpoint from being a PUT to a POST call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Add support for filtering events by attendee email
 * Add buffer support for file attachments
+* Change rotate secret endpoint from being a PUT to a POST call
 * Fix issue where crypto import was causing downstream Jest incompatibilities
 
 ### 7.5.2 / 2024-07-12

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -130,7 +130,7 @@ export class Webhooks extends Resource {
   }: DestroyWebhookParams & Overrides): Promise<
     NylasResponse<WebhookWithSecret>
   > {
-    return super._update({
+    return super._create({
       path: `/v3/webhooks/${webhookId}/rotate-secret`,
       requestBody: {},
       overrides,

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -161,7 +161,7 @@ describe('Webhooks', () => {
       });
 
       expect(apiClient.request).toHaveBeenCalledWith({
-        method: 'PUT',
+        method: 'POST',
         path: '/v3/webhooks/webhook123/rotate-secret',
         body: {},
         overrides: {


### PR DESCRIPTION
# Description
This PR fixes the rotate secret function to make a POST call rather than a PUT. Closes #583.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.