### PR TITLE
Add missing `message.deleted` Webhook trigger

### DIFF
--- a/src/models/webhooks.ts
+++ b/src/models/webhooks.ts
@@ -133,6 +133,7 @@ export enum WebhookTriggers {
   // Message triggers
   MessageCreated = 'message.created',
   MessageUpdated = 'message.updated',
+  MessageDeleted = 'message.deleted',
   MessageSendSuccess = 'message.send_success',
   MessageSendFailed = 'message.send_failed',
   MessageBounceDetected = 'message.bounce_detected',


### PR DESCRIPTION
<!-- Add information about your PR here -->
Hi there. I noticed that your `WebhookTrigger` enum doesn't include `message.deleted` which, while left out in a bunch of lists of possible triggers in the docs, still exist as a possible trigger:
https://developer.nylas.com/docs/reference/notifications/messages/message-deleted/

This isn't a huge thing at all but I am quite obsessed with types so it would be cool if this was in the enum and I didn't have to do
```ts
type WebhookTriggersWithDeleted = WebhookTriggers | 'message.deleted';
```


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.