### PR TITLE
fix(events): make Participant.email optional to match API behaviour (#670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Make `Participant.email` optional in `Event` model to match API behavior ([#670](https://github.com/nylas/nylas-nodejs/issues/670))
+
 ## [7.13.1] - 2025-09-18
 
 ### Fixed

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -609,7 +609,7 @@ export interface Participant {
   /**
    * Participant's email address.
    */
-  email: string;
+  email?: string;
   /**
    * Participant's name.
    */


### PR DESCRIPTION
# What did you do?
- [x] make Participant.email optional to match API behaviour

<!-- Add information about your PR here -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.