### PR TITLE
fix: update event status type to use 'maybe' instead of 'tentative'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### Unreleased
+* Fix event status type to use 'maybe' instead of 'tentative' in Event interface to match API documentation
+
 ### 7.9.0 / 2025-04-30
 * Add support for Notetaker API endpoints
 * Update calendar and event models with notetaker settings

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -396,7 +396,7 @@ export interface ListImportEventQueryParams extends ListQueryParams {
 /**
  * Enum representing the status of an event.
  */
-type Status = 'confirmed' | 'tentative' | 'cancelled';
+type Status = 'confirmed' | 'maybe' | 'cancelled';
 
 /**
  * Enum representing the status of an RSVP response.


### PR DESCRIPTION
# What did you do?
The event status type in the Event interface was incorrectly using 'tentative' instead of 'maybe' as one of its possible values. This change updates the type to match the API documentation.

Changes:
- Update Status type to use 'maybe' instead of 'tentative'
- Update CHANGELOG.md

Fixes #626

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.