### PR TITLE
Update the filename field to be optional

### DIFF
--- a/src/models/attachments.ts
+++ b/src/models/attachments.ts
@@ -3,9 +3,9 @@
  */
 interface BaseAttachment {
   /**
-   * Attachment's name.
+   * Attachment's name. The availability of a filename depends on the provider.
    */
-  filename: string;
+  filename?: string;
 
   /**
    * Attachment's content type.


### PR DESCRIPTION
Nylas Support #98515

In rare cases, the attachment does not have a file name from the Gmail API, and the content disposition is set to inline, which also does not include a filename

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.