### PR TITLE
fix: transform anyEmail array into comma-delimited any_email parameter in threads list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Remove `createdAt` field from message model.
 * Change `latestMessageReceivedDate` & `latestMessageSentDate` to be optional on threads model.
+* Fix issue where query params with array values were not being transformed into comma-delimited strings
 
 ### 7.7.2 / 2024-12-02
 * Fix `credentials` resource to use correct endpoint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",
-        "eslint-plugin-import": "^2.28.1",
         "form-data": "^4.0.0",
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.12",

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -106,7 +106,9 @@ export default class APIClient {
           }
           url.searchParams.set('metadata_pair', metadataPair.join(','));
         } else if (Array.isArray(value)) {
-          url.searchParams.append(snakeCaseKey, value.join(','));
+          for (const item of value) {
+            url.searchParams.append(snakeCaseKey, item as string);
+          }
         } else if (typeof value === 'object') {
           for (const item in value) {
             url.searchParams.append(

--- a/src/resources/threads.ts
+++ b/src/resources/threads.ts
@@ -71,8 +71,20 @@ export class Threads extends Resource {
   }: ListThreadsParams & Overrides): AsyncListResponse<
     NylasListResponse<Thread>
   > {
+    const modifiedQueryParams: Record<string, unknown> | undefined = queryParams
+      ? { ...queryParams }
+      : undefined;
+
+    // Transform some query params that are arrays into comma-delimited strings
+    if (modifiedQueryParams && queryParams) {
+      if (Array.isArray(queryParams?.anyEmail)) {
+        delete modifiedQueryParams.anyEmail;
+        modifiedQueryParams['any_email'] = queryParams.anyEmail.join(',');
+      }
+    }
+
     return super._list<NylasListResponse<Thread>>({
-      queryParams,
+      queryParams: modifiedQueryParams,
       overrides,
       path: `/v3/grants/${identifier}/threads`,
     });

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -114,7 +114,23 @@ describe('APIClient', () => {
 
         expect(options.url).toEqual(
           new URL(
-            'https://api.us.nylas.com/test?foo=bar&list=a%2Cb%2Cc&map=key1%3Avalue1&map=key2%3Avalue2'
+            'https://api.us.nylas.com/test?foo=bar&list=a&list=b&list=c&map=key1%3Avalue1&map=key2%3Avalue2'
+          )
+        );
+      });
+
+      it('should handle repeated query parameters', () => {
+        const options = client.requestOptions({
+          path: '/test',
+          method: 'GET',
+          queryParams: {
+            eventType: ['default', 'outOfOffice', 'focusTime'],
+          },
+        });
+
+        expect(options.url).toEqual(
+          new URL(
+            'https://api.us.nylas.com/test?event_type=default&event_type=outOfOffice&event_type=focusTime'
           )
         );
       });

--- a/tests/resources/threads.spec.ts
+++ b/tests/resources/threads.spec.ts
@@ -1,12 +1,12 @@
 import APIClient from '../../src/apiClient';
 import { Threads } from '../../src/resources/threads';
-jest.mock('../src/apiClient');
+jest.mock('../../src/apiClient');
 
 describe('Threads', () => {
   let apiClient: jest.Mocked<APIClient>;
   let threads: Threads;
 
-  beforeAll(() => {
+  beforeEach(() => {
     apiClient = new APIClient({
       apiKey: 'apiKey',
       apiUri: 'https://test.api.nylas.com',
@@ -34,6 +34,25 @@ describe('Threads', () => {
         overrides: {
           apiUri: 'https://test.api.nylas.com',
           headers: { override: 'bar' },
+        },
+      });
+    });
+
+    it('should transform anyEmail array into comma-delimited any_email parameter', async () => {
+      const mockEmails = ['test1@example.com', 'test2@example.com'];
+      await threads.list({
+        identifier: 'id123',
+        queryParams: {
+          anyEmail: mockEmails,
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/grants/id123/threads',
+        overrides: undefined,
+        queryParams: {
+          any_email: mockEmails.join(','),
         },
       });
     });


### PR DESCRIPTION
# Background
Fixes https://github.com/nylas/nylas-nodejs/issues/615 - looks like we introduced a regression in https://github.com/nylas/nylas-nodejs/pull/606.

I've reverted that PR because the proper way to pass an array of items for a single query param is to repeat the query param. 

Instead, I've added an override/transformation for the `threads.list` method that converts the `anyEmail` query param to a comma-separated list. I avoided putting this in `apiClient` because in my opinion, that's too disconnected from the resource where these overrides should occur.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.