### PR TITLE
Fix the ability to rotate webhook secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix for the webhook rotate secret calling the wrong endpoint
+
 ### 7.6.1 / 2024-10-30
 * Add support for filtering events by masterEventID
 * Add support for gzip compression

--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -131,7 +131,7 @@ export class Webhooks extends Resource {
     NylasResponse<WebhookWithSecret>
   > {
     return super._create({
-      path: `/v3/webhooks/${webhookId}/rotate-secret`,
+      path: `/v3/webhooks/rotate-secret/${webhookId}`,
       requestBody: {},
       overrides,
     });

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -162,7 +162,7 @@ describe('Webhooks', () => {
 
       expect(apiClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v3/webhooks/webhook123/rotate-secret',
+        path: '/v3/webhooks/rotate-secret/webhook123',
         body: {},
         overrides: {
           apiUri: 'https://test.api.nylas.com',


### PR DESCRIPTION
<!-- Add information about your PR here -->
# Description
The `webhooks.rotateSecret` method calls the incorrect URL, so all calls using this method fail with an error. This fixes that by switching the URL to the correct one. Closes #596. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.