### PR TITLE
Fix FormData import compatibility issues with ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add new webhook trigger types
 * Change rotate secret endpoint from being a PUT to a POST call
 * Fix issue where crypto import was causing downstream Jest incompatibilities
+* Fix FormData import compatibility issues with ESM
 
 ### 7.5.2 / 2024-07-12
 * Fix issue where metadata was being incorrectly modified before being sent to the API

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -7,7 +7,7 @@ import {
 } from './models/error.js';
 import { objKeysToCamelCase, objKeysToSnakeCase } from './utils.js';
 import { SDK_VERSION } from './version.js';
-import * as FormData from 'form-data';
+import FormData from 'form-data';
 import { snakeCase } from 'change-case';
 
 /**

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -21,7 +21,7 @@ import {
   SendMessageRequest,
   UpdateDraftRequest,
 } from '../models/drafts.js';
-import * as FormData from 'form-data';
+import FormData from 'form-data';
 import { encodeAttachmentStreams, objKeysToSnakeCase } from '../utils.js';
 import { SmartCompose } from './smartCompose.js';
 import APIClient, { RequestOptionsParams } from '../apiClient.js';

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -311,13 +311,10 @@ export class Messages extends Resource {
   static _buildFormRequest(
     requestBody: CreateDraftRequest | UpdateDraftRequest | SendMessageRequest
   ): FormData {
-    let form: FormData;
     // FormData imports are funky, cjs needs to use .default, es6 doesn't
-    if (typeof (FormData as any).default !== 'undefined') {
-      form = new (FormData as any).default();
-    } else {
-      form = new FormData();
-    }
+    const FormData = require('form-data');
+    const FormDataConstructor = FormData.default || FormData;
+    const form = new FormDataConstructor();
 
     // Split out the message payload from the attachments
     const messagePayload = {

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -312,9 +312,9 @@ export class Messages extends Resource {
     requestBody: CreateDraftRequest | UpdateDraftRequest | SendMessageRequest
   ): FormData {
     // FormData imports are funky, cjs needs to use .default, es6 doesn't
-    const FormData = require('form-data');
-    const FormDataConstructor = FormData.default || FormData;
-    const form = new FormDataConstructor();
+    const FD = require('form-data');
+    const FormDataConstructor = FD.default || FD;
+    const form: FormData = new FormDataConstructor();
 
     // Split out the message payload from the attachments
     const messagePayload = {


### PR DESCRIPTION
# Description
This PR fixes compatibility issues with ESM brought by the problematic form-data import statement. Fixes #576.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.