### PR TITLE
feat: add zoom as a supported provider type in Auth module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### Unreleased
+* Add support for 'zoom' as a provider type in Auth module
+
 ### 7.9.0 / 2025-04-30
 * Add support for Notetaker API endpoints
 * Update calendar and event models with notetaker settings

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -12,7 +12,8 @@ export type Provider =
   | 'microsoft'
   | 'icloud'
   | 'virtual-calendar'
-  | 'ews';
+  | 'ews'
+  | 'zoom';
 
 /**
  * Configuration for generating a URL for OAuth 2.0 authentication.

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -188,6 +188,20 @@ describe('Auth', () => {
         );
       });
 
+      it('should support zoom as a provider', () => {
+        const url = auth.urlForOAuth2({
+          clientId: 'clientId',
+          redirectUri: 'https://redirect.uri/path',
+          scope: ['calendar'],
+          provider: 'zoom',
+          includeGrantScopes: true,
+        });
+
+        expect(url).toBe(
+          'https://test.api.nylas.com/v3/connect/auth?client_id=clientId&redirect_uri=https%3A%2F%2Fredirect.uri%2Fpath&access_type=online&response_type=code&provider=zoom&include_grant_scopes=true&scope=calendar'
+        );
+      });
+
       it('should build the correct url if all the fields are set', () => {
         const url = auth.urlForOAuth2({
           clientId: 'clientId',


### PR DESCRIPTION
# What did you do?

- Add 'zoom' to Provider type in auth.ts to fix [#630](https://github.com/nylas/nylas-nodejs/issues/630)

- Add test to verify zoom provider support

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.