### PR TITLE
fix: respect timeout override when provided in request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Remove `createdAt` field from message model.
 * Change `latestMessageReceivedDate` & `latestMessageSentDate` to be optional on threads model.
+* Fix issue where timeout was not being respected when overriding the timeout in the request options.
 
 ### 7.7.2 / 2024-12-02
 * Fix `credentials` resource to use correct endpoint.

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,4 +1,5 @@
 import fetch, { Request, Response } from 'node-fetch';
+import type { AbortSignal } from 'node-fetch/externals.js';
 import { NylasConfig, OverridableNylasConfig } from './config.js';
 import {
   NylasApiError,
@@ -144,12 +145,13 @@ export default class APIClient {
   private async sendRequest(options: RequestOptionsParams): Promise<Response> {
     const req = this.newRequest(options);
     const controller: AbortController = new AbortController();
+    const timeoutDuration = options.overrides?.timeout || this.timeout;
     const timeout = setTimeout(() => {
       controller.abort();
-    }, this.timeout);
+    }, timeoutDuration);
 
     try {
-      const response = await fetch(req, { signal: controller.signal });
+      const response = await fetch(req, { signal: controller.signal as AbortSignal });
       clearTimeout(timeout);
 
       if (typeof response === 'undefined') {

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,5 +1,5 @@
 import fetch, { Request, Response } from 'node-fetch';
-import type { AbortSignal } from 'node-fetch/externals.js';
+import { AbortSignal } from 'node-fetch/externals.js';
 import { NylasConfig, OverridableNylasConfig } from './config.js';
 import {
   NylasApiError,
@@ -153,7 +153,9 @@ export default class APIClient {
     }, timeoutDuration);
 
     try {
-      const response = await fetch(req, { signal: controller.signal as AbortSignal });
+      const response = await fetch(req, {
+        signal: controller.signal as AbortSignal,
+      });
       clearTimeout(timeout);
 
       if (typeof response === 'undefined') {

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -1,6 +1,10 @@
 import { RequestInfo } from 'node-fetch';
 import APIClient, { RequestOptionsParams } from '../src/apiClient';
-import { NylasApiError, NylasOAuthError, NylasSdkTimeoutError } from '../src/models/error';
+import {
+  NylasApiError,
+  NylasOAuthError,
+  NylasSdkTimeoutError,
+} from '../src/models/error';
 import { SDK_VERSION } from '../src/version';
 import { mockedFetch, mockResponse } from './testUtils';
 
@@ -327,7 +331,12 @@ describe('APIClient', () => {
             method: 'GET',
             overrides: { timeout: overrideTimeout },
           })
-        ).rejects.toThrow(new NylasSdkTimeoutError('https://api.us.nylas.com/test', overrideTimeout * 1000));
+        ).rejects.toThrow(
+          new NylasSdkTimeoutError(
+            'https://api.us.nylas.com/test',
+            overrideTimeout * 1000
+          )
+        );
       });
 
       it('should use default timeout when no override provided', async () => {
@@ -343,7 +352,12 @@ describe('APIClient', () => {
             path: '/test',
             method: 'GET',
           })
-        ).rejects.toThrow(new NylasSdkTimeoutError('https://api.us.nylas.com/test', client.timeout));
+        ).rejects.toThrow(
+          new NylasSdkTimeoutError(
+            'https://api.us.nylas.com/test',
+            client.timeout
+          )
+        );
       });
 
       it('should complete request within timeout period', async () => {

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -1,5 +1,6 @@
+import { RequestInfo } from 'node-fetch';
 import APIClient, { RequestOptionsParams } from '../src/apiClient';
-import { NylasApiError, NylasOAuthError } from '../src/models/error';
+import { NylasApiError, NylasOAuthError, NylasSdkTimeoutError } from '../src/models/error';
 import { SDK_VERSION } from '../src/version';
 import { mockedFetch, mockResponse } from './testUtils';
 
@@ -292,6 +293,54 @@ describe('APIClient', () => {
             method: 'POST',
           })
         ).rejects.toThrow(new NylasApiError(payload));
+      });
+
+      it('should respect override timeout when provided', async () => {
+        const overrideTimeout = 2; // 2 second timeout
+
+        mockedFetch.mockImplementationOnce((_url: RequestInfo) => {
+          // Immediately throw an AbortError to simulate a timeout
+          const error = new Error('The operation was aborted');
+          error.name = 'AbortError';
+          return Promise.reject(error);
+        });
+
+        await expect(
+          client.request({
+            path: '/test',
+            method: 'GET',
+            overrides: { timeout: overrideTimeout },
+          })
+        ).rejects.toThrow(new NylasSdkTimeoutError('https://api.us.nylas.com/test', overrideTimeout * 1000));
+      });
+
+      it('should use default timeout when no override provided', async () => {
+        mockedFetch.mockImplementationOnce((_url: RequestInfo) => {
+          // Immediately throw an AbortError to simulate a timeout
+          const error = new Error('The operation was aborted');
+          error.name = 'AbortError';
+          return Promise.reject(error);
+        });
+
+        await expect(
+          client.request({
+            path: '/test',
+            method: 'GET',
+          })
+        ).rejects.toThrow(new NylasSdkTimeoutError('https://api.us.nylas.com/test', client.timeout));
+      });
+
+      it('should complete request within timeout period', async () => {
+        const payload = { data: 'test' };
+        mockedFetch.mockImplementationOnce(() =>
+          Promise.resolve(mockResponse(JSON.stringify(payload)))
+        );
+
+        const result = await client.request({
+          path: '/test',
+          method: 'GET',
+        });
+        expect(result).toEqual(payload);
       });
     });
   });


### PR DESCRIPTION
# Description
This pull request fixes an issue where the request timeout override provided in the request options was not being honored. The change ensures that if a custom timeout is specified, it is applied correctly when issuing requests, preventing them from running longer than intended.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.