### PR TITLE
[TW-5592] Support callback URIs in application updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add Workspaces API support via `nylas.workspaces` — list, find, create, update (PATCH), destroy, plus `autoGroup()` and `manualAssign()` for grouping grants by domain, `default`, `policyId`, and `ruleIds`
+- Add Workspaces API support via `nylas.workspaces` — list, find, create, update (PATCH), destroy, plus `autoGroup()` and `manualAssign()` for grouping grants by domain, `invalidAlso`, `default`, `policyId`, and `ruleIds`
 - Add Agent Account Lists API support via `nylas.lists` — create lists with `name`, optional `description`, and immutable `type`, plus list, find, update, destroy, `listItems()`, `addItems()`, and `removeItems()` for managing `/v3/lists`
 - Add Manage Domains API support via `nylas.domains` — list, find, create, update, destroy, plus `info()` and `verify()` for domain verification (`/v3/admin/domains`). Includes `ServiceAccountSigner` support for Nylas Service Account request signing, bearer-auth suppression, and canonical signed wire bodies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct `Rules` list (`GET /v3/rules`) to normalize its nested `{ data: { items, nextCursor } }` envelope back to the flat `{ data, nextCursor }` shape the list machinery expects
 - Correct `Applications` `ApplicationDetails` field `redirectUris` → `callbackUris` (V3 wire contract), widen `region`/`environment` to `string`, add hosted-auth/IdP public fields, and add `applications.update()` (PATCH)
 - Correct `Applications` `applications.update()` to accept write-only `additionalSettings` (forwarded in the request body, stripped from the response)
+- Correct `Applications` `applications.update()` to accept `callbackUris` with callback URI IDs for preserving existing callback URIs
 - Correct `RedirectUris` `update()` to use PATCH (was PUT), fix `destroy()` return type, make `platform` optional with a typed `RedirectUriPlatform` enum, and surface `deletedAt` on `RedirectUri`
 
 ## [8.2.0] - 2026-06-11

--- a/src/models/applicationDetails.ts
+++ b/src/models/applicationDetails.ts
@@ -1,4 +1,8 @@
-import { RedirectUri } from './redirectUri.js';
+import {
+  RedirectUri,
+  RedirectUriPlatform,
+  RedirectUriSettings,
+} from './redirectUri.js';
 
 /**
  * Interface for a Nylas application details object
@@ -182,11 +186,32 @@ export interface AdditionalSettings {
 export type UpdateBranding = Partial<Branding>;
 
 /**
+ * Callback URI shape accepted by application updates.
+ */
+export interface UpdateApplicationRedirectUriRequest {
+  /**
+   * Existing callback URI ID. Include this when preserving or updating an existing URI.
+   */
+  id?: string;
+  /**
+   * Redirect URL.
+   */
+  url: string;
+  /**
+   * Platform identifier. One of `web`, `js`, `ios`, `android`, `desktop`.
+   * Defaults to `web` when omitted.
+   */
+  platform?: RedirectUriPlatform;
+  /**
+   * Optional settings for the redirect URI.
+   */
+  settings?: RedirectUriSettings;
+}
+
+/**
  * Interface representing a request to update application details.
  *
  * All fields are optional; each supplied nested object is a full replace, not a deep merge.
- * Note: `callbackUris`/`redirectUris` are ignored by this endpoint — manage callback URIs
- * via the dedicated redirect-uris endpoints.
  */
 export interface UpdateApplicationRequest {
   /**
@@ -201,6 +226,10 @@ export interface UpdateApplicationRequest {
    * Identity provider (IdP) settings for the application.
    */
   idpSettings?: IdpSettings;
+  /**
+   * List of callback URIs for the application.
+   */
+  callbackUris?: UpdateApplicationRedirectUriRequest[];
   /**
    * White-label domain for the application.
    */

--- a/src/resources/applications.ts
+++ b/src/resources/applications.ts
@@ -51,8 +51,7 @@ export class Applications extends Resource {
   /**
    * Update application details.
    *
-   * Each supplied nested object is a full replace, not a deep merge. Callback URIs cannot
-   * be updated here — manage them via {@link redirectUris}.
+   * Each supplied nested object is a full replace, not a deep merge.
    * @returns The updated application details
    */
   public update({

--- a/tests/resources/applications.spec.ts
+++ b/tests/resources/applications.spec.ts
@@ -66,6 +66,13 @@ describe('Applications', () => {
             origins: 'https://example.com',
             issuers: 'https://issuer.example.com',
           },
+          callbackUris: [
+            {
+              id: '0556d035-6cb6-4262-a035-6b77e11cf8fc',
+              url: 'https://example.com/callback',
+              platform: 'web',
+            },
+          ],
           domain: 'auth.example.com',
         },
         overrides: {
@@ -91,6 +98,13 @@ describe('Applications', () => {
             origins: 'https://example.com',
             issuers: 'https://issuer.example.com',
           },
+          callbackUris: [
+            {
+              id: '0556d035-6cb6-4262-a035-6b77e11cf8fc',
+              url: 'https://example.com/callback',
+              platform: 'web',
+            },
+          ],
           domain: 'auth.example.com',
         },
         overrides: {


### PR DESCRIPTION
## Context
Follow-up to the review feedback on nylas-java#327. `PATCH /v3/applications` accepts `callback_uris`, and callers need to include an existing callback URI `id` when preserving or updating entries. The Node SDK typed request model did not expose that shape.

## Summary
- Add `UpdateApplicationRedirectUriRequest` with optional `id`, `platform`, and `settings`.
- Add `callbackUris` to `UpdateApplicationRequest` and remove stale docs saying callback URIs are ignored.
- Cover forwarding a `callbackUris` entry with an existing `id` in the application update test.
- Update the Unreleased changelog for application callback URI preservation and `invalidAlso` workspace auto-group support.

## Testing
- `npm test -- --coverage=false tests/resources/applications.spec.ts`
- `npm run lint:prettier:check`
- `npx tsc -p tsconfig.esm.json --noEmit`
- `npx tsc -p tsconfig.cjs.json --noEmit`
- GitHub Actions: passing