### PR TITLE
[TA-3764] Support send `fields` query param

### DIFF
--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -183,6 +183,7 @@ export interface MessageHeaders {
  */
 export enum MessageFields {
   STANDARD = 'standard',
+  INCLUDE_BASIC_HEADERS = 'include_basic_headers',
   INCLUDE_HEADERS = 'include_headers',
   INCLUDE_TRACKING_OPTIONS = 'include_tracking_options',
   RAW_MIME = 'raw_mime',
@@ -313,6 +314,16 @@ export interface ListMessagesQueryParams extends ListQueryParams {
 export interface FindMessageQueryParams {
   /**
    * Allows you to specify to the message with headers included.
+   */
+  fields?: MessageFields;
+}
+
+/**
+ * Interface representing the query parameters for sending a message.
+ */
+export interface SendMessageQueryParams {
+  /**
+   * Allows you to specify to return the sent message with headers included.
    */
   fields?: MessageFields;
 }

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -14,6 +14,7 @@ import {
   Message,
   ScheduledMessage,
   ScheduledMessagesList,
+  SendMessageQueryParams,
   StopScheduledMessageResponse,
   UpdateMessageRequest,
 } from '../models/messages.js';
@@ -80,10 +81,12 @@ export interface DestroyMessageParams {
  * The parameters for the {@link Messages.send} method
  * @property identifier The identifier of the grant to act upon
  * @property requestBody The message to send
+ * @property queryParams The query parameters to include in the request
  */
 export interface SendMessageParams {
   identifier: string;
   requestBody: SendMessageRequest;
+  queryParams?: SendMessageQueryParams;
 }
 
 /**
@@ -231,6 +234,7 @@ export class Messages extends Resource {
   public async send({
     identifier,
     requestBody,
+    queryParams,
     overrides,
   }: SendMessageParams & Overrides): Promise<NylasResponse<Message>> {
     const path = makePathParams('/v3/grants/{identifier}/messages/send', {
@@ -239,6 +243,7 @@ export class Messages extends Resource {
     const requestOptions: RequestOptionsParams = {
       method: 'POST',
       path,
+      queryParams,
       overrides,
     };
 

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -763,6 +763,46 @@ describe('Messages', () => {
       });
       expect(capturedRequest.form).toBeDefined();
     });
+
+    it('should return message with headers field in response when fields=include_headers is requested', async () => {
+      const mockResponse = {
+        requestId: 'req123',
+        data: {
+          id: 'msg1',
+          grantId: 'id123',
+          object: 'message',
+          subject: 'This is my test email',
+          headers: [
+            {
+              name: 'Message-ID',
+              value: '<bde0x4tz0iuhp1c2x59cg9u29.DIM0M8N2NTA2@yahoo.com>',
+            },
+            { name: 'From', value: 'sender@example.com' },
+          ],
+        },
+      };
+      apiClient.request.mockResolvedValueOnce(mockResponse);
+
+      const result = await messages.send({
+        identifier: 'id123',
+        requestBody: {
+          to: [{ name: 'Test', email: 'test@example.com' }],
+          subject: 'This is my test email',
+        },
+        queryParams: {
+          fields: MessageFields.INCLUDE_HEADERS,
+        },
+      });
+
+      expect(result.data.headers).toBeDefined();
+      expect(result.data.headers).toEqual([
+        {
+          name: 'Message-ID',
+          value: '<bde0x4tz0iuhp1c2x59cg9u29.DIM0M8N2NTA2@yahoo.com>',
+        },
+        { name: 'From', value: 'sender@example.com' },
+      ]);
+    });
   });
 
   describe('scheduledMessages', () => {

--- a/tests/resources/messages.spec.ts
+++ b/tests/resources/messages.spec.ts
@@ -682,6 +682,87 @@ describe('Messages', () => {
       expect(typeof formData.file0).toBe('object');
       // Note: The exact structure of the Blob mock may vary, but it should exist
     });
+
+    it('should call apiClient.request with fields=include_headers query param', async () => {
+      const jsonBody = {
+        to: [{ name: 'Test', email: 'test@example.com' }],
+        subject: 'This is my test email',
+      };
+      await messages.send({
+        identifier: 'id123',
+        requestBody: jsonBody,
+        queryParams: {
+          fields: MessageFields.INCLUDE_HEADERS,
+        },
+      });
+
+      const capturedRequest = apiClient.request.mock.calls[0][0];
+      expect(capturedRequest.method).toEqual('POST');
+      expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
+      expect(capturedRequest.body).toEqual(jsonBody);
+      expect(capturedRequest.queryParams).toEqual({
+        fields: MessageFields.INCLUDE_HEADERS,
+      });
+    });
+
+    it('should call apiClient.request with fields=include_basic_headers query param', async () => {
+      const jsonBody = {
+        to: [{ name: 'Test', email: 'test@example.com' }],
+        subject: 'This is my test email',
+      };
+      await messages.send({
+        identifier: 'id123',
+        requestBody: jsonBody,
+        queryParams: {
+          fields: MessageFields.INCLUDE_BASIC_HEADERS,
+        },
+      });
+
+      const capturedRequest = apiClient.request.mock.calls[0][0];
+      expect(capturedRequest.method).toEqual('POST');
+      expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
+      expect(capturedRequest.body).toEqual(jsonBody);
+      expect(capturedRequest.queryParams).toEqual({
+        fields: MessageFields.INCLUDE_BASIC_HEADERS,
+      });
+    });
+
+    it('should include query params with multipart form data', async () => {
+      const messageJson = {
+        to: [{ name: 'Test', email: 'test@example.com' }],
+        subject: 'This is my test email',
+      };
+      const fileStream = createReadableStream('This is the text from file 1');
+      const file1: CreateAttachmentRequest = {
+        filename: 'file1.txt',
+        contentType: 'text/plain',
+        content: fileStream,
+        size: 3 * 1024 * 1024,
+      };
+
+      await messages.send({
+        identifier: 'id123',
+        requestBody: {
+          ...messageJson,
+          attachments: [file1],
+        },
+        queryParams: {
+          fields: MessageFields.INCLUDE_HEADERS,
+        },
+        overrides: {
+          apiUri: 'https://test.api.nylas.com',
+          headers: { override: 'bar' },
+        },
+      });
+
+      const capturedRequest = apiClient.request.mock.calls[0][0];
+      expect(capturedRequest.method).toEqual('POST');
+      expect(capturedRequest.path).toEqual('/v3/grants/id123/messages/send');
+      expect(capturedRequest.queryParams).toEqual({
+        fields: MessageFields.INCLUDE_HEADERS,
+      });
+      expect(capturedRequest.form).toBeDefined();
+    });
   });
 
   describe('scheduledMessages', () => {


### PR DESCRIPTION
<!-- Add information about your PR here -->
Support fields query param on messages.send()

  Adds `fields=include_headers` and `fields=include_basic_headers` query parameter
  support to the send message endpoint. When requested, the API returns a headers
   array ([{ name, value }]) on the response message object.

  - New `INCLUDE_BASIC_HEADERS` enum value added to MessageFields
  - New `SendMessageQueryParams` interface with optional fields property
  - queryParams forwarded correctly for both JSON and multipart (large
  attachment) request paths
  - Tests cover request forwarding for both field values and the multipart case,
  plus response shape assertion for the returned headers field

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.