### PR TITLE
Revert "Adding gzip headers to reduce payload sizes and enable compression"

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -207,7 +207,6 @@ export default class APIClient {
         objKeysToSnakeCase(optionParams.body, ['metadata']) // metadata should remain as is
       );
       requestOptions.headers['Content-Type'] = 'application/json';
-      requestOptions.headers['Accept-Encoding'] = 'gzip';
     }
 
     if (optionParams.form) {

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -20,7 +20,6 @@ describe('APIClient', () => {
         timeout: 30,
         headers: {
           'X-SDK-Test-Header': 'This is a test',
-          'Accept-Encoding': 'gzip',
         },
       });
 
@@ -29,7 +28,6 @@ describe('APIClient', () => {
       expect(client.timeout).toBe(30000);
       expect(client.headers).toEqual({
         'X-SDK-Test-Header': 'This is a test',
-        'Accept-Encoding': 'gzip',
       });
     });
   });
@@ -51,10 +49,7 @@ describe('APIClient', () => {
         const options = client.requestOptions({
           path: '/test',
           method: 'GET',
-          headers: {
-            'X-SDK-Test-Header': 'This is a test',
-            'Accept-Encoding': 'gzip',
-          },
+          headers: { 'X-SDK-Test-Header': 'This is a test' },
           queryParams: { param: 'value' },
           body: { id: 'abc123' },
           overrides: { apiUri: 'https://test.api.nylas.com' },
@@ -65,7 +60,6 @@ describe('APIClient', () => {
           Accept: 'application/json',
           Authorization: 'Bearer testApiKey',
           'Content-Type': 'application/json',
-          'Accept-Encoding': 'gzip',
           'User-Agent': `Nylas Node SDK v${SDK_VERSION}`,
           'X-SDK-Test-Header': 'This is a test',
         });
@@ -79,16 +73,12 @@ describe('APIClient', () => {
         const options = client.requestOptions({
           path: '/test',
           method: 'POST',
-          headers: {
-            'Accept-Encoding': 'gzip',
-          },
         });
 
         expect(options.method).toBe('POST');
         expect(options.headers).toEqual({
           Accept: 'application/json',
           Authorization: 'Bearer testApiKey',
-          'Accept-Encoding': 'gzip',
           'User-Agent': `Nylas Node SDK v${SDK_VERSION}`,
         });
         expect(options.url).toEqual(new URL('https://api.us.nylas.com/test'));
@@ -177,7 +167,6 @@ describe('APIClient', () => {
           Accept: ['application/json'],
           Authorization: ['Bearer testApiKey'],
           'Content-Type': ['application/json'],
-          'Accept-Encoding': ['gzip'],
           'User-Agent': [`Nylas Node SDK v${SDK_VERSION}`],
           'X-SDK-Test-Header': ['This is a test'],
           'global-header': ['global-value'],


### PR DESCRIPTION
- Reverts nylas/nylas-nodejs#591
- The HTTPClient used for NodeSDK includes the `"Accept-Encoding": "gzip"` by default, reverting this PR for now
