### PR TITLE
Fix query parameters for array values

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -106,9 +106,7 @@ export default class APIClient {
           }
           url.searchParams.set('metadata_pair', metadataPair.join(','));
         } else if (Array.isArray(value)) {
-          for (const item of value) {
-            url.searchParams.append(snakeCaseKey, item as string);
-          }
+          url.searchParams.append(snakeCaseKey, value.join(','));
         } else if (typeof value === 'object') {
           for (const item in value) {
             url.searchParams.append(

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -114,7 +114,7 @@ describe('APIClient', () => {
 
         expect(options.url).toEqual(
           new URL(
-            'https://api.us.nylas.com/test?foo=bar&list=a&list=b&list=c&map=key1%3Avalue1&map=key2%3Avalue2'
+            'https://api.us.nylas.com/test?foo=bar&list=a%2Cb%2Cc&map=key1%3Avalue1&map=key2%3Avalue2'
           )
         );
       });


### PR DESCRIPTION
We were creating a new snakeCaseKey=item for each item in the value array.

This was creating multiple instances of the snakeCaseKey query param if there is more than one item in an array.

<!-- Add information about your PR here -->

If more than one value was passing more than one value in an array query parameter we were generating a URL that looks like this:
`/v3/grants/9a8ce69e-61a5-42c5-bdda-1ab3c3745093/threads?limit=5&any_email=chase.w%40nylas.com&any_email=nick.b%40nylas.com`

This change makes it so that the above URL instead produces the following request URL:
`/v3/grants/9a8ce69e-61a5-42c5-bdda-1ab3c3745093/threads?limit=5&any_email=chase.w%40nylas.com,nick.b%40nylas.com`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.