### PR TITLE
fix: preserve metadata key casing in multipart form-data requests

### DIFF
--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -354,7 +354,10 @@ export class Messages extends Resource {
       ...requestBody,
       attachments: undefined,
     };
-    form.append('message', JSON.stringify(objKeysToSnakeCase(messagePayload)));
+    form.append(
+      'message',
+      JSON.stringify(objKeysToSnakeCase(messagePayload, ['metadata']))
+    );
 
     // Add a separate form field for each attachment
     if (requestBody.attachments && requestBody.attachments.length > 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -285,7 +285,7 @@ export function calculateTotalPayloadSize(requestBody: any): number {
     attachments: undefined,
   };
   const messagePayloadString = JSON.stringify(
-    objKeysToSnakeCase(messagePayloadWithoutAttachments)
+    objKeysToSnakeCase(messagePayloadWithoutAttachments, ['metadata'])
   );
   totalSize += Buffer.byteLength(messagePayloadString, 'utf8');
 

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -473,6 +473,46 @@ describe('Messages', () => {
       expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
     });
 
+    it('should preserve metadata key casing in multipart form request', async () => {
+      const largeBody = 'A'.repeat(3.5 * 1024 * 1024);
+      const metadata = {
+        myCustomKey: 'value1',
+        anotherCamelCase: 'value2',
+      };
+
+      const fileStream = createReadableStream('attachment content');
+      const attachment: CreateAttachmentRequest = {
+        filename: 'file.txt',
+        contentType: 'text/plain',
+        content: fileStream,
+        size: 1000,
+      };
+
+      await messages.send({
+        identifier: 'id123',
+        requestBody: {
+          to: [{ name: 'Test', email: 'test@example.com' }],
+          subject: 'Test',
+          body: largeBody,
+          metadata,
+          attachments: [attachment],
+        } as any,
+      });
+
+      const capturedRequest = apiClient.request.mock.calls[0][0];
+      expect(capturedRequest.form).toBeDefined();
+
+      const formData = (
+        capturedRequest.form as any as MockedFormData
+      )._getAppendedData();
+      const parsedMessage = JSON.parse(formData.message);
+
+      expect(parsedMessage.metadata).toEqual({
+        myCustomKey: 'value1',
+        anotherCamelCase: 'value2',
+      });
+    });
+
     it('should use JSON when total payload (body + attachments) is under 3MB', async () => {
       // Create a message with body + attachments under 3MB
       const smallBody = 'Small message content';


### PR DESCRIPTION
<!-- Add information about your PR here -->

When sending messages with a total payload >= 3MB, the SDK switches from JSON to multipart/form-data serialization. The form-data path in `_buildFormRequest()` was calling `objKeysToSnakeCase()` without excluding the `metadata` field, causing metadata keys like `myCustomKey` to be silently converted to `my_custom_key`. The JSON path in `apiClient.ts` already correctly excluded metadata from case conversion.

This fix adds the `['metadata']` exclusion to both `_buildFormRequest()` and `calculateTotalPayloadSize()`, making metadata handling consistent across all serialization paths (messages, drafts create/update).

Includes a regression test that verifies camelCase metadata keys survive the multipart serialization path unchanged.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.