### PR TITLE
feat(messages,drafts): support isPlaintext for messages.send and drafts.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support `isPlaintext` boolean for messages send and drafts create requests
+- Expose raw response headers on all responses via non-enumerable `rawHeaders` while keeping existing `headers` camelCased
+
+## [7.12.0] - 2025-08-01
+
 ### Changed
 - Upgraded node-fetch from v2 to v3 for better ESM support and compatibility with edge environments
 
@@ -15,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Jest configuration to properly handle ESM modules from node-fetch v3
 - Removed incompatible AbortSignal import from node-fetch externals (now uses native Node.js AbortSignal)
 
-### Added
-- Expose raw response headers on all responses via non-enumerable `rawHeaders` while keeping existing `headers` camelCased
 
 ## [7.11.0] - 2025-06-23
 

--- a/examples/messages/examples/buffer-attachments.ts
+++ b/examples/messages/examples/buffer-attachments.ts
@@ -21,7 +21,7 @@ const grantId: string = process.env.NYLAS_GRANT_ID || '';
  * Loads the entire file into memory as a Buffer.
  * Good for small files or when you need to process content.
  */
-export async function sendBufferAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false): Promise<NylasResponse<Message>> {
+export async function sendBufferAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false, isPlaintext: boolean = false): Promise<NylasResponse<Message>> {
   console.log('💾 Sending attachments using buffers...');
   
   let sizeDescription;
@@ -48,12 +48,15 @@ export async function sendBufferAttachments(fileManager: TestFileManager, recipi
   const requestBody: SendMessageRequest = {
     to: [{ name: 'Test Recipient', email: recipientEmail }],
     subject: 'Nylas SDK - Buffer Attachments',
-    body: `
+    body: isPlaintext
+      ? 'Buffer Attachments Example\nThis demonstrates sending attachments using Node.js Buffer objects.'
+      : `
       <h2>Buffer Attachments Example</h2>
       <p>This demonstrates sending attachments using Node.js Buffer objects.</p>
       <p>Good for small files when you need the content in memory.</p>
     `,
-    attachments: bufferAttachments
+    attachments: bufferAttachments,
+    isPlaintext
   };
   
   // For large files, use a longer timeout (5 minutes)

--- a/examples/messages/examples/file-path-attachments.ts
+++ b/examples/messages/examples/file-path-attachments.ts
@@ -21,7 +21,7 @@ const grantId: string = process.env.NYLAS_GRANT_ID || '';
  * This is the recommended approach for most use cases.
  * Uses streams internally for memory efficiency.
  */
-export async function sendFilePathAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false): Promise<NylasResponse<Message>> {
+export async function sendFilePathAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false, isPlaintext: boolean = false): Promise<NylasResponse<Message>> {
   console.log('📁 Sending attachments using file paths...');
   
   let attachments;
@@ -42,13 +42,16 @@ export async function sendFilePathAttachments(fileManager: TestFileManager, reci
   const requestBody: SendMessageRequest = {
     to: [{ name: 'Test Recipient', email: recipientEmail }],
     subject: `Nylas SDK - File Path Attachments (${sizeDescription})`,
-    body: `
+    body: isPlaintext
+      ? `File Path Attachments Example\nThis demonstrates sending attachments using file paths.\nAttachment size: ${sizeDescription} (${attachments.length} file${attachments.length > 1 ? 's' : ''})`
+      : `
       <h2>File Path Attachments Example</h2>
       <p>This demonstrates the most common way to send attachments using file paths.</p>
       <p>The SDK uses streams internally for memory efficiency.</p>
       <p>Attachment size: ${sizeDescription} (${attachments.length} file${attachments.length > 1 ? 's' : ''})</p>
     `,
-    attachments
+    attachments,
+    isPlaintext
   };
 
   // For large files, use a longer timeout (5 minutes)

--- a/examples/messages/examples/flexible-attachments.ts
+++ b/examples/messages/examples/flexible-attachments.ts
@@ -18,7 +18,7 @@ const grantId: string = process.env.NYLAS_GRANT_ID || '';
 /**
  * Flexible attachment sending based on format choice
  */
-export async function sendAttachmentsByFormat(fileManager: TestFileManager, format: FileFormat, recipientEmail: string, attachmentSize: 'small' | 'large' = 'small'): Promise<NylasResponse<Message>> {
+export async function sendAttachmentsByFormat(fileManager: TestFileManager, format: FileFormat, recipientEmail: string, attachmentSize: 'small' | 'large' = 'small', isPlaintext: boolean = false): Promise<NylasResponse<Message>> {
   
   let attachments: CreateAttachmentRequest[] = [];
   let subject: string;
@@ -40,7 +40,9 @@ export async function sendAttachmentsByFormat(fileManager: TestFileManager, form
   const requestBody: SendMessageRequest = {
     to: [{ name: 'Test Recipient', email: recipientEmail }],
     subject,
-    body: `
+    body: isPlaintext
+      ? `Attachment Format Test: ${format}\nThis message demonstrates sending attachments using the ${format} format.\nFiles attached: ${attachments.length}`
+      : `
       <h2>Attachment Format Test: ${format}</h2>
       <p>This message demonstrates sending attachments using the ${format} format.</p>
       <p>Files attached: ${attachments.length}</p>
@@ -48,7 +50,8 @@ export async function sendAttachmentsByFormat(fileManager: TestFileManager, form
         ${attachments.map(att => `<li>${att.filename} (${att.size} bytes)</li>`).join('')}
       </ul>
     `,
-    attachments
+    attachments,
+    isPlaintext
   };
   
   // For large files, use a longer timeout (5 minutes)

--- a/examples/messages/examples/index.ts
+++ b/examples/messages/examples/index.ts
@@ -5,9 +5,9 @@ import { sendStringAttachments } from './string-attachments';
 import { sendAttachmentsByFormat } from './flexible-attachments';
 
 export type SendAttachmentsExamples = {
-  sendFilePathAttachments: typeof sendFilePathAttachments,
-  sendStreamAttachments: typeof sendStreamAttachments,
-  sendBufferAttachments: typeof sendBufferAttachments,
-  sendStringAttachments: typeof sendStringAttachments,
-  sendAttachmentsByFormat: typeof sendAttachmentsByFormat
+  sendFilePathAttachments: (fileManager: Parameters<typeof sendFilePathAttachments>[0], recipientEmail: string, large?: boolean, isPlaintext?: boolean) => ReturnType<typeof sendFilePathAttachments>,
+  sendStreamAttachments: (fileManager: Parameters<typeof sendStreamAttachments>[0], recipientEmail: string, large?: boolean, isPlaintext?: boolean) => ReturnType<typeof sendStreamAttachments>,
+  sendBufferAttachments: (fileManager: Parameters<typeof sendBufferAttachments>[0], recipientEmail: string, large?: boolean, isPlaintext?: boolean) => ReturnType<typeof sendBufferAttachments>,
+  sendStringAttachments: (fileManager: Parameters<typeof sendStringAttachments>[0], recipientEmail: string, large?: boolean, isPlaintext?: boolean) => ReturnType<typeof sendStringAttachments>,
+  sendAttachmentsByFormat: (fileManager: Parameters<typeof sendAttachmentsByFormat>[0], format: Parameters<typeof sendAttachmentsByFormat>[1], recipientEmail: string, attachmentSize?: Parameters<typeof sendAttachmentsByFormat>[3], isPlaintext?: boolean) => ReturnType<typeof sendAttachmentsByFormat>
 };

--- a/examples/messages/examples/stream-attachments.ts
+++ b/examples/messages/examples/stream-attachments.ts
@@ -21,7 +21,7 @@ const grantId: string = process.env.NYLAS_GRANT_ID || '';
  * Useful when you're working with streams from other sources
  * or need more control over the stream processing.
  */
-export async function sendStreamAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false): Promise<NylasResponse<Message>> {
+export async function sendStreamAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false, isPlaintext: boolean = false): Promise<NylasResponse<Message>> {
   console.log('🌊 Sending attachments using streams...');
   
   let attachments: CreateAttachmentRequest[] = [];
@@ -52,13 +52,16 @@ export async function sendStreamAttachments(fileManager: TestFileManager, recipi
   const requestBody: SendMessageRequest = {
     to: [{ name: 'Test Recipient', email: recipientEmail }],
     subject: `Nylas SDK - Stream Attachments (${sizeDescription})`,
-    body: `
+    body: isPlaintext
+      ? `Stream Attachments Example\nThis demonstrates sending attachments using readable streams.\nAttachment size: ${sizeDescription} (${attachments.length} file${attachments.length > 1 ? 's' : ''})`
+      : `
       <h2>Stream Attachments Example</h2>
       <p>This demonstrates sending attachments using readable streams.</p>
       <p>Useful when you have streams from other sources.</p>
       <p>Attachment size: ${sizeDescription} (${attachments.length} file${attachments.length > 1 ? 's' : ''})</p>
     `,
-    attachments
+    attachments,
+    isPlaintext
   };
   
   // For large files, use a longer timeout (5 minutes)

--- a/examples/messages/examples/string-attachments.ts
+++ b/examples/messages/examples/string-attachments.ts
@@ -21,7 +21,7 @@ const grantId: string = process.env.NYLAS_GRANT_ID || '';
  * Perfect for sending existing files as base64 encoded strings.
  * This example pulls the same files used by other examples but encodes them as base64 strings.
  */
-export async function sendStringAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false): Promise<NylasResponse<Message>> {
+export async function sendStringAttachments(fileManager: TestFileManager, recipientEmail: string, large: boolean = false, isPlaintext: boolean = false): Promise<NylasResponse<Message>> {
   console.log('📝 Sending base64 encoded file attachments as strings...');
   
   let stringAttachments: CreateAttachmentRequest[] = [];
@@ -75,7 +75,9 @@ export async function sendStringAttachments(fileManager: TestFileManager, recipi
   const requestBody: SendMessageRequest = {
     to: [{ name: 'Test Recipient', email: recipientEmail }],
     subject: `Nylas SDK - Base64 String Attachments (${sizeDescription})`,
-    body: `
+    body: isPlaintext
+      ? `Base64 String Attachments Example\nThis demonstrates sending existing files as base64 encoded strings.\nAttachment size: ${sizeDescription} (${stringAttachments.length} file${stringAttachments.length > 1 ? 's' : ''})`
+      : `
       <h2>Base64 String Attachments Example</h2>
       <p>This demonstrates sending existing files as base64 encoded strings.</p>
       <p>Files are converted from the same test files used in other examples.</p>
@@ -84,7 +86,8 @@ export async function sendStringAttachments(fileManager: TestFileManager, recipi
         ${stringAttachments.map(att => `<li>${att.filename} (${att.size} bytes base64 encoded)</li>`).join('')}
       </ul>
     `,
-    attachments: stringAttachments
+    attachments: stringAttachments,
+    isPlaintext
   };
   
   // For large files, use a longer timeout (5 minutes)

--- a/examples/messages/messages.ts
+++ b/examples/messages/messages.ts
@@ -244,6 +244,47 @@ async function demonstrateMessageSending(): Promise<NylasResponse<Message> | nul
 }
 
 /**
+ * Demonstrates sending a plaintext-only message (no attachments)
+ */
+async function demonstratePlaintextMessageSending(): Promise<NylasResponse<Message> | null> {
+  console.log('\n=== Demonstrating Plaintext Message Sending ===');
+  try {
+    const testEmail = process.env.TEST_EMAIL;
+    if (!testEmail) {
+      console.log('TEST_EMAIL environment variable not set. Skipping plaintext message sending demo.');
+      return null;
+    }
+
+    const requestBody: SendMessageRequest = {
+      to: [{ name: 'Plaintext Recipient', email: testEmail }],
+      subject: 'Nylas SDK Messages Example - Plaintext',
+      body: 'This message is sent as plain text only.',
+      isPlaintext: true,
+    };
+
+    const sentMessage = await nylas.messages.send({
+      identifier: grantId,
+      requestBody,
+    });
+
+    console.log('Plaintext message sent successfully!');
+    console.log(`- Message ID: ${sentMessage.data.id}`);
+    console.log(`- Subject: ${sentMessage.data.subject}`);
+    console.log(`- To: ${sentMessage.data.to?.map(t => `${t.name} <${t.email}>`).join(', ')}`);
+
+    return sentMessage;
+  } catch (error) {
+    if (error instanceof NylasApiError) {
+      console.error(`Error sending plaintext message: ${error.message}`);
+      console.error(`Error details: ${JSON.stringify(error, null, 2)}`);
+    } else if (error instanceof Error) {
+      console.error(`Unexpected error in demonstratePlaintextMessageSending: ${error.message}`);
+    }
+    return null;
+  }
+}
+
+/**
  * Demonstrates updating a message
  */
 async function demonstrateMessageUpdate(messageId: string): Promise<void> {
@@ -464,6 +505,7 @@ async function main(): Promise<void> {
     
     // Run all demonstrations
     await demonstrateMessageFields();
+    await demonstratePlaintextMessageSending();
     await demonstrateRawMime();
     await demonstrateMessageQuerying();
     

--- a/src/models/drafts.ts
+++ b/src/models/drafts.ts
@@ -71,6 +71,11 @@ export interface CreateDraftRequest {
    * An array of custom headers to add to the message.
    */
   customHeaders?: CustomHeader[];
+  /**
+   * When true, the message body is sent as plain text and the MIME data doesn't include the HTML version of the message.
+   * When false, the message body is sent as HTML. Defaults to false.
+   */
+  isPlaintext?: boolean;
 }
 
 /**
@@ -103,7 +108,10 @@ export interface Draft
 /**
  * Interface representing a request to update a draft.
  */
-export type UpdateDraftRequest = Partial<CreateDraftRequest> & {
+export type UpdateDraftRequest = Omit<
+  Partial<CreateDraftRequest>,
+  'isPlaintext'
+> & {
   /**
    * Return drafts that are unread.
    */

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -509,6 +509,61 @@ describe('Messages', () => {
       expect(capturedRequest.method).toEqual('POST');
       expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
     });
+
+    it('should include isPlaintext in JSON body when provided', async () => {
+      const jsonBody = {
+        to: [{ name: 'Test', email: 'test@example.com' }],
+        subject: 'Plain text email',
+        body: 'Hello world',
+        isPlaintext: true,
+      };
+
+      await messages.send({
+        identifier: 'id123',
+        requestBody: jsonBody,
+      });
+
+      const capturedRequest = apiClient.request.mock.calls[0][0];
+      expect(capturedRequest.method).toEqual('POST');
+      expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
+      expect(capturedRequest.body).toEqual(jsonBody);
+    });
+
+    it('should include isPlaintext in multipart form message when provided', async () => {
+      const messageJson = {
+        to: [{ name: 'Test', email: 'test@example.com' }],
+        subject: 'Plain text email',
+        body: 'Hello world',
+        isPlaintext: true,
+      };
+      const fileStream = createReadableStream('This is the text from file 1');
+      const file1: CreateAttachmentRequest = {
+        filename: 'file1.txt',
+        contentType: 'text/plain',
+        content: fileStream,
+        size: 3 * 1024 * 1024,
+      };
+
+      await messages.send({
+        identifier: 'id123',
+        requestBody: {
+          ...messageJson,
+          attachments: [file1],
+        },
+      });
+
+      const capturedRequest = apiClient.request.mock.calls[0][0];
+      const formData = (
+        capturedRequest.form as any as MockedFormData
+      )._getAppendedData();
+      const parsed = JSON.parse(formData.message);
+      expect(parsed.to).toEqual(messageJson.to);
+      expect(parsed.subject).toEqual(messageJson.subject);
+      expect(parsed.body).toEqual(messageJson.body);
+      expect(parsed.is_plaintext).toBe(true);
+      expect(capturedRequest.method).toEqual('POST');
+      expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
+    });
   });
 
   describe('scheduledMessages', () => {


### PR DESCRIPTION
# What did you do?
- Added support for `is_plaintext` for `POST /send` and `POST /drafts` endpoints.
- Fixed the CHANGELOG.md, we forgot to add `7.12.0`  and kept it as `Unreleased`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.