### PR TITLE
fix: Add missing /cancel suffix in Notetaker API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+### Unreleased
+* Fix: Add missing `/cancel` suffix in Notetaker API endpoint
+
 ### 7.9.0 / 2025-04-30
 * Add support for Notetaker API endpoints
 * Update calendar and event models with notetaker settings

--- a/src/resources/notetakers.ts
+++ b/src/resources/notetakers.ts
@@ -172,8 +172,8 @@ export class Notetakers extends Resource {
   }: CancelNotetakerParams & Overrides): Promise<NylasBaseResponse> {
     return this._destroy({
       path: identifier
-        ? `/v3/grants/${identifier}/notetakers/${notetakerId}`
-        : `/v3/notetakers/${notetakerId}`,
+        ? `/v3/grants/${identifier}/notetakers/${notetakerId}/cancel`
+        : `/v3/notetakers/${notetakerId}/cancel`,
       overrides,
     });
   }

--- a/tests/resources/notetakers.spec.ts
+++ b/tests/resources/notetakers.spec.ts
@@ -425,7 +425,7 @@ describe('Notetakers', () => {
 
       expect(apiClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v3/grants/id123/notetakers/notetaker123',
+        path: '/v3/grants/id123/notetakers/notetaker123/cancel',
       });
     });
 
@@ -441,7 +441,7 @@ describe('Notetakers', () => {
 
       expect(apiClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v3/grants/id123/notetakers/notetaker123',
+        path: '/v3/grants/id123/notetakers/notetaker123/cancel',
         overrides: {
           apiUri: 'https://test.api.nylas.com',
           headers: { override: 'bar' },
@@ -456,7 +456,7 @@ describe('Notetakers', () => {
 
       expect(apiClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v3/notetakers/notetaker123',
+        path: '/v3/notetakers/notetaker123/cancel',
       });
     });
   });


### PR DESCRIPTION
# What did you do?
Fixes #638 - Adds the missing /cancel suffix to the Notetaker API endpoint that was introduced in v7.9.0

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.