### PR TITLE
fix(models): add truncated webhook triggers and Notetaker calendar/event IDs

### DIFF
--- a/src/models/notetakers.ts
+++ b/src/models/notetakers.ts
@@ -71,6 +71,14 @@ export interface Notetaker {
    */
   state: NotetakerState;
   /**
+   * The calendar ID associated with the Notetaker bot, if applicable.
+   */
+  calendarId?: string;
+  /**
+   * The event ID associated with the Notetaker bot, if applicable.
+   */
+  eventId?: string;
+  /**
    * Notetaker Meeting Settings
    */
   meetingSettings: NotetakerMeetingSettings;

--- a/src/models/webhooks.ts
+++ b/src/models/webhooks.ts
@@ -133,6 +133,8 @@ export enum WebhookTriggers {
   // Message triggers
   MessageCreated = 'message.created',
   MessageUpdated = 'message.updated',
+  MessageCreatedTruncated = 'message.created.truncated',
+  MessageUpdatedTruncated = 'message.updated.truncated',
   MessageSendSuccess = 'message.send_success',
   MessageSendFailed = 'message.send_failed',
   MessageBounceDetected = 'message.bounce_detected',

--- a/tests/resources/notetakers.spec.ts
+++ b/tests/resources/notetakers.spec.ts
@@ -377,6 +377,37 @@ describe('Notetakers', () => {
         path: '/v3/notetakers/notetaker123',
       });
     });
+
+    it('should return calendarId and eventId when present in the response', async () => {
+      const mockResponse = {
+        requestId: 'req-123',
+        data: {
+          id: 'notetaker123',
+          name: 'Nylas Notetaker',
+          joinTime: 1744222418,
+          meetingLink: 'https://meet.google.com/abc-def-ghi',
+          meetingProvider: 'Google Meet',
+          state: 'scheduled',
+          calendarId: 'calendar123',
+          eventId: 'event456',
+          meetingSettings: {
+            videoRecording: true,
+            audioRecording: true,
+            transcription: false,
+          },
+        },
+      };
+
+      apiClient.request.mockResolvedValueOnce(mockResponse);
+
+      const response = await notetakers.find({
+        identifier: 'id123',
+        notetakerId: 'notetaker123',
+      });
+
+      expect(response.data.calendarId).toBe('calendar123');
+      expect(response.data.eventId).toBe('event456');
+    });
   });
 
   describe('update', () => {

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -301,6 +301,17 @@ describe('Webhooks', () => {
     });
   });
 
+  describe('WebhookTriggers', () => {
+    it('should include truncated message webhook triggers', () => {
+      expect(WebhookTriggers.MessageCreatedTruncated).toBe(
+        'message.created.truncated'
+      );
+      expect(WebhookTriggers.MessageUpdatedTruncated).toBe(
+        'message.updated.truncated'
+      );
+    });
+  });
+
   describe('extractChallengeParameter', () => {
     it('should extract the challenge parameter from a valid URL', () => {
       const url = 'https://example.com?challenge=testValue';


### PR DESCRIPTION
## Summary
- Adds `message.created.truncated` and `message.updated.truncated` to `WebhookTriggers` (#723)
- Adds optional `calendarId` and `eventId` fields to the `Notetaker` model (#682)
- Adds tests covering both changes

## JIRA
[TW-5661](https://nylas.atlassian.net/browse/TW-5661)

## Test plan
- [x] `npm test -- tests/resources/webhooks.spec.ts tests/resources/notetakers.spec.ts`

Fixes #723
Fixes #682

Made with [Cursor](https://cursor.com)

[TW-5661]: https://nylas.atlassian.net/browse/TW-5661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ