### PR TITLE
Add support for listImportEvents method to import events from calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for `listImportEvents` method to import events from a specified calendar within a given time frame
+
 ### 7.7.4 / 2025-01-23
 * Fix: any_email was not transformed to a comma delimited list for messages.list
 
@@ -91,7 +94,7 @@
 * **BREAKING CHANGE**: Dropped the use of 'Collections' in favor of 'Resources'
 * **BREAKING CHANGE**: Removed all REST calls from models and moved them directly into resources
 * **REMOVED**: Local Webhook development support is removed due to incompatibility
-* Rewrote the majority of SDK to be more modular and efficient
+* Rewritten the majority of SDK to be more modular and efficient
 * Removed the use of custom strings for serialization and deserialization, now automatically converting to camelCase and from the API's snake_case
 * Added support for both ES6 and CommonJS module systems
 * Created models for all API resources and endpoints, for all HTTP methods to reduce confusion on which fields are available for each endpoint
@@ -416,7 +419,7 @@ Note: version 4.2.1 was not released.
 * Added `upgrade()` and `downgrade()` for account management
 * Added `getRaw()` for retrieving raw messages
 * **BREAKING CHANGE**: Changed API for sending raw messages to use `draft.send()` instead of `Message.sendRaw()`
-* Changed `list()` to override default `offset` with user’s
+* Changed `list()` to override default `offset` with user's
 * **BREAKING CHANGE**: Changed models for `Contact`, `Draft`, `Event`, `File`, `Folder`, `Message`, and `Thread` to accurately reflect the attribute that the API returns
 * Return headers correctly for `expanded` view for `Message` objects
 * **BREAKING CHANGE**: Return `Message` object instead of `Draft` object after send

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -336,7 +336,7 @@ export type SendRsvpQueryParams = FindEventQueryParams;
 /**
  * Interface representing the query parameters for importing events.
  */
-export interface ImportEventQueryParams {
+export interface ListImportEventQueryParams {
   /**
    * (Required) Calendar ID to import events from. "primary" is a supported value indicating the user's primary calendar.
    * Note: "primary" is not supported for iCloud.

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -334,6 +334,41 @@ export type DestroyEventQueryParams = CreateEventQueryParams;
 export type SendRsvpQueryParams = FindEventQueryParams;
 
 /**
+ * Interface representing the query parameters for importing events.
+ */
+export interface ImportEventQueryParams {
+  /**
+   * (Required) Calendar ID to import events from. "primary" is a supported value indicating the user's primary calendar.
+   * Note: "primary" is not supported for iCloud.
+   */
+  calendarId: string;
+  /**
+   * Filter for events that start at or after the specified time, in Unix timestamp format.
+   * Defaults to the time of the request.
+   */
+  start?: number;
+  /**
+   * Filter for events that end at or before the specified time, in Unix timestamp format.
+   * Defaults to one month from the time of the request.
+   */
+  end?: number;
+  /**
+   * The maximum number of objects to return.
+   * This field defaults to 50. The maximum allowed value is 500.
+   */
+  max_results?: number;
+  /**
+   * An identifier that specifies which page of data to return.
+   * This value should be taken from the next_cursor response field.
+   */
+  page_token?: string;
+  /**
+   * Specify fields that you want Nylas to return, as a comma-separated list.
+   */
+  select?: string;
+}
+
+/**
  * Enum representing the status of an event.
  */
 type Status = 'confirmed' | 'tentative' | 'cancelled';

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -336,7 +336,7 @@ export type SendRsvpQueryParams = FindEventQueryParams;
 /**
  * Interface representing the query parameters for importing events.
  */
-export interface ListImportEventQueryParams extends ListQueryParams  {
+export interface ListImportEventQueryParams extends ListQueryParams {
   /**
    * (Required) Calendar ID to import events from. "primary" is a supported value indicating the user's primary calendar.
    * Note: "primary" is not supported for iCloud.

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -336,7 +336,7 @@ export type SendRsvpQueryParams = FindEventQueryParams;
 /**
  * Interface representing the query parameters for importing events.
  */
-export interface ListImportEventQueryParams {
+export interface ListImportEventQueryParams extends ListQueryParams  {
   /**
    * (Required) Calendar ID to import events from. "primary" is a supported value indicating the user's primary calendar.
    * Note: "primary" is not supported for iCloud.
@@ -352,20 +352,6 @@ export interface ListImportEventQueryParams {
    * Defaults to one month from the time of the request.
    */
   end?: number;
-  /**
-   * The maximum number of objects to return.
-   * This field defaults to 50. The maximum allowed value is 500.
-   */
-  max_results?: number;
-  /**
-   * An identifier that specifies which page of data to return.
-   * This value should be taken from the next_cursor response field.
-   */
-  page_token?: string;
-  /**
-   * Specify fields that you want Nylas to return, as a comma-separated list.
-   */
-  select?: string;
 }
 
 /**

--- a/src/resources/events.ts
+++ b/src/resources/events.ts
@@ -128,7 +128,9 @@ export class Events extends Resource {
     identifier,
     queryParams,
     overrides,
-  }: ListImportEventParams & Overrides): AsyncListResponse<NylasListResponse<Event>> {
+  }: ListImportEventParams & Overrides): AsyncListResponse<
+    NylasListResponse<Event>
+  > {
     return super._list({
       queryParams,
       path: `/v3/grants/${identifier}/events/import`,

--- a/src/resources/events.ts
+++ b/src/resources/events.ts
@@ -5,7 +5,7 @@ import {
   DestroyEventQueryParams,
   Event,
   FindEventQueryParams,
-  ImportEventQueryParams,
+  ListImportEventQueryParams,
   ListEventQueryParams,
   SendRsvpQueryParams,
   SendRsvpRequest,
@@ -81,7 +81,7 @@ export interface DestroyEventParams {
  */
 export interface ListImportEventParams {
   identifier: string;
-  queryParams: ImportEventQueryParams;
+  queryParams: ListImportEventQueryParams;
 }
 
 /**

--- a/src/resources/events.ts
+++ b/src/resources/events.ts
@@ -5,6 +5,7 @@ import {
   DestroyEventQueryParams,
   Event,
   FindEventQueryParams,
+  ImportEventQueryParams,
   ListEventQueryParams,
   SendRsvpQueryParams,
   SendRsvpRequest,
@@ -76,6 +77,15 @@ export interface DestroyEventParams {
 
 /**
  * @property identifier The identifier of the grant to act upon
+ * @property queryParams The query parameters to include in the request
+ */
+export interface ListImportEventParams {
+  identifier: string;
+  queryParams: ImportEventQueryParams;
+}
+
+/**
+ * @property identifier The identifier of the grant to act upon
  * @property eventId The id of the Event to update.
  * @property queryParams The query parameters to include in the request
  * @property requestBody The values to send the RSVP with
@@ -105,6 +115,23 @@ export class Events extends Resource {
     return super._list({
       queryParams,
       path: `/v3/grants/${identifier}/events`,
+      overrides,
+    });
+  }
+
+  /**
+   * (Beta) Import events from a calendar within a given time frame
+   * This is useful when you want to import, store, and synchronize events from the time frame to your application
+   * @return The list of imported Events
+   */
+  public listImportEvents({
+    identifier,
+    queryParams,
+    overrides,
+  }: ListImportEventParams & Overrides): AsyncListResponse<NylasListResponse<Event>> {
+    return super._list({
+      queryParams,
+      path: `/v3/grants/${identifier}/events/import`,
       overrides,
     });
   }

--- a/tests/resources/events.spec.ts
+++ b/tests/resources/events.spec.ts
@@ -128,6 +128,88 @@ describe('Events', () => {
     //TODO::More iterator tests
   });
 
+  describe('listImportEvents', () => {
+    it('should call apiClient.request with the correct params', async () => {
+      await events.listImportEvents({
+        identifier: 'id123',
+        queryParams: {
+          calendarId: 'calendar123',
+          start: 1617235200,
+          end: 1619827200,
+          max_results: 100,
+          select: 'id,name',
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/grants/id123/events/import',
+        queryParams: {
+          calendarId: 'calendar123',
+          start: 1617235200,
+          end: 1619827200,
+          max_results: 100,
+          select: 'id,name',
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+    });
+
+    it('should paginate correctly with page_token for import events', async () => {
+      apiClient.request.mockResolvedValueOnce({
+        requestId: 'request123',
+        data: [
+          {
+            id: 'id',
+            name: 'name',
+          },
+        ],
+        nextCursor: 'cursor123',
+      });
+      const eventList = await events.listImportEvents({
+        identifier: 'id123',
+        queryParams: {
+          calendarId: 'calendar123',
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+      apiClient.request.mockResolvedValueOnce({
+        requestId: 'request123',
+        data: [
+          {
+            id: 'id',
+            name: 'name',
+          },
+        ],
+      });
+      await eventList.next();
+
+      expect(apiClient.request).toBeCalledTimes(2);
+      expect(apiClient.request).toHaveBeenLastCalledWith({
+        method: 'GET',
+        path: '/v3/grants/id123/events/import',
+        queryParams: {
+          calendarId: 'calendar123',
+          pageToken: 'cursor123',
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+    });
+  });
+
   describe('find', () => {
     it('should call apiClient.request with the correct params', async () => {
       await events.find({

--- a/tests/resources/events.spec.ts
+++ b/tests/resources/events.spec.ts
@@ -136,7 +136,7 @@ describe('Events', () => {
           calendarId: 'calendar123',
           start: 1617235200,
           end: 1619827200,
-          max_results: 100,
+          limit: 100,
           select: 'id,name',
         },
         overrides: {
@@ -152,7 +152,7 @@ describe('Events', () => {
           calendarId: 'calendar123',
           start: 1617235200,
           end: 1619827200,
-          max_results: 100,
+          limit: 100,
           select: 'id,name',
         },
         overrides: {


### PR DESCRIPTION
# Background
This adds support for the new beta endpoint [GET /v3/grants/{grant_id}/events/import](https://developer.nylas.com/docs/api/v3/ecc/#get-/v3/grants/-grant_id-/events/import), which allows importing events from a calendar within a specified time frame. This is useful for applications that need to synchronize events with their own calendaring solution or enrich events with custom data.

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.