### PR TITLE
Remove `created_at` field from message model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+* Remove `createdAt` field from message model.
+* Change `latestMessageReceivedDate` & `latestMessageSentDate` to be optional on threads model.
+
 ### 7.7.2 / 2024-12-02
 * Fix `credentials` resource to use correct endpoint.
 

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -1,6 +1,6 @@
+import { Attachment } from './attachments.js';
 import { EmailName } from './events.js';
 import { ListQueryParams } from './listQueryParams.js';
-import { Attachment } from './attachments.js';
 
 /**
  * @internal Internal interface for a message.
@@ -19,10 +19,6 @@ export interface BaseMessage {
    * This may be different from the unverified Date header in raw message object.
    */
   date: number;
-  /**
-   * Unix timestamp of when the message was created.
-   */
-  createdAt: number;
   /**
    * The ID of the folder(s) the message appears in.
    */

--- a/src/models/threads.ts
+++ b/src/models/threads.ts
@@ -1,7 +1,7 @@
-import { Message } from './messages.js';
 import { Draft } from './drafts.js';
 import { EmailName } from './events.js';
 import { ListQueryParams } from './listQueryParams.js';
+import { Message } from './messages.js';
 
 /**
  * Interface representing a Nylas thread object.
@@ -42,11 +42,11 @@ export interface Thread {
   /**
    * Unix timestamp of the most recent message received in the thread.
    */
-  latestMessageReceivedDate: number;
+  latestMessageReceivedDate?: number;
   /**
    * Unix timestamp of the most recent message sent in the thread.
    */
-  latestMessageSentDate: number;
+  latestMessageSentDate?: number;
   /**
    * An array of participants in the thread.
    */

--- a/tests/resources/drafts.spec.ts
+++ b/tests/resources/drafts.spec.ts
@@ -1,8 +1,8 @@
 import APIClient from '../../src/apiClient';
-import { Drafts } from '../../src/resources/drafts';
-import { createReadableStream, MockedFormData } from '../testUtils';
 import { CreateAttachmentRequest } from '../../src/models/attachments';
+import { Drafts } from '../../src/resources/drafts';
 import { objKeysToCamelCase } from '../../src/utils';
+import { createReadableStream, MockedFormData } from '../testUtils';
 jest.mock('../src/apiClient');
 
 // Mock the FormData constructor
@@ -77,7 +77,6 @@ describe('Drafts', () => {
           },
         ],
         date: 1705084742,
-        created_at: 1705084926,
       };
 
       const draft = objKeysToCamelCase(apiDraft);
@@ -123,7 +122,6 @@ describe('Drafts', () => {
           },
         ],
         date: 1705084742,
-        createdAt: 1705084926,
       });
     });
   });


### PR DESCRIPTION
<!-- Add information about your PR here -->
- Nylas API no longer return `created_at` field on message response (#573 )  - [Nylas Bug improvements](https://developer.nylas.com/docs/new/release-notes/2024-07-10-new-in-nylas/#nylas-api-bug-fixes-and-improvements)
- Therefore, removing them on the SDK.
- Change `latestMessageReceivedDate` & `latestMessageSentDate` to be optional on threads model.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.