### PR TITLE
v7.6.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-### Unreleased
+### 7.6.0 / 2024-10-18
 * Add support for filtering events by attendee email
 * Add buffer support for file attachments
 * Add new webhook trigger types
+* Add ews as a provider
 * Change rotate secret endpoint from being a PUT to a POST call
 * Fix issue where crypto import was causing downstream Jest incompatibilities
 * Fix FormData import compatibility issues with ESM
+* Remove eslint-plugin-import from production dependencies
 
 ### 7.5.2 / 2024-07-12
 * Fix issue where metadata was being incorrectly modified before being sent to the API


### PR DESCRIPTION
# Changelog
* Add support for filtering events by attendee email (#577)
* Add buffer support for file attachments (#579)
* Add new webhook trigger types (#585, #582)
* Add ews as a provider (#578)
* Change rotate secret endpoint from being a PUT to a POST call (#584, #583)
* Fix issue where crypto import was causing downstream Jest incompatibilities (#574)
* Fix FormData import compatibility issues with ESM (#586, #576)
* Remove eslint-plugin-import from production dependencies (#575)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.