### PR TITLE
fix: any_email was not transformed to a comma delimited list for messages.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix: any_email was not transformed to a comma delimited list for messages.list
+
 ### 7.7.3 / 2025-01-23
 * Remove `createdAt` field from message model.
 * Change `latestMessageReceivedDate` & `latestMessageSentDate` to be optional on threads model.

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -141,8 +141,20 @@ export class Messages extends Resource {
   }: ListMessagesParams & Overrides): AsyncListResponse<
     NylasListResponse<Message>
   > {
+    const modifiedQueryParams: Record<string, unknown> | undefined = queryParams
+      ? { ...queryParams }
+      : undefined;
+
+    // Transform some query params that are arrays into comma-delimited strings
+    if (modifiedQueryParams && queryParams) {
+      if (Array.isArray(queryParams?.anyEmail)) {
+        delete modifiedQueryParams.anyEmail;
+        modifiedQueryParams['any_email'] = queryParams.anyEmail.join(',');
+      }
+    }
+
     return super._list<NylasListResponse<Message>>({
-      queryParams,
+      queryParams: modifiedQueryParams,
       overrides,
       path: `/v3/grants/${identifier}/messages`,
     });

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -52,6 +52,25 @@ describe('Messages', () => {
         },
       });
     });
+
+    it('should transform anyEmail array into comma-delimited any_email parameter', async () => {
+      const mockEmails = ['test1@example.com', 'test2@example.com'];
+      await messages.list({
+        identifier: 'id123',
+        queryParams: {
+          anyEmail: mockEmails,
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/grants/id123/messages',
+        overrides: undefined,
+        queryParams: {
+          any_email: mockEmails.join(','),
+        },
+      });
+    });
   });
 
   describe('find', () => {


### PR DESCRIPTION
# Background
fix: any_email was not transformed to a comma delimited list for messages.list, this was missed as part of https://github.com/nylas/nylas-nodejs/pull/618

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.