### PR TITLE
fix(grants): Support queryParams in list method first parameter

### DIFF
--- a/src/resources/grants.ts
+++ b/src/resources/grants.ts
@@ -10,6 +10,14 @@ import {
   ListGrantsQueryParams,
   UpdateGrantRequest,
 } from '../models/grants.js';
+import { ListQueryParams } from '../models/listQueryParams.js';
+
+/**
+ * @property queryParams The query parameters to include in the request
+ */
+export interface ListGrantsParams {
+  queryParams?: ListGrantsQueryParams;
+}
 
 /**
  * @property grantId The id of the Grant to retrieve.
@@ -45,13 +53,16 @@ export class Grants extends Resource {
    * @return The list of Grants
    */
   public async list(
-    { overrides }: Overrides = {},
-    queryParams?: ListGrantsQueryParams
+    { overrides, queryParams }: Overrides & ListGrantsParams = {},
+    /**
+     * @deprecated Use `queryParams` instead.
+     */
+    _queryParams?: ListQueryParams
   ): Promise<NylasListResponse<Grant>> {
     return super._list<NylasListResponse<Grant>>({
-      queryParams,
+      queryParams: queryParams ?? _queryParams ?? undefined,
       path: `/v3/grants`,
-      overrides,
+      overrides: overrides ?? {},
     });
   }
 

--- a/tests/resources/grants.spec.ts
+++ b/tests/resources/grants.spec.ts
@@ -15,9 +15,9 @@ describe('Grants', () => {
     }) as jest.Mocked<APIClient>;
 
     grants = new Grants(apiClient);
-    
+
     // Create a spy implementation that captures the inputs
-    apiClient.request = jest.fn().mockImplementation((input) => {
+    apiClient.request = jest.fn().mockImplementation(input => {
       // eslint-disable-next-line no-console
       console.log('Request input:', JSON.stringify(input, null, 2));
       return Promise.resolve({

--- a/tests/resources/grants.spec.ts
+++ b/tests/resources/grants.spec.ts
@@ -1,12 +1,12 @@
 import APIClient from '../../src/apiClient';
 import { Grants } from '../../src/resources/grants';
-jest.mock('../src/apiClient');
+jest.mock('../../src/apiClient');
 
 describe('Grants', () => {
   let apiClient: jest.Mocked<APIClient>;
   let grants: Grants;
 
-  beforeAll(() => {
+  beforeEach(() => {
     apiClient = new APIClient({
       apiKey: 'apiKey',
       apiUri: 'https://api.nylas.com',
@@ -15,7 +15,15 @@ describe('Grants', () => {
     }) as jest.Mocked<APIClient>;
 
     grants = new Grants(apiClient);
-    apiClient.request.mockResolvedValue({});
+    
+    // Create a spy implementation that captures the inputs
+    apiClient.request = jest.fn().mockImplementation((input) => {
+      // eslint-disable-next-line no-console
+      console.log('Request input:', JSON.stringify(input, null, 2));
+      return Promise.resolve({
+        data: [],
+      });
+    });
   });
 
   describe('list', () => {
@@ -27,23 +35,95 @@ describe('Grants', () => {
         },
       });
 
-      expect(apiClient.request).toHaveBeenCalledWith({
-        method: 'GET',
-        path: '/v3/grants',
-        overrides: {
-          apiUri: 'https://test.api.nylas.com',
-          headers: { override: 'bar' },
-        },
-      });
+      expect(apiClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          path: '/v3/grants',
+          overrides: {
+            apiUri: 'https://test.api.nylas.com',
+            headers: { override: 'bar' },
+          },
+        })
+      );
     });
 
     it('should call apiClient.request even without overrides set', async () => {
       await grants.list();
 
-      expect(apiClient.request).toHaveBeenCalledWith({
-        method: 'GET',
-        path: '/v3/grants',
+      expect(apiClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          path: '/v3/grants',
+        })
+      );
+    });
+
+    it('should properly pass queryParams when provided in the first parameter', async () => {
+      await grants.list({
+        queryParams: {
+          limit: 10,
+          offset: 5,
+          provider: 'google',
+        },
       });
+
+      expect(apiClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          path: '/v3/grants',
+          queryParams: {
+            limit: 10,
+            offset: 5,
+            provider: 'google',
+          },
+        })
+      );
+    });
+
+    it('should properly pass both queryParams and overrides when provided', async () => {
+      await grants.list({
+        queryParams: {
+          limit: 20,
+          provider: 'microsoft',
+        },
+        overrides: {
+          apiUri: 'https://custom.api.nylas.com',
+          headers: { custom: 'header' },
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          path: '/v3/grants',
+          queryParams: {
+            limit: 20,
+            provider: 'microsoft',
+          },
+          overrides: {
+            apiUri: 'https://custom.api.nylas.com',
+            headers: { custom: 'header' },
+          },
+        })
+      );
+    });
+
+    it('should support the deprecated _queryParams parameter', async () => {
+      await grants.list({}, {
+        limit: 15,
+        provider: 'imap',
+      } as any);
+
+      expect(apiClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'GET',
+          path: '/v3/grants',
+          queryParams: {
+            limit: 15,
+            provider: 'imap',
+          },
+        })
+      );
     });
   });
 


### PR DESCRIPTION
# Background
List grants method did not follow the same syntax as our other methods, which could have been confusing. This PR fixes it so that the list method takes an object as the first param in which queryParam is an optional property.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.