### PR TITLE
[TW-4918] Improve attachment download stream developer experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add `attachments.downloadNodeStream()` as a Node.js convenience helper for converting attachment downloads to `NodeJS.ReadableStream`.
+
+### Fixed
+- Update `attachments.download()` documentation to describe its Web `ReadableStream<Uint8Array>` return type.
+
 ## [8.1.1] - 2026-05-08
 
 ### Fixed

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -8,7 +8,7 @@ import { objKeysToCamelCase, objKeysToSnakeCase } from './utils.js';
 import { SDK_VERSION } from './version.js';
 import { FormData } from 'formdata-node';
 import { FormDataEncoder } from 'form-data-encoder';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { snakeCase } from 'change-case';
 
 /**

--- a/src/resources/attachments.ts
+++ b/src/resources/attachments.ts
@@ -10,6 +10,8 @@ import {
 import { NylasResponse } from '../models/response.js';
 import { makePathParams } from '../utils.js';
 import { Resource } from './resource.js';
+import { Readable } from 'stream';
+import type { ReadableStream as NodeReadableStream } from 'stream/web';
 
 /**
  * @property identifier The ID of the grant to act upon. Use "me" to refer to the grant associated with an access token.
@@ -106,6 +108,35 @@ export class Attachments extends Resource {
       queryParams,
       overrides,
     });
+  }
+
+  /**
+   * Download the attachment data as a Node.js readable stream.
+   *
+   * This is a Node.js convenience wrapper around {@link Attachments.download}. Use
+   * {@link Attachments.download} directly in Fetch-native runtimes, such as Cloudflare Workers,
+   * where Web ReadableStreams are the standard stream primitive.
+   *
+   * @param identifier Grant ID or email account to query
+   * @param attachmentId The id of the attachment to download.
+   * @param queryParams The query parameters to include in the request
+   * @returns {NodeJS.ReadableStream} The Node.js readable stream containing the file data.
+   */
+  public async downloadNodeStream({
+    identifier,
+    attachmentId,
+    queryParams,
+    overrides,
+  }: DownloadAttachmentParams & Overrides): Promise<NodeJS.ReadableStream> {
+    const stream = await this.download({
+      identifier,
+      attachmentId,
+      queryParams,
+      overrides,
+    });
+    return Readable.fromWeb(
+      stream as unknown as NodeReadableStream<Uint8Array>
+    );
   }
 
   /**

--- a/src/resources/attachments.ts
+++ b/src/resources/attachments.ts
@@ -10,7 +10,6 @@ import {
 import { NylasResponse } from '../models/response.js';
 import { makePathParams } from '../utils.js';
 import { Resource } from './resource.js';
-import { Readable } from 'stream';
 import type { ReadableStream as NodeReadableStream } from 'stream/web';
 
 /**
@@ -134,6 +133,7 @@ export class Attachments extends Resource {
       queryParams,
       overrides,
     });
+    const { Readable } = await import('stream');
     return Readable.fromWeb(
       stream as unknown as NodeReadableStream<Uint8Array>
     );

--- a/src/resources/attachments.ts
+++ b/src/resources/attachments.ts
@@ -80,15 +80,15 @@ export class Attachments extends Resource {
   /**
    * Download the attachment data
    *
-   * This method returns a NodeJS.ReadableStream which can be used to stream the attachment data.
+   * This method returns a Web ReadableStream which can be used to stream the attachment data.
    * This is particularly useful for handling large attachments efficiently, as it avoids loading
-   * the entire file into memory. The stream can be piped to a file stream or used in any other way
-   * that Node.js streams are typically used.
+   * the entire file into memory. In Node.js, convert it with Readable.fromWeb() when a
+   * NodeJS.ReadableStream is required.
    *
    * @param identifier Grant ID or email account to query
    * @param attachmentId The id of the attachment to download.
    * @param queryParams The query parameters to include in the request
-   * @returns {NodeJS.ReadableStream} The ReadableStream containing the file data.
+   * @returns {ReadableStream<Uint8Array>} The ReadableStream containing the file data.
    */
   public download({
     identifier,

--- a/src/resources/attachments.ts
+++ b/src/resources/attachments.ts
@@ -10,7 +10,8 @@ import {
 import { NylasResponse } from '../models/response.js';
 import { makePathParams } from '../utils.js';
 import { Resource } from './resource.js';
-import type { ReadableStream as NodeReadableStream } from 'stream/web';
+import { Readable } from 'node:stream';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
 /**
  * @property identifier The ID of the grant to act upon. Use "me" to refer to the grant associated with an access token.
@@ -133,7 +134,6 @@ export class Attachments extends Resource {
       queryParams,
       overrides,
     });
-    const { Readable } = await import('stream');
     return Readable.fromWeb(
       stream as unknown as NodeReadableStream<Uint8Array>
     );

--- a/tests/resources/attachments.spec.ts
+++ b/tests/resources/attachments.spec.ts
@@ -1,5 +1,6 @@
 import APIClient from '../../src/apiClient';
 import { Attachments } from '../../src/resources/attachments';
+import { Readable } from 'stream';
 jest.mock('../../src/apiClient');
 
 describe('Attachments', () => {
@@ -185,6 +186,64 @@ describe('Attachments', () => {
       await attachments.download({
         identifier: 'id%20123',
         attachmentId: 'attach%2F123',
+        queryParams: { messageId: 'message123' },
+        overrides: {},
+      });
+      expect(apiClient.requestStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/v3/grants/id%20123/attachments/attach%2F123/download',
+        })
+      );
+    });
+  });
+
+  describe('downloadNodeStream', () => {
+    it('should convert the downloaded Web ReadableStream into a Node.js readable stream', async () => {
+      apiClient.requestStream.mockResolvedValueOnce(
+        new ReadableStream({
+          start(controller: ReadableStreamDefaultController<Uint8Array>): void {
+            controller.enqueue(new Uint8Array([1, 2, 3]));
+            controller.close();
+          },
+        })
+      );
+
+      const stream = await attachments.downloadNodeStream({
+        identifier: 'id123',
+        attachmentId: 'attach123',
+        queryParams: {
+          messageId: 'message123',
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+        chunks.push(Buffer.from(chunk));
+      }
+
+      expect(stream).toBeInstanceOf(Readable);
+      expect(Buffer.concat(chunks)).toEqual(Buffer.from([1, 2, 3]));
+      expect(apiClient.requestStream).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/v3/grants/id123/attachments/attach123/download',
+        queryParams: {
+          messageId: 'message123',
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+    });
+
+    it('should URL encode identifier and attachmentId in downloadNodeStream', async () => {
+      await attachments.downloadNodeStream({
+        identifier: 'id 123',
+        attachmentId: 'attach/123',
         queryParams: { messageId: 'message123' },
         overrides: {},
       });


### PR DESCRIPTION
## Summary
- add attachments.downloadNodeStream() as a non-breaking Node.js convenience helper that converts attachment downloads to NodeJS.ReadableStream
- keep attachments.download() returning Web ReadableStream<Uint8Array> for Fetch-native runtimes such as Cloudflare Workers
- use explicit node:stream imports for Node built-ins, consistent with the SDK's existing Cloudflare Workers requirement for nodejs_compat
- update attachments.download() JSDoc to describe the actual Web Stream return type
- add attachment resource tests for the Node stream helper
- add an Unreleased CHANGELOG entry

## Jira
- [TW-4918](https://nylas.atlassian.net/browse/TW-4918)

## Why
The v8 native Fetch migration changed Response.body to the Web Streams API. That is the right cross-runtime primitive, but Node.js production apps commonly need Node streams for pipeline(), file writes, S3 uploads, and HTTP response streaming. This PR preserves the existing API while adding an explicit Node-friendly path.

The SDK already requires Cloudflare Workers deployments to enable nodejs_compat, as shown by the existing Workers examples and top-level Node built-in usage in the SDK. Using node:stream is therefore explicit and consistent rather than introducing a new compatibility requirement.

## Validation
- npm test -- attachments.spec.ts --coverage=false
- npm run build
- npm run lint -- --quiet

Note: npm test -- attachments.spec.ts passes the attachment suite, but exits nonzero when coverage is enabled because this repo enforces global coverage thresholds for focused test runs.

[TW-4918]: https://nylas.atlassian.net/browse/TW-4918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ