### PR TITLE
fix: convert override timeout to milliseconds

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -156,7 +156,9 @@ export default class APIClient {
   private async sendRequest(options: RequestOptionsParams): Promise<Response> {
     const req = this.newRequest(options);
     const controller: AbortController = new AbortController();
-    const timeoutDuration = options.overrides?.timeout || this.timeout;
+    const timeoutDuration = options.overrides?.timeout
+      ? options.overrides.timeout * 1000
+      : this.timeout; // timeout is converted to milliseconds in client
     const timeout = setTimeout(() => {
       controller.abort();
     }, timeoutDuration);


### PR DESCRIPTION
Previously, the timeout on the client was converted to milliseconds during initialization, but `overrides.timeout` was used as-is.  PR updates `sendRequest` so that `options.overrides.timeout` is also converted to milliseconds.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.