### PR TITLE
feat(api): expose raw response headers on all responses via non-enumerable rawHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Jest configuration to properly handle ESM modules from node-fetch v3
 - Removed incompatible AbortSignal import from node-fetch externals (now uses native Node.js AbortSignal)
 
+### Added
+- Expose raw response headers on all responses via non-enumerable `rawHeaders` while keeping existing `headers` camelCased
+
 ## [7.11.0] - 2025-06-23
 
 ### Added

--- a/examples/messages/README.md
+++ b/examples/messages/README.md
@@ -21,6 +21,15 @@ The file is structured with:
 ### Basic Messages (`messages.ts`)
 Shows basic message operations including reading, sending, and drafting messages.
 
+### Accessing Rate Limit Headers
+All SDK responses now expose a non-enumerable `rawHeaders` with dashed lowercase keys so you can read rate limit information:
+
+```ts
+const res = await nylas.messages.list({ identifier: process.env.NYLAS_GRANT_ID!, queryParams: { limit: 1 } });
+const limit = res.rawHeaders?.['x-rate-limit-limit'];
+const remaining = res.rawHeaders?.['x-rate-limit-remaining'];
+```
+
 ## Quick Start
 
 ### 1. Set up environment

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -288,11 +288,22 @@ export default class APIClient {
     const text = await response.text();
 
     try {
-      const responseJSON = JSON.parse(text);
-      // Inject the flow ID and headers into the response
-      responseJSON.flowId = flowId;
-      responseJSON.headers = headers;
-      return objKeysToCamelCase(responseJSON, ['metadata']);
+      const parsed = JSON.parse(text);
+      const payload = objKeysToCamelCase(
+        {
+          ...parsed,
+          flowId,
+          // deprecated: headers will be removed in a future release. This is for backwards compatibility.
+          headers,
+        },
+        ['metadata']
+      );
+      // Attach rawHeaders as a non-enumerable property to avoid breaking deep equality
+      Object.defineProperty(payload, 'rawHeaders', {
+        value: headers,
+        enumerable: false,
+      });
+      return payload;
     } catch (e) {
       throw new Error(`Could not parse response from the server: ${text}`);
     }

--- a/src/models/response.ts
+++ b/src/models/response.ts
@@ -10,6 +10,7 @@ export interface NylasBaseResponse {
   flowId?: string;
   /**
    * The response headers with camelCased keys (backwards compatible)
+   * @deprecated Use rawHeaders instead
    */
   headers?: Record<string, string>;
   /**
@@ -37,6 +38,7 @@ export interface NylasResponse<T> {
   flowId?: string;
   /**
    * The response headers
+   * @deprecated Use rawHeaders instead
    */
   headers?: Record<string, string>;
   /**
@@ -68,6 +70,7 @@ export interface NylasListResponse<T> {
   flowId?: string;
   /**
    * The response headers with camelCased keys (backwards compatible)
+   * @deprecated Use rawHeaders instead
    */
   headers?: Record<string, string>;
   /**

--- a/src/models/response.ts
+++ b/src/models/response.ts
@@ -3,6 +3,19 @@
  */
 export interface NylasBaseResponse {
   requestId: string;
+  /**
+   * The flow ID
+   * Provide this to Nylas support to help trace requests and responses
+   */
+  flowId?: string;
+  /**
+   * The response headers with camelCased keys (backwards compatible)
+   */
+  headers?: Record<string, string>;
+  /**
+   * The raw response headers with original dashed lowercase keys
+   */
+  rawHeaders?: Record<string, string>;
 }
 
 /**
@@ -26,6 +39,10 @@ export interface NylasResponse<T> {
    * The response headers
    */
   headers?: Record<string, string>;
+  /**
+   * The raw response headers with original dashed lowercase keys
+   */
+  rawHeaders?: Record<string, string>;
 }
 
 /**
@@ -44,6 +61,19 @@ export interface NylasListResponse<T> {
    * The cursor to use to get the next page of data.
    */
   nextCursor?: string;
+  /**
+   * The flow ID
+   * Provide this to Nylas support to help trace requests and responses
+   */
+  flowId?: string;
+  /**
+   * The response headers with camelCased keys (backwards compatible)
+   */
+  headers?: Record<string, string>;
+  /**
+   * The raw response headers with original dashed lowercase keys
+   */
+  rawHeaders?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
# What did you do?
- add tests for rawHeaders on responses
- update response models to include rawHeaders
- attach rawHeaders in API client without breaking equality

Addresses https://github.com/nylas/nylas-nodejs/issues/659

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.