### PR TITLE
Autofix: Unable to rotate webhook secrets

### DIFF
--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -131,7 +131,7 @@ export class Webhooks extends Resource {
     NylasResponse<WebhookWithSecret>
   > {
     return super._create({
-      path: `/v3/webhooks/${webhookId}/rotate-secret`,
+      path: `/v3/webhooks/rotate-secret/${webhookId}`,
       requestBody: {},
       overrides,
     });


### PR DESCRIPTION
I have identified the issue in the `rotateSecret` method of the `Webhooks` class. The problem was that it was using the incorrect HTTP method and path. I've updated the method to use the correct POST request to the `/v3/webhooks/rotate-secret/{id}` endpoint as specified in the documentation. 