### PR TITLE
Updated to support the latest changes in the GET notetakers endpoint

### DIFF
--- a/examples/notetakers/notetaker.ts
+++ b/examples/notetakers/notetaker.ts
@@ -9,7 +9,8 @@ import {
   Notetaker,
   NylasResponse, 
   NylasListResponse,
-  NylasApiError
+  NylasApiError,
+  ListNotetakersQueryParams
 } from 'nylas';
 
 // Load environment variables from .env file
@@ -78,9 +79,15 @@ async function listNotetakers(): Promise<NylasListResponse<Notetaker>> {
   console.log('\n=== Listing All Notetakers ===');
   
   try {
-    const notetakers = await nylas.notetakers.list({});
+    // List notetakers ordered by name in ascending order
+    const notetakers = await nylas.notetakers.list({
+      queryParams: {
+        orderBy: 'name',
+        orderDirection: 'asc'
+      }
+    });
     
-    console.log(`Found ${notetakers.data.length} notetakers:`);
+    console.log(`Found ${notetakers.data.length} notetakers (ordered by name):`);
     for (const notetaker of notetakers.data) {
       console.log(`- ${notetaker.name} (ID: ${notetaker.id}, State: ${notetaker.state})`);
     }

--- a/src/models/notetakers.ts
+++ b/src/models/notetakers.ts
@@ -231,14 +231,14 @@ export interface ListNotetakersQueryParams extends ListQueryParams {
   state?: NotetakerState;
 
   /**
-   * Filter for Notetaker bots that are scheduled to join meetings after the specified time, in Unix timestamp format.
+   * Filter for Notetaker bots that have join times that start at or after a specific time, in Unix timestamp format.
    */
-  joinTimeFrom?: number;
+  joinTimeStart?: number;
 
   /**
-   * Filter for Notetaker bots that are scheduled to join meetings until the specified time, in Unix timestamp format.
+   * Filter for Notetaker bots that have join times that end at or are before a specific time, in Unix timestamp format.
    */
-  joinTimeUntil?: number;
+  joinTimeEnd?: number;
 
   /**
    * The maximum number of objects to return.
@@ -257,6 +257,18 @@ export interface ListNotetakersQueryParams extends ListQueryParams {
    * This value should be taken from the prev_cursor response field.
    */
   prevPageToken?: string;
+
+  /**
+   * The field to order the Notetaker bots by.
+   * @default created_at
+   */
+  orderBy?: 'name' | 'join_time' | 'created_at';
+
+  /**
+   * The direction to order the Notetaker bots by.
+   * @default asc
+   */
+  orderDirection?: 'asc' | 'desc';
 }
 
 /**

--- a/tests/resources/notetakers.spec.ts
+++ b/tests/resources/notetakers.spec.ts
@@ -66,8 +66,8 @@ describe('Notetakers', () => {
     it('should support filtering by join time range', async () => {
       await notetakers.list({
         queryParams: {
-          joinTimeFrom: 1683936000,
-          joinTimeUntil: 1684022400,
+          joinTimeStart: 1683936000,
+          joinTimeEnd: 1684022400,
         },
       });
 
@@ -75,8 +75,8 @@ describe('Notetakers', () => {
         method: 'GET',
         path: '/v3/notetakers',
         queryParams: {
-          joinTimeFrom: 1683936000,
-          joinTimeUntil: 1684022400,
+          joinTimeStart: 1683936000,
+          joinTimeEnd: 1684022400,
         },
       });
     });
@@ -119,9 +119,11 @@ describe('Notetakers', () => {
         identifier: 'id123',
         queryParams: {
           state: 'media_processing',
-          joinTimeFrom: 1683936000,
+          joinTimeStart: 1683936000,
           limit: 25,
           pageToken: 'next_page_token',
+          orderBy: 'name',
+          orderDirection: 'desc',
         },
       });
 
@@ -130,9 +132,119 @@ describe('Notetakers', () => {
         path: '/v3/grants/id123/notetakers',
         queryParams: {
           state: 'media_processing',
-          joinTimeFrom: 1683936000,
+          joinTimeStart: 1683936000,
           limit: 25,
           pageToken: 'next_page_token',
+          orderBy: 'name',
+          orderDirection: 'desc',
+        },
+      });
+    });
+
+    it('should support ordering by name', async () => {
+      await notetakers.list({
+        queryParams: {
+          orderBy: 'name',
+          orderDirection: 'asc',
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/notetakers',
+        queryParams: {
+          orderBy: 'name',
+          orderDirection: 'asc',
+        },
+      });
+    });
+
+    it('should use default order direction when not specified', async () => {
+      await notetakers.list({
+        queryParams: {
+          orderBy: 'name',
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/notetakers',
+        queryParams: {
+          orderBy: 'name',
+        },
+      });
+    });
+
+    it('should use default order by when only direction specified', async () => {
+      await notetakers.list({
+        queryParams: {
+          orderDirection: 'desc',
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/notetakers',
+        queryParams: {
+          orderDirection: 'desc',
+        },
+      });
+    });
+
+    it('should support ordering by join_time', async () => {
+      await notetakers.list({
+        queryParams: {
+          orderBy: 'join_time',
+          orderDirection: 'asc',
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/notetakers',
+        queryParams: {
+          orderBy: 'join_time',
+          orderDirection: 'asc',
+        },
+      });
+    });
+
+    it('should support ordering by created_at', async () => {
+      await notetakers.list({
+        queryParams: {
+          orderBy: 'created_at',
+          orderDirection: 'desc',
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/notetakers',
+        queryParams: {
+          orderBy: 'created_at',
+          orderDirection: 'desc',
+        },
+      });
+    });
+
+    it('should support combining ordering with other filters', async () => {
+      await notetakers.list({
+        queryParams: {
+          state: 'attending',
+          joinTimeStart: 1683936000,
+          orderBy: 'name',
+          orderDirection: 'desc',
+        },
+      });
+
+      expect(apiClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/notetakers',
+        queryParams: {
+          state: 'attending',
+          joinTimeStart: 1683936000,
+          orderBy: 'name',
+          orderDirection: 'desc',
         },
       });
     });


### PR DESCRIPTION
# What did you do?
- [x] Renamed GET notetaker query params `join_time_from` and  `join_time_until` to `join_time_start` and `join_time_end`
- [x] Added support for  GET notetaker query params `orderDirection` and `orderBy`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.