### PR TITLE
Release v7.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-### Unreleased
+# Changelog
+### 7.9.0 / 2025-04-30
 * Add support for Notetaker API endpoints
 * Update calendar and event models with notetaker settings
 * Add support for `tentativeAsBusy` parameter in availability and event listing
-
-# Changelog
 
 ### 7.8.0 / 2025-03-03
 * Add support for `listImportEvents` method to import events from a specified calendar within a given time frame


### PR DESCRIPTION
# Changelog
- [x] Add support for Notetaker API endpoints
- [x] Update calendar and event models with notetaker settings
- [x] Add support for `tentativeAsBusy` parameter in availability and event listing

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.