### PR TITLE
fix(models): add missing WebhookTriggers enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Missing webhook trigger types (`message.deleted`, `message.created.cleaned`, `grant.imap_sync_completed`, Notetaker triggers, Agent Account and transactional deliverability triggers, and legacy tracking triggers)
+
 ## [8.3.0] - 2026-06-17
 
 ### Added

--- a/src/models/webhooks.ts
+++ b/src/models/webhooks.ts
@@ -129,10 +129,13 @@ export enum WebhookTriggers {
   GrantUpdated = 'grant.updated',
   GrantDeleted = 'grant.deleted',
   GrantExpired = 'grant.expired',
+  GrantImapSyncCompleted = 'grant.imap_sync_completed',
 
   // Message triggers
   MessageCreated = 'message.created',
+  MessageCreatedCleaned = 'message.created.cleaned',
   MessageUpdated = 'message.updated',
+  MessageDeleted = 'message.deleted',
   MessageCreatedTruncated = 'message.created.truncated',
   MessageUpdatedTruncated = 'message.updated.truncated',
   MessageSendSuccess = 'message.send_success',
@@ -141,8 +144,23 @@ export enum WebhookTriggers {
 
   // Message tracking triggers
   MessageOpened = 'message.opened',
+  MessageOpenedLegacy = 'message.opened.legacy',
   MessageLinkClicked = 'message.link_clicked',
+  MessageLinkClickedLegacy = 'message.link_clicked.legacy',
   ThreadReplied = 'thread.replied',
+  ThreadRepliedLegacy = 'thread.replied.legacy',
+
+  // Agent Account deliverability triggers
+  MessageDelivered = 'message.delivered',
+  MessageBounced = 'message.bounced',
+  MessageComplaint = 'message.complaint',
+  MessageRejected = 'message.rejected',
+
+  // Transactional email deliverability triggers
+  MessageTransactionalDelivered = 'message.transactional.delivered',
+  MessageTransactionalBounced = 'message.transactional.bounced',
+  MessageTransactionalComplaint = 'message.transactional.complaint',
+  MessageTransactionalRejected = 'message.transactional.rejected',
 
   // ExtractAI triggers
   MessageIntelligenceOrder = 'message.intelligence.order',
@@ -163,6 +181,13 @@ export enum WebhookTriggers {
   BookingRescheduled = 'booking.rescheduled',
   BookingCancelled = 'booking.cancelled',
   BookingReminder = 'booking.reminder',
+
+  // Notetaker triggers
+  NotetakerCreated = 'notetaker.created',
+  NotetakerUpdated = 'notetaker.updated',
+  NotetakerDeleted = 'notetaker.deleted',
+  NotetakerMeetingState = 'notetaker.meeting_state',
+  NotetakerMedia = 'notetaker.media',
 }
 
 /**

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -313,15 +313,9 @@ describe('Webhooks', () => {
       ['MessageBounced', 'message.bounced'],
       ['MessageComplaint', 'message.complaint'],
       ['MessageRejected', 'message.rejected'],
-      [
-        'MessageTransactionalDelivered',
-        'message.transactional.delivered',
-      ],
+      ['MessageTransactionalDelivered', 'message.transactional.delivered'],
       ['MessageTransactionalBounced', 'message.transactional.bounced'],
-      [
-        'MessageTransactionalComplaint',
-        'message.transactional.complaint',
-      ],
+      ['MessageTransactionalComplaint', 'message.transactional.complaint'],
       ['MessageTransactionalRejected', 'message.transactional.rejected'],
       ['NotetakerCreated', 'notetaker.created'],
       ['NotetakerUpdated', 'notetaker.updated'],

--- a/tests/resources/webhooks.spec.ts
+++ b/tests/resources/webhooks.spec.ts
@@ -302,6 +302,36 @@ describe('Webhooks', () => {
   });
 
   describe('WebhookTriggers', () => {
+    it.each([
+      ['MessageDeleted', 'message.deleted'],
+      ['MessageCreatedCleaned', 'message.created.cleaned'],
+      ['GrantImapSyncCompleted', 'grant.imap_sync_completed'],
+      ['MessageOpenedLegacy', 'message.opened.legacy'],
+      ['MessageLinkClickedLegacy', 'message.link_clicked.legacy'],
+      ['ThreadRepliedLegacy', 'thread.replied.legacy'],
+      ['MessageDelivered', 'message.delivered'],
+      ['MessageBounced', 'message.bounced'],
+      ['MessageComplaint', 'message.complaint'],
+      ['MessageRejected', 'message.rejected'],
+      [
+        'MessageTransactionalDelivered',
+        'message.transactional.delivered',
+      ],
+      ['MessageTransactionalBounced', 'message.transactional.bounced'],
+      [
+        'MessageTransactionalComplaint',
+        'message.transactional.complaint',
+      ],
+      ['MessageTransactionalRejected', 'message.transactional.rejected'],
+      ['NotetakerCreated', 'notetaker.created'],
+      ['NotetakerUpdated', 'notetaker.updated'],
+      ['NotetakerDeleted', 'notetaker.deleted'],
+      ['NotetakerMeetingState', 'notetaker.meeting_state'],
+      ['NotetakerMedia', 'notetaker.media'],
+    ] as const)('should map %s to %s', (key, value) => {
+      expect(WebhookTriggers[key]).toBe(value);
+    });
+
     it('should include truncated message webhook triggers', () => {
       expect(WebhookTriggers.MessageCreatedTruncated).toBe(
         'message.created.truncated'


### PR DESCRIPTION
## Summary
- Adds 19 missing webhook trigger types to `WebhookTriggers` so the SDK matches the [Nylas v3 notification reference](https://developer.nylas.com/docs/reference/notifications/)
- Adds table-driven tests for all newly added triggers
- Supersedes community PR #746 (thanks @Kile for reporting `message.deleted`)

## Triggers added
- **Message:** `message.deleted`, `message.created.cleaned`
- **Grant:** `grant.imap_sync_completed`
- **Notetaker:** `notetaker.created`, `notetaker.updated`, `notetaker.deleted`, `notetaker.meeting_state`, `notetaker.media`
- **Agent Accounts:** `message.delivered`, `message.bounced`, `message.complaint`, `message.rejected`
- **Transactional:** `message.transactional.delivered`, `message.transactional.bounced`, `message.transactional.complaint`, `message.transactional.rejected`
- **Legacy (Contract):** `message.opened.legacy`, `message.link_clicked.legacy`, `thread.replied.legacy`

## Test plan
- [x] `npm test -- tests/resources/webhooks.spec.ts` (40 tests pass)

Closes TW-5668
Closes #746

Made with [Cursor](https://cursor.com)