### PR TITLE
fix(auth): stop sending apiKey as client_secret in OAuth token exchange body

### DIFF
--- a/src/resources/auth.ts
+++ b/src/resources/auth.ts
@@ -48,10 +48,6 @@ export class Auth extends Resource {
   public exchangeCodeForToken(
     request: CodeExchangeRequest
   ): Promise<CodeExchangeResponse> {
-    if (!request.clientSecret) {
-      request.clientSecret = this.apiClient.apiKey;
-    }
-
     return this.apiClient.request<CodeExchangeResponse>({
       method: 'POST',
       path: makePathParams('/v3/connect/token', {}),
@@ -70,10 +66,6 @@ export class Auth extends Resource {
   public refreshAccessToken(
     request: TokenExchangeRequest
   ): Promise<CodeExchangeResponse> {
-    if (!request.clientSecret) {
-      request.clientSecret = this.apiClient.apiKey;
-    }
-
     return this.apiClient.request<CodeExchangeResponse>({
       method: 'POST',
       path: makePathParams('/v3/connect/token', {}),

--- a/tests/resources/auth.spec.ts
+++ b/tests/resources/auth.spec.ts
@@ -46,7 +46,7 @@ describe('Auth', () => {
         });
       });
 
-      it('should default clientSecret to the API key', async () => {
+      it('should not include clientSecret in body when not provided', async () => {
         const payload: CodeExchangeRequest = {
           clientId: 'clientId',
           redirectUri: 'https://redirect.uri/path',
@@ -59,7 +59,6 @@ describe('Auth', () => {
           path: '/v3/connect/token',
           body: {
             clientId: 'clientId',
-            clientSecret: 'apiKey',
             redirectUri: 'https://redirect.uri/path',
             code: 'code',
             grantType: 'authorization_code',
@@ -115,7 +114,7 @@ describe('Auth', () => {
         });
       });
 
-      it('should default clientSecret to the API key', async () => {
+      it('should not include clientSecret in body when not provided', async () => {
         const payload: TokenExchangeRequest = {
           clientId: 'clientId',
           redirectUri: 'https://redirect.uri/path',
@@ -128,7 +127,6 @@ describe('Auth', () => {
           path: '/v3/connect/token',
           body: {
             clientId: 'clientId',
-            clientSecret: 'apiKey',
             redirectUri: 'https://redirect.uri/path',
             refreshToken: 'refreshToken',
             grantType: 'refresh_token',


### PR DESCRIPTION
## Summary

- Removes the auto-population of `clientSecret` from `apiKey` in `exchangeCodeForToken` and `refreshAccessToken`
- The `apiKey` is already sent via `Authorization: Bearer` header on every request — including `/v3/connect/token` — so including it in the body was redundant and broke reverse proxy credential-injection patterns
- `clientSecret` remains available on `CodeExchangeRequest` / `TokenExchangeRequest` for callers who have a distinct OAuth client secret to pass explicitly

Fixes #703
Jira: [TW-5724](https://nylas.atlassian.net/browse/TW-5724)

## Test plan

- [ ] Updated existing "should default clientSecret to the API key" tests → now assert `clientSecret` is absent from the body when not provided
- [ ] All auth.spec.ts tests pass (`auth.ts` at 100% coverage)
- [ ] Verify `exchangeCodeForToken` and `refreshAccessToken` still work end-to-end when `clientSecret` is not passed (relying on the Authorization header)
- [ ] Verify explicit `clientSecret` in the request is still forwarded correctly in the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TW-5724]: https://nylas.atlassian.net/browse/TW-5724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ