### PR TITLE
[TW-4820] chore: prepare v8.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.4] - 2026-03-18
+
+### Added
+- Add `specificTimeAvailability` support to calendars availability POST API ([#716](https://github.com/nylas/nylas-nodejs/pull/716))
+
 ## [8.0.3] - 2026-03-17
 
 ### Added


### PR DESCRIPTION
## v8.0.4 (2026-03-18)

### Added
- Add `specificTimeAvailability` support to calendars availability POST API ([#716](https://github.com/nylas/nylas-nodejs/pull/716)) - @<commit-author>